### PR TITLE
Introduce commands to check locks

### DIFF
--- a/includes/class-cron-options-cpt.php
+++ b/includes/class-cron-options-cpt.php
@@ -271,7 +271,7 @@ class Cron_Options_CPT extends Singleton {
 	 */
 	public function create_or_update_job( $timestamp, $action, $args, $update_id = null ) {
 		// Limit how many events to insert at once
-		if ( ! Lock::check_lock( self::LOCK, 5 ) ) {
+		if ( ! Lock::check_lock( self::LOCK, JOB_CREATION_CONCURRENCY_LIMIT ) ) {
 			return false;
 		}
 

--- a/includes/class-events.php
+++ b/includes/class-events.php
@@ -148,7 +148,7 @@ class Events extends Singleton {
 		unset( $timestamp, $action, $instance );
 
 		// Limit how many events are processed concurrently
-		if ( ! is_internal_event( $event['action'] ) && ! Lock::check_lock( self::LOCK ) ) {
+		if ( ! is_internal_event( $event['action'] ) && ! Lock::check_lock( self::LOCK, JOB_CONCURRENCY_LIMIT ) ) {
 			return new \WP_Error( 'no-free-threads', sprintf( __( 'No resources available to run the job with action action `%1$s` and arguments `%2$s`.', 'automattic-cron-control' ), $event['action'], maybe_serialize( $event['args'] ) ), array( 'status' => 429, ) );
 		}
 

--- a/includes/class-lock.php
+++ b/includes/class-lock.php
@@ -72,21 +72,21 @@ class Lock {
 	/**
 	 * Retrieve a lock from cache
 	 */
-	private static function get_lock_value( $lock ) {
+	public static function get_lock_value( $lock ) {
 		return (int) wp_cache_get( self::get_key( $lock ), null, true );
 	}
 
 	/**
 	 * Retrieve a lock's timestamp
 	 */
-	private static function get_lock_timestamp( $lock ) {
+	public static function get_lock_timestamp( $lock ) {
 		return (int) wp_cache_get( self::get_key( $lock, 'timestamp' ), null, true );
 	}
 
 	/**
 	 * Clear a lock's current values, in order to free it
 	 */
-	private static function reset_lock( $lock ) {
+	public static function reset_lock( $lock ) {
 		wp_cache_set( self::get_key( $lock ), 0 );
 		wp_cache_set( self::get_key( $lock, 'timestamp' ), time() );
 

--- a/includes/class-lock.php
+++ b/includes/class-lock.php
@@ -15,7 +15,7 @@ class Lock {
 
 		// Default limit for concurrent events
 		if ( ! is_numeric( $limit ) ) {
-			$limit = JOB_CONCURRENCY_LIMIT;
+			$limit = LOCK_DEFAULT_LIMIT;
 		}
 
 		// Check if process can run

--- a/includes/constants.php
+++ b/includes/constants.php
@@ -9,3 +9,13 @@ const JOB_QUEUE_SIZE                  = 10;
 const JOB_QUEUE_WINDOW_IN_SECONDS     = 60;
 const JOB_TIMEOUT_IN_MINUTES          = 10;
 const JOB_CONCURRENCY_LIMIT           = 10;
+
+/**
+ * Job creation
+ */
+const JOB_CREATION_CONCURRENCY_LIMIT = 5;
+
+/**
+ * Locks
+ */
+const LOCK_DEFAULT_LIMIT = 10;

--- a/includes/wp-cli.php
+++ b/includes/wp-cli.php
@@ -37,4 +37,5 @@ function stop_the_insanity() {
  */
 require __DIR__ . '/wp-cli/class-cache.php';
 require __DIR__ . '/wp-cli/class-events.php';
+require __DIR__ . '/wp-cli/class-lock.php';
 require __DIR__ . '/wp-cli/class-one-time-fixers.php';

--- a/includes/wp-cli/class-lock.php
+++ b/includes/wp-cli/class-lock.php
@@ -7,17 +7,33 @@ namespace Automattic\WP\Cron_Control\CLI;
  */
 class Lock extends \WP_CLI_Command {
 	/**
-	 * Check value of execution lock
+	 * Manage the lock that limits concurrent job executions
 	 *
-	 * Not to exceed `JOB_CONCURRENCY_LIMIT`
-	 *
-	 * @subcommand check-run-lock
+	 * @subcommand run-lock
+	 * @synopsis [--reset]
 	 */
-	public function check_run_lock( $args, $assoc_args ) {
+	public function run_lock( $args, $assoc_args ) {
+		// Output information about the lock
 		\WP_CLI::line( __( 'This lock limits the number of concurrent events that are run.', 'automattic-cron-control' ) . "\n" );
 
 		\WP_CLI::line( sprintf( __( 'Maximum: %s', 'automattic-cron-control' ), number_format_i18n( \Automattic\WP\Cron_Control\JOB_CONCURRENCY_LIMIT ) ) . "\n" );
 
+		// Reset requested
+		if ( isset( $assoc_args['reset'] ) ) {
+			\WP_CLI::warning( __( 'Resetting lock', 'automattic-cron-control' ) . "\n" );
+
+			$lock      = \Automattic\WP\Cron_Control\Lock::get_lock_value( \Automattic\WP\Cron_Control\Events::LOCK );
+			$timestamp = \Automattic\WP\Cron_Control\Lock::get_lock_timestamp( \Automattic\WP\Cron_Control\Events::LOCK );
+
+			\WP_CLI::line( sprintf( __( 'Previous value: %s', 'automattic-cron-control' ), number_format_i18n( $lock ) ) );
+			\WP_CLI::line( sprintf( __( 'Previous lock expiration: %s GMT', 'automattic-cron-control' ), date( TIME_FORMAT, $timestamp ) ) . "\n" );
+
+			\Automattic\WP\Cron_Control\Lock::reset_lock( \Automattic\WP\Cron_Control\Events::LOCK );
+			\WP_CLI::success( __( 'Lock reset', 'automattic-cron-control' ) . "\n" );
+			\WP_CLI::line( __( 'New lock values:', 'automattic-cron-control' ) );
+		}
+
+		// Output lock state
 		$lock      = \Automattic\WP\Cron_Control\Lock::get_lock_value( \Automattic\WP\Cron_Control\Events::LOCK );
 		$timestamp = \Automattic\WP\Cron_Control\Lock::get_lock_timestamp( \Automattic\WP\Cron_Control\Events::LOCK );
 

--- a/includes/wp-cli/class-lock.php
+++ b/includes/wp-cli/class-lock.php
@@ -45,13 +45,16 @@ class Lock extends \WP_CLI_Command {
 
 		// Reset requested
 		if ( isset( $assoc_args['reset'] ) ) {
-			\WP_CLI::warning( __( 'Resetting lock', 'automattic-cron-control' ) . "\n" );
+			\WP_CLI::warning( __( 'Resetting lock...', 'automattic-cron-control' ) . "\n" );
 
 			$lock      = \Automattic\WP\Cron_Control\Lock::get_lock_value( $lock_name );
 			$timestamp = \Automattic\WP\Cron_Control\Lock::get_lock_timestamp( $lock_name );
 
 			\WP_CLI::line( sprintf( __( 'Previous value: %s', 'automattic-cron-control' ), number_format_i18n( $lock ) ) );
-			\WP_CLI::line( sprintf( __( 'Previous lock expiration: %s GMT', 'automattic-cron-control' ), date( TIME_FORMAT, $timestamp ) ) . "\n" );
+			\WP_CLI::line( sprintf( __( 'Previously modified: %s GMT', 'automattic-cron-control' ), date( TIME_FORMAT, $timestamp ) ) . "\n" );
+
+			\WP_CLI::confirm( sprintf( __( 'Are you sure you want to reset this lock?', 'automattic-cron-control' ) ) );
+			\WP_CLI::line( '' );
 
 			\Automattic\WP\Cron_Control\Lock::reset_lock( $lock_name );
 			\WP_CLI::success( __( 'Lock reset', 'automattic-cron-control' ) . "\n" );
@@ -63,7 +66,7 @@ class Lock extends \WP_CLI_Command {
 		$timestamp = \Automattic\WP\Cron_Control\Lock::get_lock_timestamp( $lock_name );
 
 		\WP_CLI::line( sprintf( __( 'Current value: %s', 'automattic-cron-control' ), number_format_i18n( $lock ) ) );
-		\WP_CLI::line( sprintf( __( 'Lock expiration: %s GMT', 'automattic-cron-control' ), date( TIME_FORMAT, $timestamp ) ) );
+		\WP_CLI::line( sprintf( __( 'Last modified: %s GMT', 'automattic-cron-control' ), date( TIME_FORMAT, $timestamp ) ) );
 	}
 }
 

--- a/includes/wp-cli/class-lock.php
+++ b/includes/wp-cli/class-lock.php
@@ -13,29 +13,40 @@ class Lock extends \WP_CLI_Command {
 	 * @synopsis [--reset]
 	 */
 	public function run_lock( $args, $assoc_args ) {
-		// Output information about the lock
-		\WP_CLI::line( __( 'This lock limits the number of concurrent events that are run.', 'automattic-cron-control' ) . "\n" );
+		$lock_name        = \Automattic\WP\Cron_Control\Events::LOCK;
+		$lock_limit       = \Automattic\WP\Cron_Control\JOB_CONCURRENCY_LIMIT;
+		$lock_description = __( 'This lock limits the number of events that can run concurrently.', 'automattic-cron-control' );
 
-		\WP_CLI::line( sprintf( __( 'Maximum: %s', 'automattic-cron-control' ), number_format_i18n( \Automattic\WP\Cron_Control\JOB_CONCURRENCY_LIMIT ) ) . "\n" );
+		$this->get_reset_lock( $args, $assoc_args, $lock_name, $lock_limit, $lock_description );
+	}
+
+	/**
+	 * Retrieve a lock's current value, or reset it
+	 */
+	private function get_reset_lock( $args, $assoc_args, $lock_name, $lock_limit, $lock_description ) {
+		// Output information about the lock
+		\WP_CLI::line( $lock_description . "\n" );
+
+		\WP_CLI::line( sprintf( __( 'Maximum: %s', 'automattic-cron-control' ), number_format_i18n( $lock_limit ) ) . "\n" );
 
 		// Reset requested
 		if ( isset( $assoc_args['reset'] ) ) {
 			\WP_CLI::warning( __( 'Resetting lock', 'automattic-cron-control' ) . "\n" );
 
-			$lock      = \Automattic\WP\Cron_Control\Lock::get_lock_value( \Automattic\WP\Cron_Control\Events::LOCK );
-			$timestamp = \Automattic\WP\Cron_Control\Lock::get_lock_timestamp( \Automattic\WP\Cron_Control\Events::LOCK );
+			$lock      = \Automattic\WP\Cron_Control\Lock::get_lock_value( $lock_name );
+			$timestamp = \Automattic\WP\Cron_Control\Lock::get_lock_timestamp( $lock_name );
 
 			\WP_CLI::line( sprintf( __( 'Previous value: %s', 'automattic-cron-control' ), number_format_i18n( $lock ) ) );
 			\WP_CLI::line( sprintf( __( 'Previous lock expiration: %s GMT', 'automattic-cron-control' ), date( TIME_FORMAT, $timestamp ) ) . "\n" );
 
-			\Automattic\WP\Cron_Control\Lock::reset_lock( \Automattic\WP\Cron_Control\Events::LOCK );
+			\Automattic\WP\Cron_Control\Lock::reset_lock( $lock_name );
 			\WP_CLI::success( __( 'Lock reset', 'automattic-cron-control' ) . "\n" );
 			\WP_CLI::line( __( 'New lock values:', 'automattic-cron-control' ) );
 		}
 
 		// Output lock state
-		$lock      = \Automattic\WP\Cron_Control\Lock::get_lock_value( \Automattic\WP\Cron_Control\Events::LOCK );
-		$timestamp = \Automattic\WP\Cron_Control\Lock::get_lock_timestamp( \Automattic\WP\Cron_Control\Events::LOCK );
+		$lock      = \Automattic\WP\Cron_Control\Lock::get_lock_value( $lock_name );
+		$timestamp = \Automattic\WP\Cron_Control\Lock::get_lock_timestamp( $lock_name );
 
 		\WP_CLI::line( sprintf( __( 'Current value: %s', 'automattic-cron-control' ), number_format_i18n( $lock ) ) );
 		\WP_CLI::line( sprintf( __( 'Lock expiration: %s GMT', 'automattic-cron-control' ), date( TIME_FORMAT, $timestamp ) ) );

--- a/includes/wp-cli/class-lock.php
+++ b/includes/wp-cli/class-lock.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Automattic\WP\Cron_Control\CLI;
+
+/**
+ * Manage Cron Control's internal locks
+ */
+class Lock extends \WP_CLI_Command {
+	/**
+	 * Check value of execution lock
+	 *
+	 * Not to exceed `JOB_CONCURRENCY_LIMIT`
+	 *
+	 * @subcommand check-run-lock
+	 */
+	public function check_run_lock( $args, $assoc_args ) {
+		\WP_CLI::line( __( 'This lock limits the number of concurrent events that are run.', 'automattic-cron-control' ) . "\n" );
+
+		\WP_CLI::line( sprintf( __( 'Maximum: %s', 'automattic-cron-control' ), number_format_i18n( \Automattic\WP\Cron_Control\JOB_CONCURRENCY_LIMIT ) ) . "\n" );
+
+		$lock      = \Automattic\WP\Cron_Control\Lock::get_lock_value( \Automattic\WP\Cron_Control\Events::LOCK );
+		$timestamp = \Automattic\WP\Cron_Control\Lock::get_lock_timestamp( \Automattic\WP\Cron_Control\Events::LOCK );
+
+		\WP_CLI::line( sprintf( __( 'Current value: %s', 'automattic-cron-control' ), number_format_i18n( $lock ) ) );
+		\WP_CLI::line( sprintf( __( 'Lock expiration: %s GMT', 'automattic-cron-control' ), date( TIME_FORMAT, $timestamp ) ) );
+	}
+}
+
+\WP_CLI::add_command( 'cron-control locks', 'Automattic\WP\Cron_Control\CLI\Lock' );

--- a/includes/wp-cli/class-lock.php
+++ b/includes/wp-cli/class-lock.php
@@ -9,13 +9,27 @@ class Lock extends \WP_CLI_Command {
 	/**
 	 * Manage the lock that limits concurrent job executions
 	 *
-	 * @subcommand run-lock
+	 * @subcommand manage-run-lock
 	 * @synopsis [--reset]
 	 */
-	public function run_lock( $args, $assoc_args ) {
+	public function manage_run_lock( $args, $assoc_args ) {
 		$lock_name        = \Automattic\WP\Cron_Control\Events::LOCK;
 		$lock_limit       = \Automattic\WP\Cron_Control\JOB_CONCURRENCY_LIMIT;
-		$lock_description = __( 'This lock limits the number of events that can run concurrently.', 'automattic-cron-control' );
+		$lock_description = __( 'This lock limits the number of events run concurrently.', 'automattic-cron-control' );
+
+		$this->get_reset_lock( $args, $assoc_args, $lock_name, $lock_limit, $lock_description );
+	}
+
+	/**
+	 * Manage the lock that limits concurrent job creation
+	 *
+	 * @subcommand manage-create-lock
+	 * @synopsis [--reset]
+	 */
+	public function manage_create_lock( $args, $assoc_args ) {
+		$lock_name        = \Automattic\WP\Cron_Control\Cron_Options_CPT::LOCK;
+		$lock_limit       = \Automattic\WP\Cron_Control\JOB_CREATION_CONCURRENCY_LIMIT;
+		$lock_description = __( 'This lock limits the number of events created concurrently.', 'automattic-cron-control' );
 
 		$this->get_reset_lock( $args, $assoc_args, $lock_name, $lock_limit, $lock_description );
 	}


### PR DESCRIPTION
Concurrency is controlled via internal locks, and sometimes it's useful to check the value to confirm that things aren't deadlocked.

See #28 