### PR TITLE
Set the `DOING_CRON` constant as early as possible

### DIFF
--- a/includes/class-events.php
+++ b/includes/class-events.php
@@ -28,6 +28,7 @@ class Events extends Singleton {
 	 * Prepare environment to run job
 	 *
 	 * Must run as early as possible, particularly before any client code is loaded
+	 * This also runs before Core has parsed the request and set the \REST_REQUEST constant
 	 */
 	public function prepare_environment() {
 		if ( ! is_rest_endpoint_request( 'run' ) ) {

--- a/includes/class-events.php
+++ b/includes/class-events.php
@@ -18,6 +18,25 @@ class Events extends Singleton {
 	protected function class_init() {
 		// Prime lock cache if not present
 		Lock::prime_lock( self::LOCK );
+
+		// Prepare environment as early as possible
+		$earliest_action = did_action( 'muplugins_loaded' ) ? 'plugins_loaded' : 'muplugins_loaded';
+		add_action( $earliest_action, array( $this, 'prepare_environment' ) );
+	}
+
+	/**
+	 * Prepare environment to run job
+	 *
+	 * Must run as early as possible, particularly before any client code is loaded
+	 */
+	public function prepare_environment() {
+		if ( ! is_rest_endpoint_request( 'run' ) ) {
+			return;
+		}
+
+		ignore_user_abort( true );
+		set_time_limit( JOB_TIMEOUT_IN_MINUTES * MINUTE_IN_SECONDS );
+		define( 'DOING_CRON', true );
 	}
 
 	/**
@@ -136,12 +155,8 @@ class Events extends Singleton {
 		}
 
 		// Mark the event completed, and reschedule if desired
+		// Core does this before running the job, so we respect that
 		$this->update_event_record( $event );
-
-		// Prepare environment to run job
-		ignore_user_abort( true );
-		set_time_limit( JOB_TIMEOUT_IN_MINUTES * MINUTE_IN_SECONDS );
-		define( 'DOING_CRON', true );
 
 		// Run the event
 		do_action_ref_array( $event['action'], $event['args'] );

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -10,6 +10,37 @@ function is_internal_event( $action ) {
 }
 
 /**
+ * Check if the current request is to one of the plugin's REST endpoints
+ *
+ * @param string $type list|run
+ *
+ * @return bool
+ */
+function is_rest_endpoint_request( $type = 'list' ) {
+	// Which endpoint are we checking
+	$endpoint = null;
+	switch ( $type ) {
+		case 'list' :
+			$endpoint = REST_API::ENDPOINT_LIST;
+			break;
+
+		case 'run' :
+			$endpoint = REST_API::ENDPOINT_RUN;
+			break;
+	}
+
+	// No endpoint to check
+	if ( is_null( $endpoint ) ) {
+		return false;
+	}
+
+	// Build the full endpoint and check against the current request
+	$run_endpoint = sprintf( '%s/%s/%s', rest_get_url_prefix(), REST_API::API_NAMESPACE, $endpoint );
+
+	return in_array( $run_endpoint, parse_request() );
+}
+
+/**
  * Flush plugin's internal caches
  *
  * FOR INTERNAL USE ONLY - see WP-CLI; all other cache clearance should happen through the `Cron_Options_CPT` class

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -47,3 +47,62 @@ function collapse_events_array( $events, $timestamp = null ) {
 
 	return $collapsed_events;
 }
+
+/**
+ * Parse request using Core's logic
+ *
+ * We have occasion to check the request before Core has done so, such as when preparing the environment to run a cron job
+ */
+function parse_request() {
+	$rewrite_index = 'index.php';
+
+	/**
+	 * Start what's borrowed from Core
+	 *
+	 * References to $wp_rewrite->index were replaced with $rewrite_index, and whitespace updated, but otherwise, this is directly from WP::parse_request()
+	 */
+	$pathinfo = isset( $_SERVER['PATH_INFO'] ) ? $_SERVER['PATH_INFO'] : '';
+	list( $pathinfo ) = explode( '?', $pathinfo );
+	$pathinfo = str_replace( "%", "%25", $pathinfo );
+
+	list( $req_uri ) = explode( '?', $_SERVER['REQUEST_URI'] );
+	$self = $_SERVER['PHP_SELF'];
+	$home_path = trim( parse_url( home_url(), PHP_URL_PATH ), '/' );
+	$home_path_regex = sprintf( '|^%s|i', preg_quote( $home_path, '|' ) );
+
+	// Trim path info from the end and the leading home path from the
+	// front. For path info requests, this leaves us with the requesting
+	// filename, if any. For 404 requests, this leaves us with the
+	// requested permalink.
+	$req_uri = str_replace( $pathinfo, '', $req_uri );
+	$req_uri = trim( $req_uri, '/' );
+	$req_uri = preg_replace( $home_path_regex, '', $req_uri );
+	$req_uri = trim( $req_uri, '/' );
+	$pathinfo = trim( $pathinfo, '/' );
+	$pathinfo = preg_replace( $home_path_regex, '', $pathinfo );
+	$pathinfo = trim( $pathinfo, '/' );
+	$self = trim( $self, '/' );
+	$self = preg_replace( $home_path_regex, '', $self );
+	$self = trim( $self, '/' );
+
+	// The requested permalink is in $pathinfo for path info requests and
+	//  $req_uri for other requests.
+	if ( ! empty( $pathinfo ) && !preg_match( '|^.*' . $rewrite_index . '$|', $pathinfo ) ) {
+		$requested_path = $pathinfo;
+	} else {
+		// If the request uri is the index, blank it out so that we don't try to match it against a rule.
+		if ( $req_uri == $rewrite_index ) {
+			$req_uri = '';
+		}
+
+		$requested_path = $req_uri;
+	}
+
+	$requested_file = $req_uri;
+	/**
+	 * End what's borrowed from Core
+	 */
+
+	// Return array of data about the request
+	return compact( 'requested_path', 'requested_file', 'self' );
+}


### PR DESCRIPTION
In particular, the `DOING_CRON` constant should be set before any client code is loaded.

Fixes #44