### PR TITLE
Allow whitelisted events to run concurrently

### DIFF
--- a/includes/class-events.php
+++ b/includes/class-events.php
@@ -353,7 +353,14 @@ class Events extends Singleton {
 	 * @return bool
 	 */
 	private function reset_event_lock( $event ) {
-		return Lock::reset_lock( $this->get_lock_key_for_event_action( $event ), JOB_LOCK_EXPIRY_IN_MINUTES * \MINUTE_IN_SECONDS );
+		$lock_key = $this->get_lock_key_for_event_action( $event );
+		$expires  = JOB_LOCK_EXPIRY_IN_MINUTES * \MINUTE_IN_SECONDS;
+
+		if ( isset( $this->concurrent_action_whitelist[ $event->action ] ) ) {
+			return Lock::free_lock( $lock_key, $expires );
+		} else {
+			return Lock::reset_lock( $lock_key, $expires );
+		}
 	}
 
 	/**

--- a/includes/class-events.php
+++ b/includes/class-events.php
@@ -301,7 +301,7 @@ class Events extends Singleton {
 		}
 
 		// Check if any resources are available to execute this job
-		// If not, the indivdual-event lock must be freed, otherwise it's deadlocked until it times out
+		// If not, the individual-event lock must be freed, otherwise it's deadlocked until it times out
 		if ( ! Lock::check_lock( self::LOCK, JOB_CONCURRENCY_LIMIT ) ) {
 			$this->reset_event_lock( $event );
 			return false;

--- a/includes/class-events.php
+++ b/includes/class-events.php
@@ -64,8 +64,6 @@ class Events extends Singleton {
 		if ( is_array( $concurrency_whitelist ) && ! empty( $concurrency_whitelist ) ) {
 			$this->concurrent_action_whitelist = $concurrency_whitelist;
 		}
-
-		unset( $concurrency_whitelist );
 	}
 
 	/**


### PR DESCRIPTION
In some circumstances, multiple events with the same action can safely run in parallel. This is usually not the case, largely due to Core's alloptions, but sometimes an event is written in a way that we can support concurrent executions.

Fixes #106