### PR TITLE
Fix timeouts on event-level locking

### DIFF
--- a/includes/class-events.php
+++ b/includes/class-events.php
@@ -184,7 +184,7 @@ class Events extends Singleton {
 	 * @param $event array Event data
 	 */
 	private function prime_event_action_lock( $event ) {
-		Lock::prime_lock( $this->get_lock_key_for_event_action( $event ), JOB_LOCK_EXPIRY_IN_MINUTES );
+		Lock::prime_lock( $this->get_lock_key_for_event_action( $event ), JOB_LOCK_EXPIRY_IN_MINUTES * \MINUTE_IN_SECONDS );
 	}
 
 	/**
@@ -206,7 +206,7 @@ class Events extends Singleton {
 		}
 
 		// Limit to one concurrent execution of a specific action
-		if ( ! Lock::check_lock( $this->get_lock_key_for_event_action( $event ), 1, JOB_LOCK_EXPIRY_IN_MINUTES ) ) {
+		if ( ! Lock::check_lock( $this->get_lock_key_for_event_action( $event ), 1, JOB_LOCK_EXPIRY_IN_MINUTES * \MINUTE_IN_SECONDS ) ) {
 			return false;
 		}
 
@@ -226,7 +226,7 @@ class Events extends Singleton {
 		}
 
 		// Reset individual event lock
-		Lock::reset_lock( $this->get_lock_key_for_event_action( $event ), JOB_LOCK_EXPIRY_IN_MINUTES );
+		Lock::reset_lock( $this->get_lock_key_for_event_action( $event ), JOB_LOCK_EXPIRY_IN_MINUTES * \MINUTE_IN_SECONDS );
 	}
 
 	/**

--- a/includes/class-lock.php
+++ b/includes/class-lock.php
@@ -5,12 +5,16 @@ namespace Automattic\WP\Cron_Control;
 class Lock {
 	/**
 	 * Set a lock and limit how many concurrent jobs are permitted
+	 *
+	 * @param $lock     string  Lock name
+	 * @param $limit    int     Concurrency limit
+	 * @param $timeout  int     Timeout in seconds
+	 *
+	 * @return bool
 	 */
-	public static function check_lock( $lock, $limit = null, $timeout_in_minutes = null ) {
+	public static function check_lock( $lock, $limit = null, $timeout = null ) {
 		// Timeout, should a process die before its lock is freed
-		if ( is_numeric( $timeout_in_minutes ) ) {
-			$timeout = $timeout_in_minutes * \MINUTE_IN_SECONDS;
-		} else {
+		if ( ! is_numeric( $timeout ) ) {
 			$timeout = LOCK_DEFULT_TIMEOUT_IN_MINUTES * \MINUTE_IN_SECONDS;
 		}
 


### PR DESCRIPTION
The constant name `JOB_LOCK_EXPIRY_IN_MINUTES` made it clear that I should've multiplied by `\MINUTE_IN_SECONDS` when setting expirations and resetting locks. That said, due to inconsistent implementations (also my fault), one `Lock` method accepted minutes, while two others used seconds; this inconsistency certainly contributed to the bug.

By updating the `Lock` class to consistently accept seconds for expirations, and adding the necessary multiplication, event-level locks should work as intended. A better docblock should also reduce the chance of this recurring.

Aside, the global lock wasn't affected by this issue because it doesn't set timeouts; timeouts were introduced in #66, as part of providing event-level locking.