### PR TITLE
Fix tests by forcing a version of PHPUnit earlier than 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,14 @@ env:
   - WP_VERSION=trunk WP_MULTISITE=1
 
 before_script:
+  - phpenv config-rm xdebug.ini
+  - export PATH="$HOME/.composer/vendor/bin:$PATH"
+  - |
+    if [[ ${TRAVIS_PHP_VERSION:0:2} == "7." ]]; then
+      composer global require "phpunit/phpunit=5.7.*"
+    elif [[ ${TRAVIS_PHP_VERSION:0:3} != "5.2" ]]; then
+      composer global require "phpunit/phpunit=4.8.*"
+    fi
   - bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
 
 script: phpunit


### PR DESCRIPTION
PHPUnit 6 drops the `PHPUnit_Framework_TestCase` class, breaking all tests derived from Core. This fix is derived from Core's solution; see https://core.trac.wordpress.org/ticket/39822.