### PR TITLE
Update internal jobs creation

### DIFF
--- a/includes/class-internal-events.php
+++ b/includes/class-internal-events.php
@@ -75,9 +75,19 @@ class Internal_Events extends Singleton {
 	public function schedule_internal_events() {
 		$when = strtotime( sprintf( '+%d seconds', JOB_QUEUE_WINDOW_IN_SECONDS ) );
 
+		$schedules = wp_get_schedules();
+
 		foreach ( $this->internal_jobs as $job_args ) {
 			if ( ! wp_next_scheduled( $job_args['action'] ) ) {
-				wp_schedule_event( $when, $job_args['schedule'], $job_args['action'] );
+				$interval = array_key_exists( $job_args['schedule'], $schedules ) ? $schedules[ $job_args['schedule'] ]['interval'] : 0;
+
+				$args = array(
+					'schedule' => $job_args['schedule'],
+					'args'     => array(),
+					'interval' => $interval,
+				);
+
+				Cron_Options_CPT::instance()->create_or_update_job( $when, $job_args['action'], $args );
 			}
 		}
 	}

--- a/includes/class-internal-events.php
+++ b/includes/class-internal-events.php
@@ -53,7 +53,8 @@ class Internal_Events extends Singleton {
 		);
 
 		// Register hooks
-		add_action( 'wp_loaded', array( $this, 'schedule_internal_events' ) );
+		add_action( 'admin_init', array( $this, 'schedule_internal_events' ) );
+		add_action( 'rest_api_init', array( $this, 'schedule_internal_events' ) );
 		add_filter( 'cron_schedules', array( $this, 'register_internal_events_schedules' ) );
 
 		foreach ( $this->internal_jobs as $internal_job ) {

--- a/tests/test-rest-api.php
+++ b/tests/test-rest-api.php
@@ -37,6 +37,17 @@ class REST_API_Tests extends \WP_UnitTestCase {
 	public function test_get_items() {
 		$ev = Utils::create_test_event();
 
+		// Don't test internal events with this test
+		$internal_events = array(
+			'a8c_cron_control_force_publish_missed_schedules',
+			'a8c_cron_control_confirm_scheduled_posts',
+			'a8c_cron_control_delete_cron_option',
+			'a8c_cron_control_purge_completed_events',
+		);
+		foreach ( $internal_events as $internal_event ) {
+			wp_clear_scheduled_hook( $internal_event );
+		}
+
 		$request = new \WP_REST_Request( 'POST', '/' . \Automattic\WP\Cron_Control\REST_API::API_NAMESPACE . '/' . \Automattic\WP\Cron_Control\REST_API::ENDPOINT_LIST );
 		$request->set_body( wp_json_encode( array( 'secret' => \WP_CRON_CONTROL_SECRET, ) ) );
 		$request->set_header( 'content-type', 'application/json' );


### PR DESCRIPTION
* Change which hooks are used, reducing the chance that random site visitors will trigger creation (Fixes #16)
* Inserts internal jobs directly, rathe than relying on filtering to capture their addition (Fixes #17)