### PR TITLE
Purge completed events more frequently

### DIFF
--- a/includes/class-internal-events.php
+++ b/includes/class-internal-events.php
@@ -35,7 +35,7 @@ class Internal_Events extends Singleton {
 				'callback' => 'delete_cron_option',
 			),
 			array(
-				'schedule' => 'hourly',
+				'schedule' => 'a8c_cron_control_ten_minutes',
 				'action'   => 'a8c_cron_control_purge_completed_events',
 				'callback' => 'purge_completed_events',
 			),


### PR DESCRIPTION
Volume can be sufficient on busier sites that hourly purges are insufficient.

Fixes #13 