### PR TITLE
Introduce CLI commands to view plugin data

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -8,3 +8,10 @@ namespace Automattic\WP\Cron_Control;
 function is_internal_event( $action ) {
 	return Internal_Events::instance()->is_internal_event( $action );
 }
+
+/**
+ * Flush plugin's internal caches
+ */
+function flush_internal_caches() {
+	return wp_cache_delete( Cron_Options_CPT::CACHE_KEY );
+}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -11,7 +11,9 @@ function is_internal_event( $action ) {
 
 /**
  * Flush plugin's internal caches
+ *
+ * FOR INTERNAL USE ONLY - see WP-CLI; all other cache clearance should happen through the `Cron_Options_CPT` class
  */
-function flush_internal_caches() {
+function _flush_internal_caches() {
 	return wp_cache_delete( Cron_Options_CPT::CACHE_KEY );
 }

--- a/includes/wp-cli.php
+++ b/includes/wp-cli.php
@@ -7,6 +7,11 @@ if ( ! defined( '\WP_CLI' ) || ! \WP_CLI ) {
 }
 
 /**
+ * Consistent time format across commands
+ */
+const TIME_FORMAT = 'Y-m-d H:i:s';
+
+/**
  *  Clear all of the caches for memory management
  */
 function stop_the_insanity() {

--- a/includes/wp-cli.php
+++ b/includes/wp-cli.php
@@ -35,5 +35,6 @@ function stop_the_insanity() {
 /**
  * Load commands
  */
-require __DIR__ . '/wp-cli/class-data.php';
+require __DIR__ . '/wp-cli/class-cache.php';
+require __DIR__ . '/wp-cli/class-events.php';
 require __DIR__ . '/wp-cli/class-one-time-fixers.php';

--- a/includes/wp-cli/class-cache.php
+++ b/includes/wp-cli/class-cache.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Automattic\WP\Cron_Control\CLI;
+
+/**
+ * Manage Cron Control's internal caches
+ */
+class Cache extends \WP_CLI_Command {
+	/**
+	 * Flush the cache
+	 *
+	 * @subcommand flush
+	 */
+	public function flush_internal_caches( $args, $assoc_args ) {
+		$flushed = \Automattic\WP\Cron_Control\flush_internal_caches();
+
+		if ( $flushed ) {
+			\WP_CLI::success( __( 'Internal caches cleared', 'automattic-cron-control' ) );
+		} else {
+			\WP_CLI::warning( __( 'No caches to clear', 'automattic-cron-control' ) );
+		}
+	}
+}
+
+\WP_CLI::add_command( 'cron-control cache', 'Automattic\WP\Cron_Control\CLI\Cache' );

--- a/includes/wp-cli/class-cache.php
+++ b/includes/wp-cli/class-cache.php
@@ -12,7 +12,7 @@ class Cache extends \WP_CLI_Command {
 	 * @subcommand flush
 	 */
 	public function flush_internal_caches( $args, $assoc_args ) {
-		$flushed = \Automattic\WP\Cron_Control\flush_internal_caches();
+		$flushed = \Automattic\WP\Cron_Control\_flush_internal_caches();
 
 		if ( $flushed ) {
 			\WP_CLI::success( __( 'Internal caches cleared', 'automattic-cron-control' ) );

--- a/includes/wp-cli/class-data.php
+++ b/includes/wp-cli/class-data.php
@@ -9,12 +9,10 @@ class Data extends \WP_CLI_Command {
 	/**
 	 * Flush Cron Control's internal caches
 	 *
-	 * eg.: `wp --allow-root cron-control-data flush-cache`
-	 *
-	 * @subcommand flush-cache
+	 * @subcommand flush-caches
 	 */
-	public function flush_internal_cache( $args, $assoc_args ) {
-		$flushed = wp_cache_delete( \Automattic\WP\Cron_Control\Cron_Options_CPT::CACHE_KEY );
+	public function flush_internal_caches( $args, $assoc_args ) {
+		$flushed = \Automattic\WP\Cron_Control\flush_internal_caches();
 
 		if ( $flushed ) {
 			\WP_CLI::success( __( 'Internal caches cleared', 'automattic-cron-control' ) );

--- a/includes/wp-cli/class-data.php
+++ b/includes/wp-cli/class-data.php
@@ -52,12 +52,6 @@ class Data extends \WP_CLI_Command {
 			$events_for_display      = $this->format_events( $events['items'] );
 			$total_events_to_display = count( $events_for_display );
 
-			// How shall we display?
-			$format = 'table';
-			if ( isset( $assoc_args['format'] ) ) {
-				$format = $assoc_args['format'];
-			}
-
 			// Count, noting if showing fewer than all
 			if ( $events['total_items'] <= $total_events_to_display ) {
 				\WP_CLI::line( sprintf( __( 'Displaying all %s entries', 'automattic-cron-control' ), number_format_i18n( $total_events_to_display ) ) );
@@ -66,6 +60,11 @@ class Data extends \WP_CLI_Command {
 			}
 
 			// And reformat
+			$format = 'table';
+			if ( isset( $assoc_args['format'] ) ) {
+				$format = $assoc_args['format'];
+			}
+
 			\WP_CLI\Utils\format_items( $format, $events_for_display, array(
 				'ID',
 				'action',

--- a/includes/wp-cli/class-data.php
+++ b/includes/wp-cli/class-data.php
@@ -73,6 +73,7 @@ class Data extends \WP_CLI_Command {
 				'next_run_gmt',
 				'next_run_relative',
 				'recurrence',
+				'schedule_name',
 				'last_updated_gmt',
 				'event_args',
 			) );
@@ -150,7 +151,8 @@ class Data extends \WP_CLI_Command {
 				'instance'          => '',
 				'next_run_gmt'      => date( $this->time_format, strtotime( $event->post_date_gmt ) ),
 				'next_run_relative' => $this->calculate_interval( strtotime( $event->post_date_gmt ) - time() ),
-				'recurrence'        => 'Non-repeating',
+				'recurrence'        => __( 'Non-repeating', 'automattic-cron-control' ),
+				'schedule_name'     => __( 'n/a', 'automattic-cron-control' ),
 				'last_updated_gmt'  => date( $this->time_format, strtotime( $event->post_modified_gmt ) ),
 				'event_args'        => '',
 			);
@@ -177,9 +179,14 @@ class Data extends \WP_CLI_Command {
 						$row['event_args'] = maybe_serialize( $args['args'] );
 					}
 
-					// Human-readable
+					// Human-readable version of next run
 					if ( isset( $args['interval'] ) && $args['interval'] ) {
 						$row['recurrence'] = $this->calculate_interval( $args['interval'] );
+					}
+
+					// Named schedule
+					if ( isset( $args['schedule'] ) && $args['schedule'] ) {
+						$row['schedule_name'] = $args['schedule'];
 					}
 				}
 			}

--- a/includes/wp-cli/class-data.php
+++ b/includes/wp-cli/class-data.php
@@ -71,9 +71,9 @@ class Data extends \WP_CLI_Command {
 				'instance',
 				'next_run_gmt',
 				'next_run_relative',
+				'last_updated_gmt',
 				'recurrence',
 				'schedule_name',
-				'last_updated_gmt',
 				'event_args',
 			) );
 		}
@@ -150,9 +150,9 @@ class Data extends \WP_CLI_Command {
 				'instance'          => '',
 				'next_run_gmt'      => date( $this->time_format, strtotime( $event->post_date_gmt ) ),
 				'next_run_relative' => $this->calculate_interval( strtotime( $event->post_date_gmt ) - time() ),
+				'last_updated_gmt'  => date( $this->time_format, strtotime( $event->post_modified_gmt ) ),
 				'recurrence'        => __( 'Non-repeating', 'automattic-cron-control' ),
 				'schedule_name'     => __( 'n/a', 'automattic-cron-control' ),
-				'last_updated_gmt'  => date( $this->time_format, strtotime( $event->post_modified_gmt ) ),
 				'event_args'        => '',
 			);
 

--- a/includes/wp-cli/class-data.php
+++ b/includes/wp-cli/class-data.php
@@ -20,6 +20,79 @@ class Data extends \WP_CLI_Command {
 			\WP_CLI::warning( __( 'No caches to clear', 'automattic-cron-control' ) );
 		}
 	}
+
+	/**
+	 * List cron events
+	 *
+	 * Intentionally bypasses caching to ensure latest data is shown
+	 *
+	 * @subcommand show-events
+	 */
+	public function show_events( $args, $assoc_args ) {
+		$events = $this->get_events( $args, $assoc_args );
+		$this->format_events( $events );
+	}
+
+	/**
+	 * Retrieve list of events, and related data, for a given request
+	 */
+	private function get_events( $args, $assoc_args ) {
+		global $wpdb;
+
+		// Validate status, with a default
+		$status = 'pending';
+		if ( isset( $assoc_args['status'] ) ) {
+			$status = $assoc_args['status'];
+		}
+
+		if ( 'pending' !== $status && 'completed' !== $status ) {
+			\WP_CLI::error( __( 'Invalid status requested', 'automattic-cron-control' ) );
+		}
+
+		// Convert to post status
+		$post_status = null;
+		switch ( $status ) {
+			case 'pending' :
+				$post_status = \Automattic\WP\Cron_Control\Cron_Options_CPT::POST_STATUS_PENDING;
+				break;
+
+			case 'completed' :
+				$post_status = \Automattic\WP\Cron_Control\Cron_Options_CPT::POST_STATUS_COMPLETED;
+				break;
+		}
+
+		// Total to show
+		$limit = 25;
+		if ( isset( $assoc_args['limit'] ) && is_numeric( $assoc_args['limit'] ) ) {
+			$limit = max( 1, min( absint( $assoc_args['limit'] ), 500 ) );
+		}
+
+		// Pagination
+		$page = 1;
+		if ( isset( $assoc_args['page'] ) && is_numeric( $assoc_args['page'] ) ) {
+			$page = absint( $assoc_args['page'] );
+		}
+
+		$offset = absint( ( $page - 1 ) * $limit );
+
+		// Query
+		$items = $wpdb->get_results( $wpdb->prepare( "SELECT SQL_CALC_FOUND_ROWS ID, post_content_filtered, post_date_gmt, post_modified_gmt FROM {$wpdb->posts} WHERE post_type = %s AND post_status = %s ORDER BY post_date ASC LIMIT %d,%d", \Automattic\WP\Cron_Control\Cron_Options_CPT::POST_TYPE, $post_status, $offset, $limit ) );
+
+		// Bail if we don't get results
+		if ( ! is_array( $items ) ) {
+			\WP_CLI::error( __( 'Problem retrieving events', 'automattic-cron-control' ) );
+		}
+
+		// Include total for pagination etc
+		$total_items = $wpdb->get_var( 'SELECT FOUND_ROWS()' );
+
+		return compact( 'status', 'limit', 'page', 'offset', 'items', 'total_items' );
+	}
+
+	/**
+	 *
+	 */
+	private function format_events( $events ) {}
 }
 
 \WP_CLI::add_command( 'cron-control-data', 'Automattic\WP\Cron_Control\CLI\Data' );

--- a/includes/wp-cli/class-data.php
+++ b/includes/wp-cli/class-data.php
@@ -6,8 +6,6 @@ namespace Automattic\WP\Cron_Control\CLI;
  * Manage Cron Control's data, including internal caches
  */
 class Data extends \WP_CLI_Command {
-	private $time_format = 'Y-m-d H:i:s';
-
 	/**
 	 * Flush Cron Control's internal caches
 	 *
@@ -148,9 +146,9 @@ class Data extends \WP_CLI_Command {
 				'ID'                => $event->ID,
 				'action'            => '',
 				'instance'          => '',
-				'next_run_gmt'      => date( $this->time_format, strtotime( $event->post_date_gmt ) ),
+				'next_run_gmt'      => date( TIME_FORMAT, strtotime( $event->post_date_gmt ) ),
 				'next_run_relative' => $this->calculate_interval( strtotime( $event->post_date_gmt ) - time() ),
-				'last_updated_gmt'  => date( $this->time_format, strtotime( $event->post_modified_gmt ) ),
+				'last_updated_gmt'  => date( TIME_FORMAT, strtotime( $event->post_modified_gmt ) ),
 				'recurrence'        => __( 'Non-repeating', 'automattic-cron-control' ),
 				'schedule_name'     => __( 'n/a', 'automattic-cron-control' ),
 				'event_args'        => '',

--- a/includes/wp-cli/class-data.php
+++ b/includes/wp-cli/class-data.php
@@ -54,7 +54,7 @@ class Data extends \WP_CLI_Command {
 
 			// Count, noting if showing fewer than all
 			if ( $events['total_items'] <= $total_events_to_display ) {
-				\WP_CLI::line( sprintf( __( 'Displaying all %s entries', 'automattic-cron-control' ), number_format_i18n( $total_events_to_display ) ) );
+				\WP_CLI::line( sprintf( _n( 'Displaying one entry', 'Displaying all %s entries', $total_events_to_display, 'automattic-cron-control' ), number_format_i18n( $total_events_to_display ) ) );
 			} else {
 				\WP_CLI::line( sprintf( __( 'Displaying %s of %s entries, page %s of %s', 'automattic-cron-control' ), number_format_i18n( $total_events_to_display ), number_format_i18n( $events['total_items'] ), number_format_i18n( $events['page'] ), number_format_i18n( $events['total_pages'] ) ) );
 			}

--- a/includes/wp-cli/class-events.php
+++ b/includes/wp-cli/class-events.php
@@ -3,30 +3,15 @@
 namespace Automattic\WP\Cron_Control\CLI;
 
 /**
- * Manage Cron Control's data, including internal caches
+ * Manage Cron Control's data
  */
-class Data extends \WP_CLI_Command {
-	/**
-	 * Flush Cron Control's internal caches
-	 *
-	 * @subcommand flush-caches
-	 */
-	public function flush_internal_caches( $args, $assoc_args ) {
-		$flushed = \Automattic\WP\Cron_Control\flush_internal_caches();
-
-		if ( $flushed ) {
-			\WP_CLI::success( __( 'Internal caches cleared', 'automattic-cron-control' ) );
-		} else {
-			\WP_CLI::warning( __( 'No caches to clear', 'automattic-cron-control' ) );
-		}
-	}
-
+class Events extends \WP_CLI_Command {
 	/**
 	 * List cron events
 	 *
 	 * Intentionally bypasses caching to ensure latest data is shown
 	 *
-	 * @subcommand list-events
+	 * @subcommand list
 	 */
 	public function list_events( $args, $assoc_args ) {
 		$events = $this->get_events( $args, $assoc_args );
@@ -42,7 +27,7 @@ class Data extends \WP_CLI_Command {
 
 			// Not much to do
 			if ( 0 === $events['total_items'] ) {
-				\WP_CLI::success( __( 'Nothing to display', 'automattic-cron-control' ) );
+				\WP_CLI::success( __( 'No events to display', 'automattic-cron-control' ) );
 				return;
 			}
 
@@ -256,4 +241,4 @@ class Data extends \WP_CLI_Command {
 	}
 }
 
-\WP_CLI::add_command( 'cron-control-data', 'Automattic\WP\Cron_Control\CLI\Data' );
+\WP_CLI::add_command( 'cron-control events', 'Automattic\WP\Cron_Control\CLI\Events' );


### PR DESCRIPTION
While the plugin uses a CPT, it often must interact with it before WordPress is ready, so CPT entries are manipulated directly. As a result, Core's caches aren't always correct (see #24), so WP-CLI's existing ways of listing posts can't be relied upon. Additionally, given how the plugin stores its data, and how that data is best displayed, custom commands are warranted.