### PR TITLE
Free locks after timeouts and other uncatchable errors

### DIFF
--- a/includes/class-events.php
+++ b/includes/class-events.php
@@ -458,6 +458,8 @@ class Events extends Singleton {
 			return;
 		}
 
+		do_action( 'a8c_cron_control_freeing_event_locks_after_execution_timeout', $this->running_event );
+
 		$this->do_lock_cleanup( $this->running_event );
 	}
 }

--- a/includes/class-events.php
+++ b/includes/class-events.php
@@ -280,6 +280,8 @@ class Events extends Singleton {
 			// Note that timeouts and memory exhaustion do not invoke this block
 			// Instead, those locks are freed in `do_lock_cleanup_on_shutdown()`
 
+			do_action( 'a8c_cron_control_event_threw_catchable_error', $event, $t );
+
 			$return = array(
 				'success' => false,
 				'message' => sprintf( __( 'Callback for job with action `%1$s` and arguments `%2$s` raised a Throwable - %3$s in %4$s on line %5$d.', 'automattic-cron-control' ), $event->action, maybe_serialize( $event->args ), $t->getMessage(), $t->getFile(), $t->getLine() ),

--- a/includes/class-events.php
+++ b/includes/class-events.php
@@ -286,7 +286,7 @@ class Events extends Singleton {
 			);
 		}
 
-		// Free process for the next event, unless it wasn't set to begin with
+		// Free locks for the next event, unless they weren't set to begin with
 		if ( ! $force ) {
 			// Don't need special timeout handling
 			$this->running_event = null;
@@ -311,7 +311,7 @@ class Events extends Singleton {
 	 *
 	 * Used to ensure only one instance of a particular event, such as `wp_version_check` runs at one time
 	 *
-	 * @param $event array Event data
+	 * @param $event object Event data
 	 */
 	private function prime_event_action_lock( $event ) {
 		Lock::prime_lock( $this->get_lock_key_for_event_action( $event ), JOB_LOCK_EXPIRY_IN_MINUTES * \MINUTE_IN_SECONDS );


### PR DESCRIPTION
If an event times out or exhausts available memory, the fatal-error try-catch handling added in #118 is not invoked. PHP does, however, invoke any callbacks registered with `register_shutdown_function()`, which is what Core uses for its `shutdown` action. Accordingly, we can free locks set for error-producing events by hooking to Core's `shutdown`.