### PR TITLE
Improve caching and event CPT handling

### DIFF
--- a/includes/class-cron-options-cpt.php
+++ b/includes/class-cron-options-cpt.php
@@ -16,6 +16,8 @@ class Cron_Options_CPT extends Singleton {
 	const POST_STATUS_PENDING   = 'inherit';
 	const POST_STATUS_COMPLETED = 'trash';
 
+	const CACHE_KEY             = 'a8c_cron_ctrl_option';
+
 	private $posts_to_clean = array();
 
 	private $option_before_unscheduling = null;
@@ -64,6 +66,14 @@ class Cron_Options_CPT extends Singleton {
 	 * Override cron option requests with data from CPT
 	 */
 	public function get_option() {
+		// Use cached value for reads, except when we're unscheduling and state is important
+		$cached_option = wp_cache_get( self::CACHE_KEY, null, true );
+
+		if ( ! $this->is_unscheduling() && false !== $cached_option ) {
+			return $cached_option;
+		}
+
+		// Start building a new cron option
 		$cron_array = array(
 			'version' => 2, // Core versions the cron array; without this, events will continually requeue
 		);
@@ -133,6 +143,9 @@ class Cron_Options_CPT extends Singleton {
 			$this->option_before_unscheduling = null;
 		}
 
+		// Cache the results, bearing in mind that they won't be used during unscheduling events
+		wp_cache_set( self::CACHE_KEY, $cron_array, null, 1 * \HOUR_IN_SECONDS );
+
 		return $cron_array;
 	}
 
@@ -201,26 +214,21 @@ class Cron_Options_CPT extends Singleton {
 	/**
 	 * Retrieve list of jobs, respecting whether or not the CPT is registered
 	 *
-	 * `WP_Query` also can't be used before `init` due to capabilities checks
+	 * Uses a direct query to avoid stale caches that result in duplicate events
 	 */
 	private function get_jobs( $args ) {
-		// If called before `init`, we need to query directly because post types aren't registered earlier
-		if ( did_action( 'init' ) ) {
-			return get_posts( $args );
+		global $wpdb;
+
+		$orderby = 'date' === $args['orderby'] ? 'post_date' : $args['orderby'];
+
+		if ( isset( $args['paged'] ) ) {
+			$paged  = max( 0, $args['paged'] - 1 );
+			$offset = $paged * $args['posts_per_page'];
 		} else {
-			global $wpdb;
-
-			$orderby = 'date' === $args['orderby'] ? 'post_date' : $args['orderby'];
-
-			if ( isset( $args['paged'] ) ) {
-				$paged  = max( 0, $args['paged'] - 1 );
-				$offset = $paged * $args['posts_per_page'];
-			} else {
-				$offset = 0;
-			}
-
-			return $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$wpdb->posts} WHERE post_type = %s AND post_status = %s ORDER BY %s %s LIMIT %d,%d;", $args['post_type'], $args['post_status'], $orderby, $args['order'], $offset, $args['posts_per_page'] ), 'OBJECT' );
+			$offset = 0;
 		}
+
+		return $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$wpdb->posts} WHERE post_type = %s AND post_status = %s ORDER BY %s %s LIMIT %d,%d;", $args['post_type'], $args['post_status'], $orderby, $args['order'], $offset, $args['posts_per_page'] ), 'OBJECT' );
 	}
 
 	/**
@@ -292,6 +300,9 @@ class Cron_Options_CPT extends Singleton {
 			}
 		}
 
+		// Delete internal cache
+		wp_cache_delete( self::CACHE_KEY );
+
 		// Allow more events to be created
 		Lock::free_lock( self::LOCK );
 	}
@@ -333,6 +344,9 @@ class Cron_Options_CPT extends Singleton {
 			wp_add_trashed_suffix_to_post_name_for_post( $job_post_id );
 			$this->posts_to_clean[] = $job_post_id;
 		}
+
+		// Delete internal cache
+		wp_cache_delete( self::CACHE_KEY );
 
 		return true;
 	}

--- a/includes/class-cron-options-cpt.php
+++ b/includes/class-cron-options-cpt.php
@@ -67,10 +67,12 @@ class Cron_Options_CPT extends Singleton {
 	 */
 	public function get_option() {
 		// Use cached value for reads, except when we're unscheduling and state is important
-		$cached_option = wp_cache_get( self::CACHE_KEY, null, true );
+		if ( ! $this->is_unscheduling() ) {
+			$cached_option = wp_cache_get( self::CACHE_KEY, null, true );
 
-		if ( ! $this->is_unscheduling() && false !== $cached_option ) {
-			return $cached_option;
+			if ( false !== $cached_option ) {
+				return $cached_option;
+			}
 		}
 
 		// Start building a new cron option


### PR DESCRIPTION
The initial design is prone to race conditions that generate duplicate entries and, under sufficient load, can induce the plugin's internal locking to trigger an infinite loop. This was largely a casualty of my desire to make the CPT an independent element of the plugin, one that the plugin could operate without. Testing, however, showed that doing so simply shifts the concurrency issues to `update_option()` calls.

With this update, the plugin's events store now handles its own caching, and its event handlers interact with the datastore directly, rather than relying on hooks in Core's cron functions. Said functions are still hooked, but those interactions are maintained for the benefit of code outside of this plugin.

Additionally, all events are now created manually, ensuring data integrity.