### PR TITLE
Add a description for the one-time fixers set of commands

### DIFF
--- a/includes/wp-cli/class-one-time-fixers.php
+++ b/includes/wp-cli/class-one-time-fixers.php
@@ -2,8 +2,10 @@
 
 namespace Automattic\WP\Cron_Control\CLI;
 
+/**
+ * Run one-time fixers for Cron Control
+ */
 class One_Time_Fixers extends \WP_CLI_Command {
-
 	/**
 	 * Remove corrupt Cron Control data resulting from initial plugin deployment
 	 *


### PR DESCRIPTION
Displays when `wp` is run without a subcommand, and probably elsewhere.