### PR TITLE
Add event-level locking

### DIFF
--- a/includes/class-events.php
+++ b/includes/class-events.php
@@ -162,10 +162,9 @@ class Events extends Singleton {
 		// Run the event
 		do_action_ref_array( $event['action'], $event['args'] );
 
-		// Free process for the next event
-		// Lock isn't set when event execution is forced or event is Internal, so we don't want to alter it
-		if ( ! $force && ! is_internal_event( $event['action'] ) ) {
-			Lock::free_lock( self::LOCK );
+		// Free process for the next event, unless it wasn't set to begin with
+		if ( ! $force ) {
+			$this->do_lock_cleanup( $event );
 		}
 
 		return array(
@@ -194,6 +193,16 @@ class Events extends Singleton {
 
 		// Let's go!
 		return true;
+	}
+
+	/**
+	 * @param $event array Event data
+	 */
+	private function do_lock_cleanup( $event ) {
+		// Lock isn't set when event is Internal, so we don't want to alter it
+		if ( ! is_internal_event( $event['action'] ) ) {
+			Lock::free_lock( self::LOCK );
+		}
 	}
 
 	/**

--- a/includes/class-events.php
+++ b/includes/class-events.php
@@ -206,7 +206,7 @@ class Events extends Singleton {
 		}
 
 		// Limit to one concurrent execution of a specific action
-		if ( ! Lock::check_lock( $this->get_lock_key_for_event_action( $event ), 1 ) ) {
+		if ( ! Lock::check_lock( $this->get_lock_key_for_event_action( $event ), 1, JOB_LOCK_EXPIRY_IN_MINUTES ) ) {
 			return false;
 		}
 

--- a/includes/class-events.php
+++ b/includes/class-events.php
@@ -183,7 +183,7 @@ class Events extends Singleton {
 	 *
 	 * @param $event array Event data
 	 */
-	private function prime_event_action_lock( $event ) { error_log( var_export( $this->get_lock_key_for_event_action( $event ), true ) );
+	private function prime_event_action_lock( $event ) {
 		Lock::prime_lock( $this->get_lock_key_for_event_action( $event ), JOB_LOCK_EXPIRY_IN_MINUTES );
 	}
 

--- a/includes/class-lock.php
+++ b/includes/class-lock.php
@@ -30,14 +30,14 @@ class Lock {
 	/**
 	 * When event completes, allow another
 	 */
-	public static function free_lock( $lock ) {
+	public static function free_lock( $lock, $expires = 0 ) {
 		if ( self::get_lock_value( $lock ) > 1 ) {
 			wp_cache_decr( self::get_key( $lock ) );
 		} else {
-			wp_cache_set( self::get_key( $lock ), 0 );
+			wp_cache_set( self::get_key( $lock ), 0, null, $expires );
 		}
 
-		wp_cache_set( self::get_key( $lock, 'timestamp' ), time() );
+		wp_cache_set( self::get_key( $lock, 'timestamp' ), time(), null, $expires );
 
 		return true;
 	}
@@ -62,9 +62,9 @@ class Lock {
 	/**
 	 * Ensure lock entries are initially set
 	 */
-	public static function prime_lock( $lock ) {
-		wp_cache_add( self::get_key( $lock ), 0 );
-		wp_cache_add( self::get_key( $lock, 'timestamp' ), time() );
+	public static function prime_lock( $lock, $expires = 0 ) {
+		wp_cache_add( self::get_key( $lock ), 0, null, $expires );
+		wp_cache_add( self::get_key( $lock, 'timestamp' ), time(), null, $expires );
 
 		return null;
 	}
@@ -86,9 +86,9 @@ class Lock {
 	/**
 	 * Clear a lock's current values, in order to free it
 	 */
-	public static function reset_lock( $lock ) {
-		wp_cache_set( self::get_key( $lock ), 0 );
-		wp_cache_set( self::get_key( $lock, 'timestamp' ), time() );
+	public static function reset_lock( $lock, $expires = 0 ) {
+		wp_cache_set( self::get_key( $lock ), 0, null, $expires );
+		wp_cache_set( self::get_key( $lock, 'timestamp' ), time(), null, $expires );
 
 		return true;
 	}

--- a/includes/class-lock.php
+++ b/includes/class-lock.php
@@ -6,9 +6,16 @@ class Lock {
 	/**
 	 * Set a lock and limit how many concurrent jobs are permitted
 	 */
-	public static function check_lock( $lock, $limit = null ) {
-		// Prevent deadlock
-		if ( self::get_lock_timestamp( $lock ) < time() - JOB_TIMEOUT_IN_MINUTES * MINUTE_IN_SECONDS ) {
+	public static function check_lock( $lock, $limit = null, $timeout_in_minutes = null ) {
+		// Timeout, should a process die before its lock is freed
+		if ( is_numeric( $timeout_in_minutes ) ) {
+			$timeout = $timeout_in_minutes * \MINUTE_IN_SECONDS;
+		} else {
+			$timeout = LOCK_DEFULT_TIMEOUT_IN_MINUTES * \MINUTE_IN_SECONDS;
+		}
+
+		// Check for, and recover from, deadlock
+		if ( self::get_lock_timestamp( $lock ) < time() - $timeout ) {
 			self::reset_lock( $lock );
 			return true;
 		}

--- a/includes/constants.php
+++ b/includes/constants.php
@@ -19,4 +19,5 @@ const JOB_CREATION_CONCURRENCY_LIMIT = 5;
 /**
  * Locks
  */
-const LOCK_DEFAULT_LIMIT = 10;
+const LOCK_DEFAULT_LIMIT             = 10;
+const LOCK_DEFULT_TIMEOUT_IN_MINUTES = 10;

--- a/includes/constants.php
+++ b/includes/constants.php
@@ -8,6 +8,7 @@ namespace Automattic\WP\Cron_Control;
 const JOB_QUEUE_SIZE                  = 10;
 const JOB_QUEUE_WINDOW_IN_SECONDS     = 60;
 const JOB_TIMEOUT_IN_MINUTES          = 10;
+const JOB_LOCK_EXPIRY_IN_MINUTES      = 30;
 const JOB_CONCURRENCY_LIMIT           = 10;
 
 /**

--- a/includes/wp-cli/class-lock.php
+++ b/includes/wp-cli/class-lock.php
@@ -35,6 +35,24 @@ class Lock extends \WP_CLI_Command {
 	}
 
 	/**
+	 * Manage the lock that limits concurrent execution of jobs with the same action
+	 *
+	 * @subcommand manage-event-lock
+	 * @synopsis <action> [--reset]
+	 */
+	public function manage_event_lock( $args, $assoc_args ) {
+		if ( empty( $args[0] ) ) {
+			\WP_CLI::error( sprintf( __( 'Specify an action', 'automattic-cron-control' ) ) );
+		}
+
+		$lock_name        = \Automattic\WP\Cron_Control\Events::instance()->get_lock_key_for_event_action( array( 'action' => $args[0], ) );
+		$lock_limit       = 1;
+		$lock_description = __( "This lock prevents concurrent executions of events with the same action, regardless of the action's arguments.", 'automattic-cron-control' );
+
+		$this->get_reset_lock( $args, $assoc_args, $lock_name, $lock_limit, $lock_description );
+	}
+
+	/**
 	 * Retrieve a lock's current value, or reset it
 	 */
 	private function get_reset_lock( $args, $assoc_args, $lock_name, $lock_limit, $lock_description ) {


### PR DESCRIPTION
Running multiple of the same action may not be wise, particularly if those actions generate significant database queries or other load. On the other hand, setting the concurrency to `1` is likely to create a backlog. By introducing event-level locking, multiple events can run simultaneously while reducing the chance that long-running or load-intensive events will induce a backlog, performance degradation, or both.

Fixes #65