### PR TITLE
Add duplicate detection

### DIFF
--- a/includes/class-cron-options-cpt.php
+++ b/includes/class-cron-options-cpt.php
@@ -110,12 +110,6 @@ class Cron_Options_CPT extends Singleton {
 			// Loop through results and built output Core expects
 			if ( ! empty( $jobs_posts ) ) {
 				foreach ( $jobs_posts as $jobs_post ) {
-					// Detect duplicates, as indicated by Core's suffixing of post_name
-					if ( substr_count( $jobs_post->post_name, '-' ) > 2 ) {
-						$this->mark_job_post_completed( $jobs_post->ID );
-						continue;
-					}
-
 					$timestamp = strtotime( $jobs_post->post_date_gmt );
 
 					$job_args = maybe_unserialize( $jobs_post->post_content_filtered );


### PR DESCRIPTION
Following #12, duplicates are greatly reduced, but do still occur. When they're detected, they should be marked completed preemptively.

Fixes #7.