### PR TITLE
Ensure WP-CLI's `--quiet` flag is respected

### DIFF
--- a/includes/wp-cli/class-events.php
+++ b/includes/wp-cli/class-events.php
@@ -44,9 +44,9 @@ class Events extends \WP_CLI_Command {
 
 			// Count, noting if showing fewer than all
 			if ( $events['total_items'] <= $total_events_to_display ) {
-				\WP_CLI::line( sprintf( _n( 'Displaying one entry', 'Displaying all %s entries', $total_events_to_display, 'automattic-cron-control' ), number_format_i18n( $total_events_to_display ) ) );
+				\WP_CLI::log( sprintf( _n( 'Displaying one entry', 'Displaying all %s entries', $total_events_to_display, 'automattic-cron-control' ), number_format_i18n( $total_events_to_display ) ) );
 			} else {
-				\WP_CLI::line( sprintf( __( 'Displaying %1$s of %2$s entries, page %3$s of %4$s', 'automattic-cron-control' ), number_format_i18n( $total_events_to_display ), number_format_i18n( $events['total_items'] ), number_format_i18n( $events['page'] ), number_format_i18n( $events['total_pages'] ) ) );
+				\WP_CLI::log( sprintf( __( 'Displaying %1$s of %2$s entries, page %3$s of %4$s', 'automattic-cron-control' ), number_format_i18n( $total_events_to_display ), number_format_i18n( $events['total_items'] ), number_format_i18n( $events['page'] ), number_format_i18n( $events['total_pages'] ) ) );
 			}
 
 			// And reformat
@@ -117,7 +117,7 @@ class Events extends \WP_CLI_Command {
 			\WP_CLI::error( sprintf( __( 'Failed to locate event %d. Please confirm that the entry exists and that the ID is that of an event.', 'automattic-cron-control' ), $args[0] ) );
 		}
 
-		\WP_CLI::line( sprintf( __( 'Found event %1$d with action `%2$s` and instance identifier `%3$s`', 'automattic-cron-control' ), $args[0], $event->action, $event->instance ) );
+		\WP_CLI::log( sprintf( __( 'Found event %1$d with action `%2$s` and instance identifier `%3$s`', 'automattic-cron-control' ), $args[0], $event->action, $event->instance ) );
 
 		// Proceed?
 		$now = time();
@@ -358,7 +358,7 @@ class Events extends \WP_CLI_Command {
 			\WP_CLI::error( __( 'Invalid event ID', 'automattic-cron-control' ) );
 		}
 
-		\WP_CLI::line( __( 'Locating event...', 'automattic-cron-control' ) . "\n" );
+		\WP_CLI::log( __( 'Locating event...', 'automattic-cron-control' ) . "\n" );
 
 		// Look up full event object
 		$event = \Automattic\WP\Cron_Control\get_event_by_id( $jid );
@@ -369,10 +369,10 @@ class Events extends \WP_CLI_Command {
 				\WP_CLI::warning( __( 'This is an event created by the Cron Control plugin. It will recreated automatically.', 'automattic-cron-control' ) );
 			}
 
-			\WP_CLI::line( sprintf( __( 'Execution time: %s GMT', 'automattic-cron-control' ), date( TIME_FORMAT, $event->timestamp ) ) );
-			\WP_CLI::line( sprintf( __( 'Action: %s', 'automattic-cron-control' ), $event->action ) );
-			\WP_CLI::line( sprintf( __( 'Instance identifier: %s', 'automattic-cron-control' ), $event->instance ) );
-			\WP_CLI::line( '' );
+			\WP_CLI::log( sprintf( __( 'Execution time: %s GMT', 'automattic-cron-control' ), date( TIME_FORMAT, $event->timestamp ) ) );
+			\WP_CLI::log( sprintf( __( 'Action: %s', 'automattic-cron-control' ), $event->action ) );
+			\WP_CLI::log( sprintf( __( 'Instance identifier: %s', 'automattic-cron-control' ), $event->instance ) );
+			\WP_CLI::log( '' );
 			\WP_CLI::confirm( sprintf( __( 'Are you sure you want to delete this event?', 'automattic-cron-control' ) ) );
 
 			// Try to delete the item and provide some relevant output
@@ -413,13 +413,13 @@ class Events extends \WP_CLI_Command {
 		$assoc_args['limit'] = 50;
 
 		// Gather events
-		\WP_CLI::line( __( 'Gathering events...', 'automattic-cron-control' ) );
+		\WP_CLI::log( __( 'Gathering events...', 'automattic-cron-control' ) );
 
 		$events_to_delete = array();
 
 		$events = $this->get_events( $args, $assoc_args );
 
-		\WP_CLI::line( sprintf( _n( 'Found one event to check', 'Found %s events to check', $events['total_items'], 'automattic-cron-control' ), number_format_i18n( $events['total_items'] ) ) );
+		\WP_CLI::log( sprintf( _n( 'Found one event to check', 'Found %s events to check', $events['total_items'], 'automattic-cron-control' ), number_format_i18n( $events['total_items'] ) ) );
 
 		$search_progress = \WP_CLI\Utils\make_progress_bar( sprintf( __( 'Searching events for those with the action `%s`', 'automattic-cron-control' ), $action ), $events['total_items'] );
 
@@ -450,7 +450,7 @@ class Events extends \WP_CLI_Command {
 
 		$search_progress->finish();
 
-		\WP_CLI::line( '' );
+		\WP_CLI::log( '' );
 
 		// Nothing more to do
 		if ( empty( $events_to_delete ) ) {
@@ -460,7 +460,7 @@ class Events extends \WP_CLI_Command {
 		// List the items to remove
 		$total_to_delete = count( $events_to_delete );
 
-		\WP_CLI::line( sprintf( _n( 'Found one event with action `%2$s`:', 'Found %1$s events with action `%2$s`:', $total_to_delete, 'automattic-cron-control' ), number_format_i18n( $total_to_delete ), $action ) );
+		\WP_CLI::log( sprintf( _n( 'Found one event with action `%2$s`:', 'Found %1$s events with action `%2$s`:', $total_to_delete, 'automattic-cron-control' ), number_format_i18n( $total_to_delete ), $action ) );
 
 		if ( $total_to_delete <= $assoc_args['limit'] ) {
 			// Sort results
@@ -480,7 +480,7 @@ class Events extends \WP_CLI_Command {
 			\WP_CLI::warning( sprintf( __( 'Events are not displayed as there are more than %s to remove', 'automattic-cron-control' ), number_format_i18n( $assoc_args['limit'] ) ) );
 		}
 
-		\WP_CLI::line( '' );
+		\WP_CLI::log( '' );
 		\WP_CLI::confirm( _n( 'Are you sure you want to delete this event?', 'Are you sure you want to delete these events?', $total_to_delete, 'automattic-cron-control' ) );
 
 		// Remove the items
@@ -520,7 +520,7 @@ class Events extends \WP_CLI_Command {
 		\Automattic\WP\Cron_Control\_resume_event_creation();
 
 		// List the removed items
-		\WP_CLI::line( "\n" . __( 'RESULTS:', 'automattic-cron-control' ) );
+		\WP_CLI::log( "\n" . __( 'RESULTS:', 'automattic-cron-control' ) );
 
 		if ( 1 === $total_to_delete && 1 === $events_deleted_count ) {
 			\WP_CLI::success( sprintf( __( 'Deleted one event: %d', 'automattic-cron-control' ), $events_deleted[0]['ID'] ) );
@@ -542,10 +542,10 @@ class Events extends \WP_CLI_Command {
 				} );
 
 				if ( count( $events_deleted ) > 0 ) {
-					\WP_CLI::line( "\n" . __( 'Events that couldn\'t be deleted:', 'automattic-cron-control' ) );
+					\WP_CLI::log( "\n" . __( 'Events that couldn\'t be deleted:', 'automattic-cron-control' ) );
 				}
 			} else {
-				\WP_CLI::line( "\n" . __( 'Events deleted:', 'automattic-cron-control' ) );
+				\WP_CLI::log( "\n" . __( 'Events deleted:', 'automattic-cron-control' ) );
 			}
 
 			// Don't display a table if there's nothing to display

--- a/includes/wp-cli/class-lock.php
+++ b/includes/wp-cli/class-lock.php
@@ -43,9 +43,9 @@ class Lock extends \WP_CLI_Command {
 	 */
 	private function get_reset_lock( $args, $assoc_args, $lock_name, $lock_limit, $lock_description ) {
 		// Output information about the lock
-		\WP_CLI::line( $lock_description . "\n" );
+		\WP_CLI::log( $lock_description . "\n" );
 
-		\WP_CLI::line( sprintf( __( 'Maximum: %s', 'automattic-cron-control' ), number_format_i18n( $lock_limit ) ) . "\n" );
+		\WP_CLI::log( sprintf( __( 'Maximum: %s', 'automattic-cron-control' ), number_format_i18n( $lock_limit ) ) . "\n" );
 
 		// Reset requested
 		if ( isset( $assoc_args['reset'] ) ) {
@@ -54,23 +54,23 @@ class Lock extends \WP_CLI_Command {
 			$lock      = \Automattic\WP\Cron_Control\Lock::get_lock_value( $lock_name );
 			$timestamp = \Automattic\WP\Cron_Control\Lock::get_lock_timestamp( $lock_name );
 
-			\WP_CLI::line( sprintf( __( 'Previous value: %s', 'automattic-cron-control' ), number_format_i18n( $lock ) ) );
-			\WP_CLI::line( sprintf( __( 'Previously modified: %s GMT', 'automattic-cron-control' ), date( TIME_FORMAT, $timestamp ) ) . "\n" );
+			\WP_CLI::log( sprintf( __( 'Previous value: %s', 'automattic-cron-control' ), number_format_i18n( $lock ) ) );
+			\WP_CLI::log( sprintf( __( 'Previously modified: %s GMT', 'automattic-cron-control' ), date( TIME_FORMAT, $timestamp ) ) . "\n" );
 
 			\WP_CLI::confirm( sprintf( __( 'Are you sure you want to reset this lock?', 'automattic-cron-control' ) ) );
-			\WP_CLI::line( '' );
+			\WP_CLI::log( '' );
 
 			\Automattic\WP\Cron_Control\Lock::reset_lock( $lock_name );
 			\WP_CLI::success( __( 'Lock reset', 'automattic-cron-control' ) . "\n" );
-			\WP_CLI::line( __( 'New lock values:', 'automattic-cron-control' ) );
+			\WP_CLI::log( __( 'New lock values:', 'automattic-cron-control' ) );
 		}
 
 		// Output lock state
 		$lock      = \Automattic\WP\Cron_Control\Lock::get_lock_value( $lock_name );
 		$timestamp = \Automattic\WP\Cron_Control\Lock::get_lock_timestamp( $lock_name );
 
-		\WP_CLI::line( sprintf( __( 'Current value: %s', 'automattic-cron-control' ), number_format_i18n( $lock ) ) );
-		\WP_CLI::line( sprintf( __( 'Last modified: %s GMT', 'automattic-cron-control' ), date( TIME_FORMAT, $timestamp ) ) );
+		\WP_CLI::log( sprintf( __( 'Current value: %s', 'automattic-cron-control' ), number_format_i18n( $lock ) ) );
+		\WP_CLI::log( sprintf( __( 'Last modified: %s GMT', 'automattic-cron-control' ), date( TIME_FORMAT, $timestamp ) ) );
 	}
 }
 

--- a/includes/wp-cli/class-one-time-fixers.php
+++ b/includes/wp-cli/class-one-time-fixers.php
@@ -23,13 +23,13 @@ class One_Time_Fixers extends \WP_CLI_Command {
 		}
 
 		// Provide some idea of what's going on
-		\WP_CLI::line( __( 'CRON CONTROL', 'automattic-cron-control' ) . "\n" );
+		\WP_CLI::log( __( 'CRON CONTROL', 'automattic-cron-control' ) . "\n" );
 
 		$table_name = \Automattic\WP\Cron_Control\Events_Store::instance()->get_table_name();
 		$count = (int) $wpdb->get_var( "SELECT COUNT(ID) FROM {$table_name}" );
 
 		if ( $count > 1 ) {
-			\WP_CLI::line( sprintf( __( 'Found %s total items', 'automattic-cron-control' ), number_format_i18n( $count ) ) . "\n\n" );
+			\WP_CLI::log( sprintf( __( 'Found %s total items', 'automattic-cron-control' ), number_format_i18n( $count ) ) . "\n\n" );
 
 			if ( $dry_run ) {
 				\WP_CLI::error( __( 'Stopping as this is a dry run!', 'automattic-cron-control' ) );
@@ -40,9 +40,9 @@ class One_Time_Fixers extends \WP_CLI_Command {
 
 		// Should we really destroy all this data?
 		if ( ! $dry_run ) {
-			\WP_CLI::line( __( 'This process will remove all data for the Cron Control plugin', 'automattic-cron-control' ) );
+			\WP_CLI::log( __( 'This process will remove all data for the Cron Control plugin', 'automattic-cron-control' ) );
 			\WP_CLI::confirm( __( 'Proceed?', 'automattic-cron-control' ) );
-			\WP_CLI::line( "\n" . __( 'Starting...', 'automattic-cron-control' ) . "\n" );
+			\WP_CLI::log( "\n" . __( 'Starting...', 'automattic-cron-control' ) . "\n" );
 		}
 
 		// Don't create new events while deleting events
@@ -56,7 +56,7 @@ class One_Time_Fixers extends \WP_CLI_Command {
 		// Remove the now-stale cache when actively run
 		if ( ! $dry_run ) {
 			\Automattic\WP\Cron_Control\_flush_internal_caches();
-			\WP_CLI::line( "\n" . sprintf( __( 'Cleared the %s cache', 'automattic-cron-control' ), 'Cron Control' ) );
+			\WP_CLI::log( "\n" . sprintf( __( 'Cleared the %s cache', 'automattic-cron-control' ), 'Cron Control' ) );
 		}
 
 		// Let event creation resume
@@ -83,12 +83,12 @@ class One_Time_Fixers extends \WP_CLI_Command {
 		}
 
 		// Provide some idea of what's going on
-		\WP_CLI::line( __( 'CRON CONTROL', 'automattic-cron-control' ) . "\n" );
+		\WP_CLI::log( __( 'CRON CONTROL', 'automattic-cron-control' ) . "\n" );
 
 		$count = (int) $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(ID) FROM {$wpdb->posts} WHERE post_type = %s;", 'a8c_cron_ctrl_event' ) );
 
 		if ( $count > 1 ) {
-			\WP_CLI::line( sprintf( __( 'Found %s total items', 'automattic-cron-control' ), number_format_i18n( $count ) ) . "\n\n" );
+			\WP_CLI::log( sprintf( __( 'Found %s total items', 'automattic-cron-control' ), number_format_i18n( $count ) ) . "\n\n" );
 			\WP_CLI::confirm( __( 'Proceed?', 'automattic-cron-control' ) );
 		} else {
 			\WP_CLI::error( __( 'No entries found...aborting!', 'automattic-cron-control' ) );
@@ -96,9 +96,9 @@ class One_Time_Fixers extends \WP_CLI_Command {
 
 		// Should we really destroy all this data?
 		if ( ! $dry_run ) {
-			\WP_CLI::line( __( 'This process will remove all CPT data for the Cron Control plugin', 'automattic-cron-control' ) );
+			\WP_CLI::log( __( 'This process will remove all CPT data for the Cron Control plugin', 'automattic-cron-control' ) );
 			\WP_CLI::confirm( __( 'Proceed?', 'automattic-cron-control' ) );
-			\WP_CLI::line( "\n" . __( 'Starting...', 'automattic-cron-control' ) . "\n" );
+			\WP_CLI::log( "\n" . __( 'Starting...', 'automattic-cron-control' ) . "\n" );
 		}
 
 		// Determine how many batches this will take
@@ -107,7 +107,7 @@ class One_Time_Fixers extends \WP_CLI_Command {
 		} else {
 			$page_size = 250;
 		}
-		\WP_CLI::line( sprintf( __( 'Processing in batches of %s', 'automattic-cron-control' ), number_format_i18n( $page_size ) ) . "\n\n" );
+		\WP_CLI::log( sprintf( __( 'Processing in batches of %s', 'automattic-cron-control' ), number_format_i18n( $page_size ) ) . "\n\n" );
 
 		$pages     = 1;
 		$page      = 1;
@@ -118,20 +118,20 @@ class One_Time_Fixers extends \WP_CLI_Command {
 
 		// Let's get on with it
 		do {
-			\WP_CLI::line( "\n\n" . sprintf( __( 'Processing page %1$s of %2$s', 'automattic-cron-control' ), number_format_i18n( $page ), number_format_i18n( $pages ) ) . "\n" );
+			\WP_CLI::log( "\n\n" . sprintf( __( 'Processing page %1$s of %2$s', 'automattic-cron-control' ), number_format_i18n( $page ), number_format_i18n( $pages ) ) . "\n" );
 
 			$items = $wpdb->get_results( $wpdb->prepare( "SELECT ID, post_title FROM {$wpdb->posts} WHERE post_type = %s LIMIT %d,%d", 'a8c_cron_ctrl_event', absint( ( $page - 1 ) * $page_size ),$page_size ) );
 
 			// Nothing more to do
 			if ( ! is_array( $items ) || empty( $items ) ) {
-				\WP_CLI::line( __( 'No more items found!', 'automattic-cron-control' ) );
+				\WP_CLI::log( __( 'No more items found!', 'automattic-cron-control' ) );
 				break;
 			}
 
-			\WP_CLI::line( sprintf( __( 'Found %s items in this batch' ), number_format_i18n( count( $items ) ) ) );
+			\WP_CLI::log( sprintf( __( 'Found %s items in this batch' ), number_format_i18n( count( $items ) ) ) );
 
 			foreach ( $items as $item ) {
-				\WP_CLI::line( "{$item->ID}, `{$item->post_title}`" );
+				\WP_CLI::log( "{$item->ID}, `{$item->post_title}`" );
 
 				if ( ! $dry_run ) {
 					wp_delete_post( $item->ID, true );

--- a/includes/wp-cli/class-rest-api.php
+++ b/includes/wp-cli/class-rest-api.php
@@ -38,7 +38,7 @@ class REST_API extends \WP_CLI_Command {
 		// Prepare items for display
 		$events_for_display      = $this->format_events( $queue_response['events'] );
 		$total_events_to_display = count( $events_for_display );
-		\WP_CLI::line( sprintf( _n( 'Displaying one event', 'Displaying %s events', $total_events_to_display, 'automattic-cron-control' ), number_format_i18n( $total_events_to_display ) ) );
+		\WP_CLI::log( sprintf( _n( 'Displaying one event', 'Displaying %s events', $total_events_to_display, 'automattic-cron-control' ), number_format_i18n( $total_events_to_display ) ) );
 
 		// And reformat
 		$format = 'table';


### PR DESCRIPTION
From `line()`'s inline doc:

> Display informational message without prefix, and ignore `--quiet`.
>
> Message is written to STDOUT. `WP_CLI::log()` is typically recommended