### PR TITLE
Improve CPT use and CLI performance

### DIFF
--- a/includes/constants.php
+++ b/includes/constants.php
@@ -12,11 +12,6 @@ const JOB_LOCK_EXPIRY_IN_MINUTES      = 30;
 const JOB_CONCURRENCY_LIMIT           = 10;
 
 /**
- * Job creation
- */
-const JOB_CREATION_CONCURRENCY_LIMIT = 5;
-
-/**
  * Locks
  */
 const LOCK_DEFAULT_LIMIT             = 10;

--- a/includes/wp-cli/class-events.php
+++ b/includes/wp-cli/class-events.php
@@ -363,7 +363,9 @@ class Events extends \WP_CLI_Command {
 			\WP_CLI::confirm( sprintf( __( 'Are you sure you want to delete this event?', 'automattic-cron-control' ) ) );
 
 			// Try to delete the item and provide some relevant output
+			\Automattic\WP\Cron_Control\Cron_Options_CPT::instance()->suspend_event_creation();
 			$trashed = wp_delete_post( $event_post->ID, true );
+			\Automattic\WP\Cron_Control\Cron_Options_CPT::instance()->resume_event_creation();
 
 			if ( false === $trashed ) {
 				\WP_CLI::error( sprintf( __( 'Failed to delete event %d', 'automattic-cron-control' ), $jid ) );
@@ -474,6 +476,9 @@ class Events extends \WP_CLI_Command {
 		$events_deleted       = array();
 		$events_deleted_count = $events_failed_delete = 0;
 
+		// Don't create new events while deleting events
+		\Automattic\WP\Cron_Control\Cron_Options_CPT::instance()->suspend_event_creation();
+
 		foreach ( $events_to_delete as $event_to_delete ) {
 			$deleted = wp_delete_post( $event_to_delete['ID'], true );
 
@@ -497,6 +502,9 @@ class Events extends \WP_CLI_Command {
 		if ( $events_deleted_count > 0 ) {
 			\Automattic\WP\Cron_Control\_flush_internal_caches();
 		}
+
+		// New events can be created now that removal is complete
+		\Automattic\WP\Cron_Control\Cron_Options_CPT::instance()->resume_event_creation();
 
 		// List the removed items
 		\WP_CLI::line( "\n" . __( 'RESULTS:', 'automattic-cron-control' ) );

--- a/includes/wp-cli/class-lock.php
+++ b/includes/wp-cli/class-lock.php
@@ -21,20 +21,6 @@ class Lock extends \WP_CLI_Command {
 	}
 
 	/**
-	 * Manage the lock that limits concurrent job creation
-	 *
-	 * @subcommand manage-create-lock
-	 * @synopsis [--reset]
-	 */
-	public function manage_create_lock( $args, $assoc_args ) {
-		$lock_name        = \Automattic\WP\Cron_Control\Cron_Options_CPT::LOCK;
-		$lock_limit       = \Automattic\WP\Cron_Control\JOB_CREATION_CONCURRENCY_LIMIT;
-		$lock_description = __( 'This lock limits the number of events created concurrently.', 'automattic-cron-control' );
-
-		$this->get_reset_lock( $args, $assoc_args, $lock_name, $lock_limit, $lock_description );
-	}
-
-	/**
 	 * Manage the lock that limits concurrent execution of jobs with the same action
 	 *
 	 * @subcommand manage-event-lock

--- a/includes/wp-cli/class-one-time-fixers.php
+++ b/includes/wp-cli/class-one-time-fixers.php
@@ -25,6 +25,9 @@ class One_Time_Fixers extends \WP_CLI_Command {
 		// Provide some idea of what's going on
 		\WP_CLI::line( __( 'CRON CONTROL', 'automattic-cron-control' ) . "\n" );
 
+		// Don't create new events while deleting events
+		\Automattic\WP\Cron_Control\Cron_Options_CPT::instance()->suspend_event_creation();
+
 		$count = $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(ID) FROM {$wpdb->posts} WHERE post_type = %s;", 'a8c_cron_ctrl_event' ) );
 
 		if ( is_numeric( $count ) ) {
@@ -101,6 +104,9 @@ class One_Time_Fixers extends \WP_CLI_Command {
 			wp_cache_delete( 'a8c_cron_ctrl_option' );
 			\WP_CLI::line( "\n" . sprintf( __( 'Cleared the %s cache', 'automattic-cron-control' ), 'Cron Control' ) );
 		}
+
+		// Let event creation resume
+		\Automattic\WP\Cron_Control\Cron_Options_CPT::instance()->resume_event_creation();
 
 		// Fin
 		\WP_CLI::success( __( 'All done.', 'automattic-cron-control' ) );


### PR DESCRIPTION
The event-creation lock has led, more often than not, to an infinite loop of attempted event creation, so it should go.

Also, when deleting events via CLI, more events shouldn't be created. `--skip-plugins` and `--skip-themes` aren't always sufficient.

Fixes #83