### PR TITLE
Job execution buffer has proven unnecessary, and just wastes time

### DIFF
--- a/includes/class-events.php
+++ b/includes/class-events.php
@@ -133,7 +133,7 @@ class Events extends Singleton {
 		}
 
 		// Ensure we don't run jobs too far ahead
-		if ( $timestamp > strtotime( sprintf( '+%d seconds', JOB_EXECUTION_BUFFER_IN_SECONDS ) ) ) {
+		if ( $timestamp > time() ) {
 			return new \WP_Error( 'premature', sprintf( __( 'Job with identifier `%1$s` is not scheduled to run yet.', 'automattic-cron-control' ), "$timestamp-$action-$instance" ), array( 'status' => 403, ) );
 		}
 

--- a/includes/constants.php
+++ b/includes/constants.php
@@ -7,6 +7,5 @@ namespace Automattic\WP\Cron_Control;
  */
 const JOB_QUEUE_SIZE                  = 10;
 const JOB_QUEUE_WINDOW_IN_SECONDS     = 60;
-const JOB_EXECUTION_BUFFER_IN_SECONDS = 15;
 const JOB_TIMEOUT_IN_MINUTES          = 10;
 const JOB_CONCURRENCY_LIMIT           = 10;


### PR DESCRIPTION
This is a bit vestigial. At some point, I thought there'd be more to do between queueing jobs and running them.

Fixes #43