### PR TITLE
Allow queue size and concurrency limits to be overridden

### DIFF
--- a/includes/constants.php
+++ b/includes/constants.php
@@ -5,12 +5,18 @@ namespace Automattic\WP\Cron_Control;
 /**
  * Adjustable queue size and concurrency limits, to facilitate scaling
  */
-$job_queue_size = defined( 'CRON_CONTROL_JOB_QUEUE_SIZE' ) && is_numeric( \CRON_CONTROL_JOB_QUEUE_SIZE ) ? absint( \CRON_CONTROL_JOB_QUEUE_SIZE ) : 10;
+$job_queue_size = 10;
+if ( defined( 'CRON_CONTROL_JOB_QUEUE_SIZE' ) && is_numeric( \CRON_CONTROL_JOB_QUEUE_SIZE ) ) {
+	$job_queue_size = absint( \CRON_CONTROL_JOB_QUEUE_SIZE );
+}
 $job_queue_size = max( 1, min( $job_queue_size, 250 ) );
 define( __NAMESPACE__ . '\JOB_QUEUE_SIZE', $job_queue_size );
 unset( $job_queue_size );
 
-$job_concurrency_limit = defined( 'CRON_CONTROL_JOB_CONCURRENCY_LIMIT' ) && is_numeric( \CRON_CONTROL_JOB_CONCURRENCY_LIMIT ) ? absint( \CRON_CONTROL_JOB_CONCURRENCY_LIMIT ) : 10;
+$job_concurrency_limit = 10;
+if ( defined( 'CRON_CONTROL_JOB_CONCURRENCY_LIMIT' ) && is_numeric( \CRON_CONTROL_JOB_CONCURRENCY_LIMIT ) ) {
+	$job_concurrency_limit = absint( \CRON_CONTROL_JOB_CONCURRENCY_LIMIT );
+}
 $job_concurrency_limit = max( 1, min( $job_concurrency_limit, 250 ) );
 define( __NAMESPACE__ . '\JOB_CONCURRENCY_LIMIT', $job_concurrency_limit );
 unset( $job_concurrency_limit );

--- a/includes/constants.php
+++ b/includes/constants.php
@@ -3,13 +3,22 @@
 namespace Automattic\WP\Cron_Control;
 
 /**
- * Job queues
+ * Adjustable queue size and concurrency limits, to facilitate scaling
  */
-const JOB_QUEUE_SIZE              = 10;
+$job_queue_size = defined( 'CRON_CONTROL_JOB_QUEUE_SIZE' ) && is_numeric( \CRON_CONTROL_JOB_QUEUE_SIZE ) ? absint( \CRON_CONTROL_JOB_QUEUE_SIZE ) : 10;
+define( __NAMESPACE__ . '\JOB_QUEUE_SIZE', $job_queue_size );
+unset( $job_queue_size );
+
+$job_concurrency_limit = defined( 'CRON_CONTROL_JOB_CONCURRENCY_LIMIT' ) && is_numeric( \CRON_CONTROL_JOB_CONCURRENCY_LIMIT ) ? absint( \CRON_CONTROL_JOB_CONCURRENCY_LIMIT ) : 10;
+define( __NAMESPACE__ . '\JOB_CONCURRENCY_LIMIT', $job_concurrency_limit );
+unset( $job_concurrency_limit );
+
+/**
+ * Job runtime constraints
+ */
 const JOB_QUEUE_WINDOW_IN_SECONDS = 60;
 const JOB_TIMEOUT_IN_MINUTES      = 10;
 const JOB_LOCK_EXPIRY_IN_MINUTES  = 30;
-const JOB_CONCURRENCY_LIMIT       = 10;
 
 /**
  * Locks

--- a/includes/constants.php
+++ b/includes/constants.php
@@ -8,16 +8,16 @@ namespace Automattic\WP\Cron_Control;
 $job_queue_size = 10;
 if ( defined( 'CRON_CONTROL_JOB_QUEUE_SIZE' ) && is_numeric( \CRON_CONTROL_JOB_QUEUE_SIZE ) ) {
 	$job_queue_size = absint( \CRON_CONTROL_JOB_QUEUE_SIZE );
+	$job_queue_size = max( 1, min( $job_queue_size, 250 ) );
 }
-$job_queue_size = max( 1, min( $job_queue_size, 250 ) );
 define( __NAMESPACE__ . '\JOB_QUEUE_SIZE', $job_queue_size );
 unset( $job_queue_size );
 
 $job_concurrency_limit = 10;
 if ( defined( 'CRON_CONTROL_JOB_CONCURRENCY_LIMIT' ) && is_numeric( \CRON_CONTROL_JOB_CONCURRENCY_LIMIT ) ) {
 	$job_concurrency_limit = absint( \CRON_CONTROL_JOB_CONCURRENCY_LIMIT );
+	$job_concurrency_limit = max( 1, min( $job_concurrency_limit, 250 ) );
 }
-$job_concurrency_limit = max( 1, min( $job_concurrency_limit, 250 ) );
 define( __NAMESPACE__ . '\JOB_CONCURRENCY_LIMIT', $job_concurrency_limit );
 unset( $job_concurrency_limit );
 

--- a/includes/constants.php
+++ b/includes/constants.php
@@ -6,10 +6,12 @@ namespace Automattic\WP\Cron_Control;
  * Adjustable queue size and concurrency limits, to facilitate scaling
  */
 $job_queue_size = defined( 'CRON_CONTROL_JOB_QUEUE_SIZE' ) && is_numeric( \CRON_CONTROL_JOB_QUEUE_SIZE ) ? absint( \CRON_CONTROL_JOB_QUEUE_SIZE ) : 10;
+$job_queue_size = max( 1, min( $job_queue_size, 250 ) );
 define( __NAMESPACE__ . '\JOB_QUEUE_SIZE', $job_queue_size );
 unset( $job_queue_size );
 
 $job_concurrency_limit = defined( 'CRON_CONTROL_JOB_CONCURRENCY_LIMIT' ) && is_numeric( \CRON_CONTROL_JOB_CONCURRENCY_LIMIT ) ? absint( \CRON_CONTROL_JOB_CONCURRENCY_LIMIT ) : 10;
+$job_concurrency_limit = max( 1, min( $job_concurrency_limit, 250 ) );
 define( __NAMESPACE__ . '\JOB_CONCURRENCY_LIMIT', $job_concurrency_limit );
 unset( $job_concurrency_limit );
 


### PR DESCRIPTION
Fixed sizes faired well to start, but it's now proven useful to be able to increase these limits in a controlled fashion.

Fixes #41
Fixes #122 