### PR TITLE
Limit an event's domination of the queue

### DIFF
--- a/includes/class-events.php
+++ b/includes/class-events.php
@@ -144,12 +144,7 @@ class Events extends Singleton {
 
 		$i = 1; // Intentionally not zero-indexed to facilitate comparisons against $action_counts members
 
-		while ( count( $reduced_queue ) < JOB_QUEUE_SIZE && ! empty( $events ) ) {
-			// Circuit breaker
-			if ( $i > 15 ) {
-				break;
-			}
-
+		while ( $i <= 15 && count( $reduced_queue ) < JOB_QUEUE_SIZE && ! empty( $events ) ) {
 			// Each time the events array is iterated over, move one instance of an action to the current queue
 			foreach ( $events as $key => $event ) {
 				$action = $event['action'];

--- a/includes/class-events.php
+++ b/includes/class-events.php
@@ -73,7 +73,7 @@ class Events extends Singleton {
 			// Necessary data to identify an individual event
 			// `$event['action']` is hashed to avoid information disclosure
 			// Core hashes `$event['instance']` for us
-			$event = array(
+			$event_data_public = array(
 				'timestamp' => $event['timestamp'],
 				'action'    => md5( $event['action'] ),
 				'instance'  => $event['instance'],
@@ -81,9 +81,9 @@ class Events extends Singleton {
 
 			// Queue internal events separately to avoid them being blocked
 			if ( is_internal_event( $event['action'] ) ) {
-				$internal_events[] = $event;
+				$internal_events[] = $event_data_public;
 			} else {
-				$current_events[] = $event;
+				$current_events[] = $event_data_public;
 			}
 		}
 
@@ -92,6 +92,7 @@ class Events extends Singleton {
 			$current_events = $this->reduce_queue( $current_events );
 		}
 
+		// Combine with Internal Events and return necessary data to process the event queue
 		return array(
 			'events'   => array_merge( $current_events, $internal_events ),
 			'endpoint' => get_rest_url( null, REST_API::API_NAMESPACE . '/' . REST_API::ENDPOINT_RUN ),

--- a/includes/class-events.php
+++ b/includes/class-events.php
@@ -144,7 +144,7 @@ class Events extends Singleton {
 
 		$i = 1; // Intentionally not zero-indexed to facilitate comparisons against $action_counts members
 
-		while ( $i <= 15 && count( $reduced_queue ) < JOB_QUEUE_SIZE && ! empty( $events ) ) {
+		do {
 			// Each time the events array is iterated over, move one instance of an action to the current queue
 			foreach ( $events as $key => $event ) {
 				$action = $event['action'];
@@ -171,7 +171,7 @@ class Events extends Singleton {
 
 				continue;
 			}
-		}
+		} while( $i <= 15 && count( $reduced_queue ) < JOB_QUEUE_SIZE && ! empty( $events ) );
 
 		/**
 		 * IMPORTANT: DO NOT re-sort the $reduced_queue array from this point forward.

--- a/includes/class-events.php
+++ b/includes/class-events.php
@@ -144,7 +144,7 @@ class Events extends Singleton {
 
 		$i = 1; // Intentionally not zero-indexed to facilitate comparisons against $action_counts members
 
-		while ( count( $reduced_queue ) < (JOB_QUEUE_SIZE*3) && ! empty( $events ) ) {
+		while ( count( $reduced_queue ) < JOB_QUEUE_SIZE && ! empty( $events ) ) {
 			// Circuit breaker
 			if ( $i > 15 ) {
 				break;

--- a/includes/class-events.php
+++ b/includes/class-events.php
@@ -89,7 +89,7 @@ class Events extends Singleton {
 
 		// Limit batch size to avoid resource exhaustion
 		if ( count( $current_events ) > JOB_QUEUE_SIZE ) {
-			$current_events = array_slice( $current_events, 0, JOB_QUEUE_SIZE );
+			$current_events = $this->reduce_queue( $current_events );
 		}
 
 		return array(
@@ -330,6 +330,19 @@ class Events extends Singleton {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Trim events queue down to the limit set by JOB_QUEUE_SIZE
+	 *
+	 * @param $events  array  List of events to be run in the current period
+	 *
+	 * @return array
+	 */
+	private function reduce_queue( $events ) {
+		$reduced_queue = array_slice( $events, 0, JOB_QUEUE_SIZE );
+
+		return $reduced_queue;
 	}
 }
 


### PR DESCRIPTION
When many events of the same action are present in a given queue, de-prioritize their many occurrences so that a particular type of event doesn't dominate a given execution. Prior to this change, long-running events, for example, could run to the exclusion of all others.

Included in this PR is a fix to the sorting between event queues. Prior to 4b7d30c, Internal Events were not exempt from the queue-size cap, though they were meant to. I introduced this bug back in https://github.com/Automattic/vip-go-mu-plugins/pull/329/commits/df42aa7c00d2416e41e08999317ea1b728fcd8df (the repo where this repo's history starts), meaning it's always been present in production.

Fixes #56