### PR TITLE
Table name shouldn't be hardcoded, though Core usually figures it out

### DIFF
--- a/includes/class-cron-options-cpt.php
+++ b/includes/class-cron-options-cpt.php
@@ -345,7 +345,7 @@ class Cron_Options_CPT extends Singleton {
 		} else {
 			global $wpdb;
 
-			$wpdb->update( 'posts', array( 'post_status' => self::POST_STATUS_COMPLETED, ), array( 'ID' => $job_post_id, ) );
+			$wpdb->update( $wpdb->posts, array( 'post_status' => self::POST_STATUS_COMPLETED, ), array( 'ID' => $job_post_id, ) );
 			wp_add_trashed_suffix_to_post_name_for_post( $job_post_id );
 			$this->posts_to_clean[] = $job_post_id;
 		}


### PR DESCRIPTION
This doesn't seem to have caused any significant issues, but it did trigger an occasional warning that I'd lost in other noise.