### PR TITLE
Slow post ID growth and improve Internal Jobs

### DIFF
--- a/includes/class-cron-options-cpt.php
+++ b/includes/class-cron-options-cpt.php
@@ -345,7 +345,7 @@ class Cron_Options_CPT extends Singleton {
 		} else {
 			global $wpdb;
 
-			$wpdb->update( 'posts', array( 'post_status' => self::POST_STATUS_COMPLETED, ), array( 'ID' => $job_post_id, ) );
+			$wpdb->update( $wpdb->posts, array( 'post_status' => self::POST_STATUS_COMPLETED, ), array( 'ID' => $job_post_id, ) );
 			wp_add_trashed_suffix_to_post_name_for_post( $job_post_id );
 			$this->posts_to_clean[] = $job_post_id;
 		}

--- a/includes/class-cron-options-cpt.php
+++ b/includes/class-cron-options-cpt.php
@@ -197,7 +197,7 @@ class Cron_Options_CPT extends Singleton {
 				$job_exists = $this->job_exists( $event['timestamp'], $event['action'], $event['instance'] );
 
 				if ( ! $job_exists ) {
-					$this->create_job( $event['timestamp'], $event['action'], $event['args'] );
+					$this->create_or_update_job( $event['timestamp'], $event['action'], $event['args'] );
 				}
 			}
 		}
@@ -232,7 +232,7 @@ class Cron_Options_CPT extends Singleton {
 	 *
 	 * Uses a direct query to avoid stale caches that result in duplicate events
 	 */
-	private function job_exists( $timestamp, $action, $instance, $return_id = false ) {
+	public function job_exists( $timestamp, $action, $instance, $return_id = false ) {
 		global $wpdb;
 
 		 $exists = $wpdb->get_col( $wpdb->prepare( "SELECT ID FROM {$wpdb->posts} WHERE post_name = %s AND post_type = %s AND post_status = %s LIMIT 1;", $this->event_name( $timestamp, $action, $instance ), self::POST_TYPE, self::POST_STATUS_PENDING ) );
@@ -250,7 +250,7 @@ class Cron_Options_CPT extends Singleton {
 	 * Can't call `wp_insert_post()` because `wp_unique_post_slug()` breaks the plugin's expectations
 	 * Also doesn't call `wp_insert_post()` because this function is needed before post types and capabilities are ready.
 	 */
-	public function create_job( $timestamp, $action, $args ) {
+	public function create_or_update_job( $timestamp, $action, $args, $update_id = null ) {
 		// Limit how many events to insert at once
 		if ( ! Lock::check_lock( self::LOCK, 5 ) ) {
 			return false;
@@ -297,8 +297,12 @@ class Cron_Options_CPT extends Singleton {
 		// Set this so it isn't empty, even though it serves us no purpose
 		$job_post['guid'] = esc_url( add_query_arg( self::POST_TYPE, $job_post['post_name'], home_url( '/' ) ) );
 
-		// Create the post
-		$inserted = $wpdb->insert( $wpdb->posts, $job_post );
+		// Create the post, or update an existing entry to run again in the future
+		if ( is_int( $update_id ) && $update_id > 0 ) {
+			$inserted = $wpdb->update( $wpdb->posts, $job_post, array( 'ID' => $update_id, ) );
+		} else {
+			$inserted = $wpdb->insert( $wpdb->posts, $job_post );
+		}
 
 		// Clear caches for new posts once the post type is registered
 		if ( $inserted ) {

--- a/includes/class-cron-options-cpt.php
+++ b/includes/class-cron-options-cpt.php
@@ -300,6 +300,7 @@ class Cron_Options_CPT extends Singleton {
 		// Create the post, or update an existing entry to run again in the future
 		if ( is_int( $update_id ) && $update_id > 0 ) {
 			$inserted = $wpdb->update( $wpdb->posts, $job_post, array( 'ID' => $update_id, ) );
+			$this->posts_to_clean[] = $update_id;
 		} else {
 			$inserted = $wpdb->insert( $wpdb->posts, $job_post );
 		}

--- a/includes/class-internal-events.php
+++ b/includes/class-internal-events.php
@@ -53,7 +53,8 @@ class Internal_Events extends Singleton {
 		);
 
 		// Register hooks
-		add_action( 'wp_loaded', array( $this, 'schedule_internal_events' ) );
+		add_action( 'admin_init', array( $this, 'schedule_internal_events' ) );
+		add_action( 'rest_api_init', array( $this, 'schedule_internal_events' ) );
 		add_filter( 'cron_schedules', array( $this, 'register_internal_events_schedules' ) );
 
 		foreach ( $this->internal_jobs as $internal_job ) {
@@ -74,9 +75,19 @@ class Internal_Events extends Singleton {
 	public function schedule_internal_events() {
 		$when = strtotime( sprintf( '+%d seconds', JOB_QUEUE_WINDOW_IN_SECONDS ) );
 
+		$schedules = wp_get_schedules();
+
 		foreach ( $this->internal_jobs as $job_args ) {
 			if ( ! wp_next_scheduled( $job_args['action'] ) ) {
-				wp_schedule_event( $when, $job_args['schedule'], $job_args['action'] );
+				$interval = array_key_exists( $job_args['schedule'], $schedules ) ? $schedules[ $job_args['schedule'] ]['interval'] : 0;
+
+				$args = array(
+					'schedule' => $job_args['schedule'],
+					'args'     => array(),
+					'interval' => $interval,
+				);
+
+				Cron_Options_CPT::instance()->create_or_update_job( $when, $job_args['action'], $args );
 			}
 		}
 	}

--- a/includes/class-main.php
+++ b/includes/class-main.php
@@ -11,11 +11,6 @@ class Main extends Singleton {
 	 * Register hooks
 	 */
 	protected function class_init() {
-		// For now, leave WP-CLI alone
-		if ( defined( 'WP_CLI' ) && WP_CLI ) {
-			return;
-		}
-
 		// Bail when plugin conditions aren't met
 		if ( ! defined( '\WP_CRON_CONTROL_SECRET' ) ) {
 			add_action( 'admin_notices', array( $this, 'admin_notice' ) );

--- a/tests/test-rest-api.php
+++ b/tests/test-rest-api.php
@@ -37,6 +37,17 @@ class REST_API_Tests extends \WP_UnitTestCase {
 	public function test_get_items() {
 		$ev = Utils::create_test_event();
 
+		// Don't test internal events with this test
+		$internal_events = array(
+			'a8c_cron_control_force_publish_missed_schedules',
+			'a8c_cron_control_confirm_scheduled_posts',
+			'a8c_cron_control_delete_cron_option',
+			'a8c_cron_control_purge_completed_events',
+		);
+		foreach ( $internal_events as $internal_event ) {
+			wp_clear_scheduled_hook( $internal_event );
+		}
+
 		$request = new \WP_REST_Request( 'POST', '/' . \Automattic\WP\Cron_Control\REST_API::API_NAMESPACE . '/' . \Automattic\WP\Cron_Control\REST_API::ENDPOINT_LIST );
 		$request->set_body( wp_json_encode( array( 'secret' => \WP_CRON_CONTROL_SECRET, ) ) );
 		$request->set_header( 'content-type', 'application/json' );


### PR DESCRIPTION
* Reuse existing event entries for recurring events (Fixes #14)
* Schedule Internal Jobs on a more-appropriate hook (Fixes #16)
* Inserts Internal Jobs directly into the CPT, rather than relying on filters for their capture (Fixes #17)