### PR TITLE
Catch callback exceptions to avoid deadlock

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,13 @@
-# Cron Control
+Cron Control
+============
 
 Execute WordPress cron events in parallel, using a custom post type for event storage.
 
 Using REST API endpoints (requires WordPress 4.4+), an event queue is produced and events are triggered.
+
+## PHP Compatibility
+
+Cron Control requires PHP 7 or greater to be able to catch fatal errors triggered by event callbacks. While the plugin may work with previous versions of PHP, internal locks may become deadlocked if callbacks fail. 
 
 ## Event Concurrency
 

--- a/includes/class-events.php
+++ b/includes/class-events.php
@@ -268,17 +268,29 @@ class Events extends Singleton {
 		$this->update_event_record( $event );
 
 		// Run the event
-		do_action_ref_array( $event->action, $event->args );
+		try {
+			do_action_ref_array( $event->action, $event->args );
+		} catch ( \Throwable $t ) {
+			$return = array(
+				'success' => false,
+				'message' => sprintf( __( 'Exception for job with action `%1$s` and arguments `%2$s` - %3$s in %4$s on line %5$d.', 'automattic-cron-control' ), $event->action, maybe_serialize( $event->args ), $t->getMessage(), $t->getFile(), $t->getLine() ),
+			);
+		}
 
 		// Free process for the next event, unless it wasn't set to begin with
 		if ( ! $force ) {
 			$this->do_lock_cleanup( $event );
 		}
 
-		return array(
-			'success' => true,
-			'message' => sprintf( __( 'Job with action `%1$s` and arguments `%2$s` executed.', 'automattic-cron-control' ), $event->action, maybe_serialize( $event->args ) ),
-		);
+		// Callback didn't trigger an exception, indicating it succeeded
+		if ( ! isset( $return ) ) {
+			$return = array(
+				'success' => true,
+				'message' => sprintf( __( 'Job with action `%1$s` and arguments `%2$s` executed.', 'automattic-cron-control' ), $event->action, maybe_serialize( $event->args ) ),
+			);
+		}
+
+		return $return;
 	}
 
 	/**

--- a/includes/class-events.php
+++ b/includes/class-events.php
@@ -273,7 +273,7 @@ class Events extends Singleton {
 		} catch ( \Throwable $t ) {
 			$return = array(
 				'success' => false,
-				'message' => sprintf( __( 'Exception for job with action `%1$s` and arguments `%2$s` - %3$s in %4$s on line %5$d.', 'automattic-cron-control' ), $event->action, maybe_serialize( $event->args ), $t->getMessage(), $t->getFile(), $t->getLine() ),
+				'message' => sprintf( __( 'Callback for job with action `%1$s` and arguments `%2$s` raised a Throwable - %3$s in %4$s on line %5$d.', 'automattic-cron-control' ), $event->action, maybe_serialize( $event->args ), $t->getMessage(), $t->getFile(), $t->getLine() ),
 			);
 		}
 

--- a/includes/wp-cli/class-lock.php
+++ b/includes/wp-cli/class-lock.php
@@ -31,7 +31,7 @@ class Lock extends \WP_CLI_Command {
 			\WP_CLI::error( sprintf( __( 'Specify an action', 'automattic-cron-control' ) ) );
 		}
 
-		$lock_name        = \Automattic\WP\Cron_Control\Events::instance()->get_lock_key_for_event_action( array( 'action' => $args[0], ) );
+		$lock_name        = \Automattic\WP\Cron_Control\Events::instance()->get_lock_key_for_event_action( (object) array( 'action' => $args[0], ) );
 		$lock_limit       = 1;
 		$lock_description = __( "This lock prevents concurrent executions of events with the same action, regardless of the action's arguments.", 'automattic-cron-control' );
 


### PR DESCRIPTION
If an event callback throws a fatal error, or exceeds the allowed execution time, the locks associated with that event's execution won't be freed, leading to deadlock. By catching these errors, we can provide useful feedback and prevent deadlock.

Fixes #105 
Fixes #117