### PR TITLE
If an event has no callbacks hooked to its action, skip it

### DIFF
--- a/includes/class-events.php
+++ b/includes/class-events.php
@@ -70,7 +70,9 @@ class Events extends Singleton {
 				if ( false === $event['args']['schedule'] ) {
 					wp_unschedule_event( $event['timestamp'], $event['action'], $event['args']['args'] );
 				} else {
-					wp_reschedule_event( $event['timestamp'], $event['args']['schedule'], $event['action'], $event['args']['args'] );
+					$timestamp = $event['timestamp'] + ( isset( $event['args']['interval'] ) ? $event['args']['interval'] : 0 );
+					wp_reschedule_event( $timestamp, $event['args']['schedule'], $event['action'], $event['args']['args'] );
+					unset( $timestamp );
 				}
 
 				continue;

--- a/includes/class-events.php
+++ b/includes/class-events.php
@@ -65,6 +65,17 @@ class Events extends Singleton {
 				continue;
 			}
 
+			// Skip events that don't have any callbacks hooked to their actions, unless their execution is requested
+			if ( false === has_action( $event['action'] ) && ! apply_filters( 'a8c_cron_control_run_event_with_no_callbacks', false, $event ) ) {
+				if ( false === $event['args']['schedule'] ) {
+					wp_unschedule_event( $event['timestamp'], $event['action'], $event['args']['args'] );
+				} else {
+					wp_reschedule_event( $event['timestamp'], $event['args']['schedule'], $event['action'], $event['args']['args'] );
+				}
+
+				continue;
+			}
+
 			// Necessary data to identify an individual event
 			// `$event['action']` is hashed to avoid information disclosure
 			// Core hashes `$event['instance']` for us

--- a/tests/includes/utils.php
+++ b/tests/includes/utils.php
@@ -13,6 +13,9 @@ class Utils {
 			'args'      => array(),
 		);
 
+		// Plugin skips events with no callbacks
+		add_action( 'a8c_cron_control_test_event', '__return_true' );
+
 		if ( $allow_multiple ) {
 			$event['action'] .= '_' . rand( 10, 100 );
 		}


### PR DESCRIPTION
Filter is available to bypass this