### PR TITLE
CLI: Allow for running all events with a given action

### DIFF
--- a/includes/class-events.php
+++ b/includes/class-events.php
@@ -270,7 +270,7 @@ class Events extends Singleton {
 	 * @param $event array Event data
 	 */
 	private function prime_event_action_lock( $event ) {
-		Lock::prime_lock( $this->get_lock_key_for_event_action( $event ), JOB_LOCK_EXPIRY_IN_MINUTES * \MINUTE_IN_SECONDS );
+		Lock::prime_lock( self::get_lock_key_for_event_action( $event ), JOB_LOCK_EXPIRY_IN_MINUTES * \MINUTE_IN_SECONDS );
 	}
 
 	/**
@@ -282,7 +282,7 @@ class Events extends Singleton {
 	 */
 	private function can_run_event( $event ) {
 		// Limit to one concurrent execution of a specific action
-		if ( ! Lock::check_lock( $this->get_lock_key_for_event_action( $event ), 1, JOB_LOCK_EXPIRY_IN_MINUTES * \MINUTE_IN_SECONDS ) ) {
+		if ( ! Lock::check_lock( self::get_lock_key_for_event_action( $event ), 1, JOB_LOCK_EXPIRY_IN_MINUTES * \MINUTE_IN_SECONDS ) ) {
 			return false;
 		}
 
@@ -325,7 +325,7 @@ class Events extends Singleton {
 	 * @return bool
 	 */
 	private function reset_event_lock( $event ) {
-		return Lock::reset_lock( $this->get_lock_key_for_event_action( $event ), JOB_LOCK_EXPIRY_IN_MINUTES * \MINUTE_IN_SECONDS );
+		return Lock::reset_lock( self::get_lock_key_for_event_action( $event ), JOB_LOCK_EXPIRY_IN_MINUTES * \MINUTE_IN_SECONDS );
 	}
 
 	/**
@@ -335,7 +335,7 @@ class Events extends Singleton {
 	 *
 	 * @return string
 	 */
-	public function get_lock_key_for_event_action( $event ) {
+	public static function get_lock_key_for_event_action( $event ) {
 		// Hashed solely to constrain overall length
 		return md5( 'ev-' . $event->action );
 	}

--- a/includes/wp-cli/class-events.php
+++ b/includes/wp-cli/class-events.php
@@ -489,6 +489,11 @@ class Events extends \WP_CLI_Command {
 			}
 
 			$delete_progress->tick();
+
+			if ( 0 === count( $events_deleted ) % 100 ) {
+				stop_the_insanity();
+				sleep( 5 );
+			}
 		}
 
 		$delete_progress->finish();
@@ -505,7 +510,7 @@ class Events extends \WP_CLI_Command {
 		\WP_CLI::line( "\n" . __( 'RESULTS:', 'automattic-cron-control' ) );
 
 		if ( 1 === $total_to_delete && 1 === $events_deleted_count ) {
-			\WP_CLI::success( sprintf( __( 'Deleted one event: %d', 'automattic-cron-control' ), $events_deleted[0]['ID'] ) );
+			\WP_CLI::success( sprintf( __( 'Deleted one event with ID `%d`', 'automattic-cron-control' ), $events_deleted[0]['ID'] ) );
 		} else {
 			if ( $events_deleted_count === $total_to_delete ) {
 				\WP_CLI::success( sprintf( __( 'Deleted %s events', 'automattic-cron-control' ), number_format_i18n( $events_deleted_count ) ) );

--- a/includes/wp-cli/class-events.php
+++ b/includes/wp-cli/class-events.php
@@ -122,7 +122,7 @@ class Events extends \WP_CLI_Command {
 		// Proceed?
 		$now = time();
 		if ( $event->timestamp > $now ) {
-			\WP_CLI::warning( sprintf( __( 'This event is not scheduled to run until %1$s GMT (%2$s)', 'automattic-cron-control' ), date( TIME_FORMAT, $event->timestamp ), $this->calculate_interval( $event->timestamp - $now ) ) );
+			\WP_CLI::warning( sprintf( __( 'This event is not scheduled to run for %2$s (at %1$s UTC)', 'automattic-cron-control' ), date( TIME_FORMAT, $event->timestamp ), $this->calculate_interval( $event->timestamp - $now ) ) );
 		}
 
 		\WP_CLI::confirm( sprintf( __( 'Run this event?', 'automattic-cron-control' ) ) );

--- a/includes/wp-cli/class-events.php
+++ b/includes/wp-cli/class-events.php
@@ -102,10 +102,27 @@ class Events extends \WP_CLI_Command {
 	 * Run an event given an ID
 	 *
 	 * @subcommand run
-	 * @synopsis <event_id>
+	 * @synopsis [--event_id=<event_id>] [--action=<action>] [<event_id>]
 	 */
-	public function run_event( $args, $assoc_args ) {
-		$this->run_event_by_id( $args, $assoc_args );
+	public function run_events( $args, $assoc_args ) {
+		// Run a specific event
+		if ( isset( $assoc_args['event_id'] ) ) {
+			$this->run_event_by_id( $assoc_args['event_id'] );
+			return;
+		}
+
+		// Run all events with a given action
+		if ( isset( $assoc_args['action'] ) ) {
+//			$this->run_event_by_action( $args, $assoc_args );
+//			return;
+		}
+
+		// Legacy call to run a single event
+		if ( isset( $args[0] ) && is_numeric( $args[0] ) ) {
+			$this->run_event_by_id( $args[0] );
+		}
+
+		\WP_CLI::error( __( 'Specify an event (or events) to run.', 'automattic-cron-control' ) );
 	}
 
 	/**
@@ -541,20 +558,20 @@ class Events extends \WP_CLI_Command {
 	/**
 	 * Run a single event given its ID
 	 */
-	private function run_event_by_id( $args, $assoc_args ) {
+	private function run_event_by_id( $event_id ) {
 		// Validate ID
-		if ( ! is_numeric( $args[0] ) ) {
+		if ( ! is_numeric( $event_id ) ) {
 			\WP_CLI::error( __( 'Specify the ID of an event to run', 'automattic-cron-control' ) );
 		}
 
 		// Retrieve information needed to execute event
-		$event = \Automattic\WP\Cron_Control\get_event_by_id( $args[0] );
+		$event = \Automattic\WP\Cron_Control\get_event_by_id( $event_id );
 
 		if ( ! is_object( $event ) ) {
-			\WP_CLI::error( sprintf( __( 'Failed to locate event %d. Please confirm that the entry exists and that the ID is that of an event.', 'automattic-cron-control' ), $args[0] ) );
+			\WP_CLI::error( sprintf( __( 'Failed to locate event %d. Please confirm that the entry exists and that the ID is that of an event.', 'automattic-cron-control' ), $event_id ) );
 		}
 
-		\WP_CLI::line( sprintf( __( 'Found event %1$d with action `%2$s` and instance identifier `%3$s`', 'automattic-cron-control' ), $args[0], $event->action, $event->instance ) );
+		\WP_CLI::line( sprintf( __( 'Found event %1$d with action `%2$s` and instance identifier `%3$s`', 'automattic-cron-control' ), $event_id, $event->action, $event->instance ) );
 
 		// Proceed?
 		$now = time();


### PR DESCRIPTION
Unlike the option provided by WP-CLI, this will set the lock to block regular requests from also running the event, and can provide a better UI for running many events (akin to the delete command).

Fixes #102 