### PR TITLE
When an event's timestamp--or other data--is invalid, remove the entry

### DIFF
--- a/includes/class-cron-options-cpt.php
+++ b/includes/class-cron-options-cpt.php
@@ -129,8 +129,10 @@ class Cron_Options_CPT extends Singleton {
 						continue;
 					}
 
+					// Retrieve event's remaining data
 					$job_args = maybe_unserialize( $jobs_post->post_content_filtered );
 					if ( ! is_array( $job_args ) ) {
+						$this->mark_job_post_completed( $jobs_post->ID );
 						continue;
 					}
 

--- a/includes/class-cron-options-cpt.php
+++ b/includes/class-cron-options-cpt.php
@@ -110,7 +110,24 @@ class Cron_Options_CPT extends Singleton {
 			// Loop through results and built output Core expects
 			if ( ! empty( $jobs_posts ) ) {
 				foreach ( $jobs_posts as $jobs_post ) {
+					// Determine event timestamp
 					$timestamp = strtotime( $jobs_post->post_date_gmt );
+
+					// When timestamp is invalid, perhaps due to post date being set to `0000-00-00 00:00:00`, attempt to fall back to the original value
+					if ( $timestamp <= 0 ) {
+						$event_data = $jobs_post->post_title;
+						$event_data = explode( '|', $event_data );
+
+						if ( is_numeric( $event_data[0] ) ) {
+							$timestamp = (int) $event_data[0];
+						}
+					}
+
+					// If timestamp is still invalid, event is removed to let its source fix it
+					if ( $timestamp <= 0 ) {
+						$this->mark_job_post_completed( $jobs_post->ID );
+						continue;
+					}
 
 					$job_args = maybe_unserialize( $jobs_post->post_content_filtered );
 					if ( ! is_array( $job_args ) ) {


### PR DESCRIPTION
If event information isn't faithfully recorded in the CPT, whatever data is captured won't be enough to run the event, remove it, or otherwise do much of anything with the CPT entry. Accordingly, when invalid states are detected, the event should be removed. Whatever created the event can then re-create it with the expected data.

Fixes #25 