### PR TITLE
Set proper status codes for REST API responses

### DIFF
--- a/includes/class-events.php
+++ b/includes/class-events.php
@@ -109,12 +109,12 @@ class Events extends Singleton {
 	public function run_event( $timestamp, $action, $instance ) {
 		// Validate input data
 		if ( empty( $timestamp ) || empty( $action ) || empty( $instance ) ) {
-			return new \WP_Error( 'missing-data', __( 'Invalid or incomplete request data.', 'automattic-cron-control' ) );
+			return new \WP_Error( 'missing-data', __( 'Invalid or incomplete request data.', 'automattic-cron-control' ), array( 'status' => 400, ) );
 		}
 
 		// Ensure we don't run jobs too far ahead
 		if ( $timestamp > strtotime( sprintf( '+%d seconds', JOB_EXECUTION_BUFFER_IN_SECONDS ) ) ) {
-			return new \WP_Error( 'premature', sprintf( __( 'Job with identifier `%1$s` is not scheduled to run yet.', 'automattic-cron-control' ), "$timestamp-$action-$instance" ) );
+			return new \WP_Error( 'premature', sprintf( __( 'Job with identifier `%1$s` is not scheduled to run yet.', 'automattic-cron-control' ), "$timestamp-$action-$instance" ), array( 'status' => 403, ) );
 		}
 
 		// Find the event to retrieve the full arguments
@@ -122,7 +122,7 @@ class Events extends Singleton {
 
 		// Nothing to do...
 		if ( ! is_array( $event ) ) {
-			return new \WP_Error( 'no-event', sprintf( __( 'Job with identifier `%1$s` could not be found.', 'automattic-cron-control' ), "$timestamp-$action-$instance" ) );
+			return new \WP_Error( 'no-event', sprintf( __( 'Job with identifier `%1$s` could not be found.', 'automattic-cron-control' ), "$timestamp-$action-$instance" ), array( 'status' => 404, ) );
 		}
 
 		unset( $timestamp, $action, $instance );
@@ -132,7 +132,7 @@ class Events extends Singleton {
 
 		// Limit how many events are processed concurrently
 		if ( ! is_internal_event( $event['action'] ) && ! Lock::check_lock( self::LOCK ) ) {
-			return new \WP_Error( 'no-free-threads', sprintf( __( 'No resources available to run the job with action action `%1$s` and arguments `%2$s`.', 'automattic-cron-control' ), $event['action'], maybe_serialize( $event['args'] ) ) );
+			return new \WP_Error( 'no-free-threads', sprintf( __( 'No resources available to run the job with action action `%1$s` and arguments `%2$s`.', 'automattic-cron-control' ), $event['action'], maybe_serialize( $event['args'] ) ), array( 'status' => 429, ) );
 		}
 
 		// Prepare environment to run job

--- a/includes/class-main.php
+++ b/includes/class-main.php
@@ -66,7 +66,7 @@ class Main extends Singleton {
 	public function block_direct_cron() {
 		if ( false !== stripos( $_SERVER['REQUEST_URI'], '/wp-cron.php' ) || false !== stripos( $_SERVER['SCRIPT_NAME'], '/wp-cron.php' ) ) {
 			status_header( 403 );
-			wp_send_json_error( new \WP_Error( 'forbidden', sprintf( __( 'Normal cron execution is blocked when the %s plugin is active.', 'automattic-cron-control' ), 'Cron Control' ) ) );
+			wp_send_json_error( new \WP_Error( 'forbidden', sprintf( __( 'Normal cron execution is blocked when the %s plugin is active.', 'automattic-cron-control' ), 'Cron Control' ) ), array( 'status' => 400, ) );
 		}
 	}
 

--- a/includes/class-rest-api.php
+++ b/includes/class-rest-api.php
@@ -75,7 +75,7 @@ class REST_API extends Singleton {
 
 		// For now, mimic original plugin's "authentication" method. This needs to be better.
 		if ( ! isset( $body['secret'] ) || ! hash_equals( \WP_CRON_CONTROL_SECRET, $body['secret'] ) ) {
-			return new \WP_Error( 'no-secret', __( 'Secret must be specified with all requests', 'automattic-cron-control' ) );
+			return new \WP_Error( 'no-secret', __( 'Secret must be specified with all requests', 'automattic-cron-control' ), array( 'status' => 400, ) );
 		}
 
 		return true;


### PR DESCRIPTION
If a status code isn't specified, `500` is used, which is not appropriate for any of our cases.

Fixes #5 