### PR TITLE
Ensure `DOING_CRON` is set for all REST requests

### DIFF
--- a/includes/class-events-store.php
+++ b/includes/class-events-store.php
@@ -121,7 +121,7 @@ class Events_Store extends Singleton {
 	 * Does not include front-end requests
 	 */
 	public function maybe_create_table_on_shutdown() {
-		if ( ! is_admin() && ! is_rest_endpoint_request( 'list' ) ) {
+		if ( ! is_admin() && ! is_rest_endpoint_request( REST_API::ENDPOINT_LIST ) ) {
 			return;
 		}
 

--- a/includes/class-events.php
+++ b/includes/class-events.php
@@ -41,7 +41,7 @@ class Events extends Singleton {
 		define( 'DOING_CRON', true );
 
 		// When running events, allow for long-running ones, and non-blocking trigger requests
-		if ( 'run' === $endpoint ) {
+		if ( REST_API::ENDPOINT_RUN === $endpoint ) {
 			ignore_user_abort( true );
 			set_time_limit( JOB_TIMEOUT_IN_MINUTES * MINUTE_IN_SECONDS );
 		}

--- a/includes/class-events.php
+++ b/includes/class-events.php
@@ -32,7 +32,8 @@ class Events extends Singleton {
 	 */
 	public function prepare_environment() {
 		// Limit to plugin's endpoints
-		if ( ! is_rest_endpoint_request( 'list' ) && ! is_rest_endpoint_request( 'run' ) ) {
+		$endpoint = get_endpoint_type();
+		if ( false === $endpoint ) {
 			return;
 		}
 
@@ -40,7 +41,7 @@ class Events extends Singleton {
 		define( 'DOING_CRON', true );
 
 		// When running events, allow for long-running ones, and non-blocking trigger requests
-		if ( is_rest_endpoint_request( 'run' ) ) {
+		if ( 'run' === $endpoint ) {
 			ignore_user_abort( true );
 			set_time_limit( JOB_TIMEOUT_IN_MINUTES * MINUTE_IN_SECONDS );
 		}

--- a/includes/class-events.php
+++ b/includes/class-events.php
@@ -31,13 +31,19 @@ class Events extends Singleton {
 	 * This also runs before Core has parsed the request and set the \REST_REQUEST constant
 	 */
 	public function prepare_environment() {
-		if ( ! is_rest_endpoint_request( 'run' ) ) {
+		// Limit to plugin's endpoints
+		if ( ! is_rest_endpoint_request( 'list' ) && ! is_rest_endpoint_request( 'run' ) ) {
 			return;
 		}
 
-		ignore_user_abort( true );
-		set_time_limit( JOB_TIMEOUT_IN_MINUTES * MINUTE_IN_SECONDS );
+		// Flag is used in many contexts, so should be set for all of our requests, regardless of the action
 		define( 'DOING_CRON', true );
+
+		// When running events, allow for long-running ones, and non-blocking trigger requests
+		if ( is_rest_endpoint_request( 'run' ) ) {
+			ignore_user_abort( true );
+			set_time_limit( JOB_TIMEOUT_IN_MINUTES * MINUTE_IN_SECONDS );
+		}
 	}
 
 	/**

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -10,6 +10,53 @@ function is_internal_event( $action ) {
 }
 
 /**
+ * Check which of the plugin's REST endpoints the current request is for, if any
+ *
+ * @return string|bool
+ */
+function get_endpoint_type() {
+	// Request won't change, so hold for the duration
+	static $endpoint = null;
+	if ( ! is_null( $endpoint ) ) {
+		return $endpoint;
+	}
+
+	// Determine request URL according to how Core does
+	$request = parse_request();
+
+	// Search by our URL "prefix"
+	$namespace = sprintf( '%s/%s', rest_get_url_prefix(), REST_API::API_NAMESPACE );
+
+	// Check if any parts of the parse request are in our namespace
+	$endpoint_slug = false;
+
+	foreach ( $request as $req ) {
+		if ( 0 === stripos( $req, $namespace ) ) {
+			$req_parts = explode( '/', $req );
+			$endpoint_slug = array_pop( $req_parts );
+			break;
+		}
+	}
+
+	// Convert endpoint slug to its type
+	switch ( $endpoint_slug ) {
+		case REST_API::ENDPOINT_LIST :
+			$endpoint = 'list';
+			break;
+
+		case REST_API::ENDPOINT_RUN :
+			$endpoint = 'run';
+			break;
+
+		default :
+			$endpoint = false;
+			break;
+	}
+
+	return $endpoint;
+}
+
+/**
  * Check if the current request is to one of the plugin's REST endpoints
  *
  * @param string $type list|run

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -34,10 +34,16 @@ function is_rest_endpoint_request( $type = 'list' ) {
 		return false;
 	}
 
+	// Hold onto request since it won't change
+	static $request = null;
+	if ( is_null( $request ) ) {
+		$request = parse_request();
+	}
+
 	// Build the full endpoint and check against the current request
 	$run_endpoint = sprintf( '%s/%s/%s', rest_get_url_prefix(), REST_API::API_NAMESPACE, $endpoint );
 
-	return in_array( $run_endpoint, parse_request(), true );
+	return in_array( $run_endpoint, $request, true );
 }
 
 /**

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -16,9 +16,9 @@ function is_internal_event( $action ) {
  */
 function get_endpoint_type() {
 	// Request won't change, so hold for the duration
-	static $endpoint = null;
-	if ( ! is_null( $endpoint ) ) {
-		return $endpoint;
+	static $endpoint_slug = null;
+	if ( ! is_null( $endpoint_slug ) ) {
+		return $endpoint_slug;
 	}
 
 	// Determine request URL according to how Core does
@@ -38,59 +38,18 @@ function get_endpoint_type() {
 		}
 	}
 
-	// Convert endpoint slug to its type
-	switch ( $endpoint_slug ) {
-		case REST_API::ENDPOINT_LIST :
-			$endpoint = 'list';
-			break;
-
-		case REST_API::ENDPOINT_RUN :
-			$endpoint = 'run';
-			break;
-
-		default :
-			$endpoint = false;
-			break;
-	}
-
-	return $endpoint;
+	return $endpoint_slug;
 }
 
 /**
  * Check if the current request is to one of the plugin's REST endpoints
  *
- * @param string $type list|run
+ * @param string $type Endpoint Constant from REST_API class to compare against
  *
  * @return bool
  */
-function is_rest_endpoint_request( $type = 'list' ) {
-	// Which endpoint are we checking
-	$endpoint = null;
-	switch ( $type ) {
-		case 'list' :
-			$endpoint = REST_API::ENDPOINT_LIST;
-			break;
-
-		case 'run' :
-			$endpoint = REST_API::ENDPOINT_RUN;
-			break;
-	}
-
-	// No endpoint to check
-	if ( is_null( $endpoint ) ) {
-		return false;
-	}
-
-	// Hold onto request since it won't change
-	static $request = null;
-	if ( is_null( $request ) ) {
-		$request = parse_request();
-	}
-
-	// Build the full endpoint and check against the current request
-	$run_endpoint = sprintf( '%s/%s/%s', rest_get_url_prefix(), REST_API::API_NAMESPACE, $endpoint );
-
-	return in_array( $run_endpoint, $request, true );
+function is_rest_endpoint_request( $type ) {
+	return get_endpoint_type() === $type;
 }
 
 /**

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -54,6 +54,13 @@ function collapse_events_array( $events, $timestamp = null ) {
  * We have occasion to check the request before Core has done so, such as when preparing the environment to run a cron job
  */
 function parse_request() {
+	// Hold onto this as it won't change during the request
+	static $parsed_request = null;
+	if ( is_array( $parsed_request ) ) {
+		return $parsed_request;
+	}
+
+	// Starting somewhere
 	$rewrite_index = 'index.php';
 
 	/**
@@ -104,5 +111,7 @@ function parse_request() {
 	 */
 
 	// Return array of data about the request
-	return compact( 'requested_path', 'requested_file', 'self' );
+	$parsed_request = compact( 'requested_path', 'requested_file', 'self' );
+
+	return $parsed_request;
 }


### PR DESCRIPTION
If code is loaded conditionally when `DOING_CRON` is set, not setting it for all of the plugin's REST endpoints can lead to unexpected behaviour.

For example, duplicate events can be created infinitely, in combination with the skip-empty-event functionality.

Fixes #97