### PR TITLE
For monitoring and alerting, include total of pending events in list endpoint response

### DIFF
--- a/includes/class-rest-api.php
+++ b/includes/class-rest-api.php
@@ -46,9 +46,17 @@ class REST_API extends Singleton {
 
 	/**
 	 * List events pending for the current period
+	 *
+	 * For monitoring and alerting, also provides the total number of pending events
 	 */
 	public function get_events() {
-		return rest_ensure_response( Events::instance()->get_events() );
+		// Provides `events` and `endpoint` keys needed to run events
+		$response_array = Events::instance()->get_events();
+
+		// Provide pending event count for monitoring etc
+		$response_array['total_events_pending'] = count_events_by_status( Events_Store::STATUS_PENDING );
+
+		return rest_ensure_response( $response_array );
 	}
 
 	/**

--- a/tests/test-rest-api.php
+++ b/tests/test-rest-api.php
@@ -74,16 +74,18 @@ class REST_API_Tests extends \WP_UnitTestCase {
 		$this->assertResponseStatus( 200, $response );
 		$this->assertArrayHasKey( 'events', $data );
 		$this->assertArrayHasKey( 'endpoint', $data );
+		$this->assertArrayHasKey( 'total_events_pending', $data );
 
 		$this->assertResponseData( array(
-			'events'   => array(
+			'events'               => array(
 				array(
 					'timestamp' => $ev['timestamp'],
 					'action'    => md5( $ev['action'] ),
 					'instance'  => md5( maybe_serialize( $ev['args'] ) ),
 				),
 			),
-			'endpoint' => get_rest_url( null, \Automattic\WP\Cron_Control\REST_API::API_NAMESPACE . '/' . \Automattic\WP\Cron_Control\REST_API::ENDPOINT_RUN ),
+			'endpoint'             => get_rest_url( null, \Automattic\WP\Cron_Control\REST_API::API_NAMESPACE . '/' . \Automattic\WP\Cron_Control\REST_API::ENDPOINT_RUN ),
+			'total_events_pending' => 1,
 		), $response );
 	}
 


### PR DESCRIPTION
A dedicated endpoint is overkill, as the list endpoint is central to the plugin operating as expected.

Fixes #100