### PR TITLE
Removing unused global $wpdb variable

### DIFF
--- a/includes/wp-cli/class-events.php
+++ b/includes/wp-cli/class-events.php
@@ -149,8 +149,6 @@ class Events extends \WP_CLI_Command {
 	 * Retrieve list of events, and related data, for a given request
 	 */
 	private function get_events( $args, $assoc_args ) {
-		global $wpdb;
-
 		// Accept a status argument, with a default
 		$status = 'pending';
 		if ( isset( $assoc_args['status'] ) ) {


### PR DESCRIPTION
The `$wpdb` variable is not being used in \Automattic\WP\Cron_Control\CLI\Events::get_events() methods and thus is not necessary to be made accessible in there.