### PR TITLE
Miscellaneous and trivial CLI improvements

### DIFF
--- a/includes/class-main.php
+++ b/includes/class-main.php
@@ -48,7 +48,7 @@ class Main extends Singleton {
 		foreach ( $constants as $constant => $expected_value ) {
 			if ( defined( $constant ) ) {
 				if ( constant( $constant ) !== $expected_value ) {
-					error_log( sprintf( __( '%s: %s set to unexpected value; must be corrected for proper behaviour.', 'automattic-cron-control' ), 'Cron Control', $constant ) );
+					error_log( sprintf( __( '%1$s: %2$s set to unexpected value; must be corrected for proper behaviour.', 'automattic-cron-control' ), 'Cron Control', $constant ) );
 				}
 			} else {
 				define( $constant, $expected_value );

--- a/includes/wp-cli/class-events.php
+++ b/includes/wp-cli/class-events.php
@@ -45,7 +45,7 @@ class Events extends \WP_CLI_Command {
 			if ( $events['total_items'] <= $total_events_to_display ) {
 				\WP_CLI::line( sprintf( _n( 'Displaying one entry', 'Displaying all %s entries', $total_events_to_display, 'automattic-cron-control' ), number_format_i18n( $total_events_to_display ) ) );
 			} else {
-				\WP_CLI::line( sprintf( __( 'Displaying %s of %s entries, page %s of %s', 'automattic-cron-control' ), number_format_i18n( $total_events_to_display ), number_format_i18n( $events['total_items'] ), number_format_i18n( $events['page'] ), number_format_i18n( $events['total_pages'] ) ) );
+				\WP_CLI::line( sprintf( __( 'Displaying %1$s of %2$s entries, page %3$s of %4$s', 'automattic-cron-control' ), number_format_i18n( $total_events_to_display ), number_format_i18n( $events['total_items'] ), number_format_i18n( $events['page'] ), number_format_i18n( $events['total_pages'] ) ) );
 			}
 
 			// And reformat
@@ -115,7 +115,7 @@ class Events extends \WP_CLI_Command {
 		// Event data
 		$event_data = $this->get_event_details_from_post_title( $event );
 
-		\WP_CLI::line( sprintf( __( 'Found event %d with action `%s` and instance identifier `%s`', 'automattic-cron-control' ), $args[0], $event_data['action'], $event_data['instance'] ) );
+		\WP_CLI::line( sprintf( __( 'Found event %1$d with action `%2$s` and instance identifier `%3$s`', 'automattic-cron-control' ), $args[0], $event_data['action'], $event_data['instance'] ) );
 
 		// Proceed?
 		$now = time();

--- a/includes/wp-cli/class-events.php
+++ b/includes/wp-cli/class-events.php
@@ -17,6 +17,11 @@ class Events extends \WP_CLI_Command {
 	public function list_events( $args, $assoc_args ) {
 		$events = $this->get_events( $args, $assoc_args );
 
+		// Prevent one from requesting a page that doesn't exist
+		if ( $events['page'] > $events['total_pages'] ) {
+			\WP_CLI::error( __( 'Invalid page requested', 'automattic-cron-control' ) );
+		}
+
 		// Output in the requested format
 		if ( isset( $assoc_args['format'] ) && 'ids' === $assoc_args['format'] ) {
 			echo implode( ' ', wp_list_pluck( $events['items'], 'ID' ) );
@@ -27,8 +32,8 @@ class Events extends \WP_CLI_Command {
 			}
 
 			// Not much to do
-			if ( 0 === $events['total_items'] ) {
-				\WP_CLI::success( __( 'No events to display', 'automattic-cron-control' ) );
+			if ( 0 === $events['total_items'] || empty( $events['items'] ) ) {
+				\WP_CLI::warning( __( 'No events to display', 'automattic-cron-control' ) );
 				return;
 			}
 

--- a/includes/wp-cli/class-events.php
+++ b/includes/wp-cli/class-events.php
@@ -18,7 +18,8 @@ class Events extends \WP_CLI_Command {
 		$events = $this->get_events( $args, $assoc_args );
 
 		// Prevent one from requesting a page that doesn't exist
-		if ( $events['page'] > $events['total_pages'] ) {
+		// Shouldn't error when first page is requested, though, as that is handled below and is an odd behaviour otherwise
+		if ( $events['page'] > $events['total_pages'] && $events['page'] > 1 ) {
 			\WP_CLI::error( __( 'Invalid page requested', 'automattic-cron-control' ) );
 		}
 

--- a/includes/wp-cli/class-one-time-fixers.php
+++ b/includes/wp-cli/class-one-time-fixers.php
@@ -9,9 +9,8 @@ class One_Time_Fixers extends \WP_CLI_Command {
 	/**
 	 * Remove corrupt Cron Control data resulting from initial plugin deployment
 	 *
-	 * eg.: `wp --allow-root cron-control-fixers remove-all-plugin-data --batch-size=15 --dry-run=true`
-	 *
 	 * @subcommand remove-all-plugin-data
+	 * @synopsis [--batch-size=<batch-size>] [--dry-run=<dry-run>]
 	 */
 	public function purge( $args, $assoc_args ) {
 		global $wpdb;
@@ -60,7 +59,7 @@ class One_Time_Fixers extends \WP_CLI_Command {
 
 		// Let's get on with it
 		do {
-			\WP_CLI::line( "\n\n" . sprintf( __( 'Processing page %s of %s', 'automattic-cron-control' ), number_format_i18n( $page ), number_format_i18n( $pages ) ) . "\n" );
+			\WP_CLI::line( "\n\n" . sprintf( __( 'Processing page %1$s of %2$s', 'automattic-cron-control' ), number_format_i18n( $page ), number_format_i18n( $pages ) ) . "\n" );
 
 			$items = $wpdb->get_results( $wpdb->prepare( "SELECT ID, post_title FROM {$wpdb->posts} WHERE post_type = %s LIMIT %d,%d", 'a8c_cron_ctrl_event', absint( ( $page - 1 ) * $page_size ),$page_size ) );
 


### PR DESCRIPTION
A few small things that've been bugging me:

* List of completed events showed a value for "next run relative" even though the event had run (Fixes #40)
* Translations with multiple replacements didn't properly use placeholders (Fixes #47)
* Requesting a non-existent page of events (page 9 of 8, for example) didn't properly error, but instead showed an empty table (Fixes #67)