### PR TITLE
Chunk events queue for cacheability

### DIFF
--- a/includes/class-events-store.php
+++ b/includes/class-events-store.php
@@ -659,7 +659,16 @@ class Events_Store extends Singleton {
 	 *
 	 */
 	private function cache_option( $option ) {
-		$size = mb_strlen( serialize( $option ) );
+		$option_size = mb_strlen( serialize( $option ) );
+		$buckets     = ceil( $option_size / CACHE_BUCKET_SIZE );
+
+		// Too large to cache
+		if ( $buckets > MAX_CACHE_BUCKETS ) {
+			$this->flush_internal_caches();
+			return false;
+		}
+
+		// TODO: chunk; https://youtu.be/dmSyrGsqmg8
 
 		return wp_cache_set( self::CACHE_KEY, $option, null, 1 * \HOUR_IN_SECONDS );
 	}

--- a/includes/class-events-store.php
+++ b/includes/class-events-store.php
@@ -707,7 +707,6 @@ class Events_Store extends Singleton {
 
 		// Store in single cache key
 		if ( 1 === $buckets ) {
-			error_log( var_export( $buckets, true ) );
 			return wp_cache_set( self::CACHE_KEY, $option, null, 1 * \HOUR_IN_SECONDS );
 		}
 

--- a/includes/class-events-store.php
+++ b/includes/class-events-store.php
@@ -713,6 +713,8 @@ class Events_Store extends Singleton {
 
 		// Too large to cache
 		if ( $buckets > MAX_CACHE_BUCKETS ) {
+			do_action( 'a8c_cron_control_uncacheable_cron_option', $option_size, $buckets, count( $option_flat ) );
+
 			$this->flush_internal_caches();
 			return false;
 		}

--- a/includes/class-events-store.php
+++ b/includes/class-events-store.php
@@ -659,6 +659,8 @@ class Events_Store extends Singleton {
 	 *
 	 */
 	private function cache_option( $option ) {
+		$size = mb_strlen( serialize( $option ) );
+
 		return wp_cache_set( self::CACHE_KEY, $option, null, 1 * \HOUR_IN_SECONDS );
 	}
 

--- a/includes/class-events-store.php
+++ b/includes/class-events-store.php
@@ -701,9 +701,10 @@ class Events_Store extends Singleton {
 	 */
 	private function cache_option( $option ) {
 		// Determine storage requirements
-		$option_flat = collapse_events_array( $option );
-		$option_size = strlen( serialize( $option_flat ) );
-		$buckets     = (int) ceil( $option_size / CACHE_BUCKET_SIZE );
+		$option_flat        = collapse_events_array( $option );
+		$option_flat_string = maybe_serialize( $option_flat );
+		$option_size        = strlen( $option_flat_string );
+		$buckets            = (int) ceil( $option_size / CACHE_BUCKET_SIZE );
 
 		// Store in single cache key
 		if ( 1 === $buckets ) {
@@ -716,7 +717,7 @@ class Events_Store extends Singleton {
 			return false;
 		}
 
-		$incrementer  = md5( serialize( $option_flat ) );
+		$incrementer  = md5( $option_flat_string . time() );
 		$event_count  = count( $option_flat );
 		$segment_size = (int) ceil( $event_count / $buckets );
 
@@ -745,7 +746,7 @@ class Events_Store extends Singleton {
 	 * @return string
 	 */
 	private function get_cache_key_for_slice( $incrementor, $slice ) {
-		return md5( sprintf( '%1$s|%2$s|%3$d', self::CACHE_KEY, $incrementor, $slice ) );
+		return md5( self::CACHE_KEY . $incrementor . $slice );
 	}
 
 	/**

--- a/includes/class-events-store.php
+++ b/includes/class-events-store.php
@@ -237,7 +237,7 @@ class Events_Store extends Singleton {
 	 */
 	public function get_option() {
 		// Use cached value when available
-		$cached_option = wp_cache_get( self::CACHE_KEY, null, true );
+		$cached_option = $this->get_cached_option();
 
 		if ( false !== $cached_option ) {
 			return $cached_option;
@@ -297,7 +297,7 @@ class Events_Store extends Singleton {
 		uksort( $cron_array, 'strnatcasecmp' );
 
 		// Cache the results
-		wp_cache_set( self::CACHE_KEY, $cron_array, null, 1 * \HOUR_IN_SECONDS );
+		$this->cache_option( $cron_array );
 
 		return $cron_array;
 	}
@@ -646,6 +646,20 @@ class Events_Store extends Singleton {
 		}
 
 		return $differences;
+	}
+
+	/**
+	 *
+	 */
+	private function get_cached_option() {
+		return wp_cache_get( self::CACHE_KEY, null, true );
+	}
+
+	/**
+	 *
+	 */
+	private function cache_option( $option ) {
+		return wp_cache_set( self::CACHE_KEY, $option, null, 1 * \HOUR_IN_SECONDS );
 	}
 
 	/**

--- a/includes/class-events-store.php
+++ b/includes/class-events-store.php
@@ -702,7 +702,7 @@ class Events_Store extends Singleton {
 	private function cache_option( $option ) {
 		// Determine storage requirements
 		$option_flat = collapse_events_array( $option );
-		$option_size = mb_strlen( serialize( $option_flat ) );
+		$option_size = strlen( serialize( $option_flat ) );
 		$buckets     = (int) ceil( $option_size / CACHE_BUCKET_SIZE );
 
 		// Store in single cache key

--- a/includes/constants.php
+++ b/includes/constants.php
@@ -37,7 +37,7 @@ const LOCK_DEFAULT_TIMEOUT_IN_MINUTES = 10;
 /**
  * Limit on size of event cache objects
  */
-$cache_bucket_size = \MB_IN_BYTES;
+$cache_bucket_size = \MB_IN_BYTES * 0.95;
 if ( defined( 'CRON_CONTROL_CACHE_BUCKET_SIZE' ) && is_numeric( \CRON_CONTROL_CACHE_BUCKET_SIZE ) ) {
 	$cache_bucket_size = absint( \CRON_CONTROL_CACHE_BUCKET_SIZE );
 	$cache_bucket_size = max( 256 * \KB_IN_BYTES, min( $cache_bucket_size, \TB_IN_BYTES ) );

--- a/includes/constants.php
+++ b/includes/constants.php
@@ -48,7 +48,7 @@ unset( $cache_bucket_size );
 /**
  * Limit how many buckets can be created, to avoid cache exhaustion
  */
-$max_cache_buckets = 25;
+$max_cache_buckets = 5;
 if ( defined( 'CRON_CONTROL_MAX_CACHE_BUCKETS' ) && is_numeric( \CRON_CONTROL_MAX_CACHE_BUCKETS ) ) {
 	$max_cache_buckets = absint( \CRON_CONTROL_MAX_CACHE_BUCKETS );
 	$max_cache_buckets = max( 1, min( $max_cache_buckets, 250 ) );

--- a/includes/constants.php
+++ b/includes/constants.php
@@ -37,10 +37,10 @@ const LOCK_DEFULT_TIMEOUT_IN_MINUTES = 10;
 /**
  * Limit on size of event cache objects
  */
-$cache_bucket_size = 1024;
+$cache_bucket_size = \MB_IN_BYTES;
 if ( defined( 'CRON_CONTROL_CACHE_BUCKET_SIZE' ) && is_numeric( \CRON_CONTROL_CACHE_BUCKET_SIZE ) ) {
 	$cache_bucket_size = absint( \CRON_CONTROL_CACHE_BUCKET_SIZE );
-	$cache_bucket_size = max( 100, min( $cache_bucket_size, \PHP_INT_MAX ) );
+	$cache_bucket_size = max( 256 * \KB_IN_BYTES, min( $cache_bucket_size, \TB_IN_BYTES ) );
 }
 define( __NAMESPACE__ . '\CRON_CONTROL_CACHE_BUCKET_SIZE', $cache_bucket_size );
-unset( $job_concurrency_limit );
+unset( $cache_bucket_size );

--- a/includes/constants.php
+++ b/includes/constants.php
@@ -42,7 +42,7 @@ if ( defined( 'CRON_CONTROL_CACHE_BUCKET_SIZE' ) && is_numeric( \CRON_CONTROL_CA
 	$cache_bucket_size = absint( \CRON_CONTROL_CACHE_BUCKET_SIZE );
 	$cache_bucket_size = max( 256 * \KB_IN_BYTES, min( $cache_bucket_size, \TB_IN_BYTES ) );
 }
-define( __NAMESPACE__ . '\CRON_CONTROL_CACHE_BUCKET_SIZE', $cache_bucket_size );
+define( __NAMESPACE__ . '\CACHE_BUCKET_SIZE', $cache_bucket_size );
 unset( $cache_bucket_size );
 
 /**
@@ -53,5 +53,5 @@ if ( defined( 'CRON_CONTROL_MAX_CACHE_BUCKETS' ) && is_numeric( \CRON_CONTROL_MA
 	$max_cache_buckets = absint( \CRON_CONTROL_MAX_CACHE_BUCKETS );
 	$max_cache_buckets = max( 1, min( $max_cache_buckets, 250 ) );
 }
-define( __NAMESPACE__ . '\CRON_CONTROL_MAX_CACHE_BUCKETS', $max_cache_buckets );
+define( __NAMESPACE__ . '\MAX_CACHE_BUCKETS', $max_cache_buckets );
 unset( $max_cache_buckets );

--- a/includes/constants.php
+++ b/includes/constants.php
@@ -44,3 +44,14 @@ if ( defined( 'CRON_CONTROL_CACHE_BUCKET_SIZE' ) && is_numeric( \CRON_CONTROL_CA
 }
 define( __NAMESPACE__ . '\CRON_CONTROL_CACHE_BUCKET_SIZE', $cache_bucket_size );
 unset( $cache_bucket_size );
+
+/**
+ * Limit how many buckets can be created, to avoid cache exhaustion
+ */
+$max_cache_buckets = 25;
+if ( defined( 'CRON_CONTROL_MAX_CACHE_BUCKETS' ) && is_numeric( \CRON_CONTROL_MAX_CACHE_BUCKETS ) ) {
+	$max_cache_buckets = absint( \CRON_CONTROL_MAX_CACHE_BUCKETS );
+	$max_cache_buckets = max( 1, min( $max_cache_buckets, 250 ) );
+}
+define( __NAMESPACE__ . '\CRON_CONTROL_MAX_CACHE_BUCKETS', $max_cache_buckets );
+unset( $max_cache_buckets );

--- a/includes/constants.php
+++ b/includes/constants.php
@@ -33,3 +33,14 @@ const JOB_LOCK_EXPIRY_IN_MINUTES  = 30;
  */
 const LOCK_DEFAULT_LIMIT             = 10;
 const LOCK_DEFULT_TIMEOUT_IN_MINUTES = 10;
+
+/**
+ * Limit on size of event cache objects
+ */
+$cache_bucket_size = 1024;
+if ( defined( 'CRON_CONTROL_CACHE_BUCKET_SIZE' ) && is_numeric( \CRON_CONTROL_CACHE_BUCKET_SIZE ) ) {
+	$cache_bucket_size = absint( \CRON_CONTROL_CACHE_BUCKET_SIZE );
+	$cache_bucket_size = max( 100, min( $cache_bucket_size, \PHP_INT_MAX ) );
+}
+define( __NAMESPACE__ . '\CRON_CONTROL_CACHE_BUCKET_SIZE', $cache_bucket_size );
+unset( $job_concurrency_limit );

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -62,12 +62,12 @@ function collapse_events_array( $events, $timestamp = null ) {
 /**
  * Convert simplified representation of cron events array to the format WordPress expects
  *
- * @param array $events
+ * @param array $events Flattened event list.
  * @return array
  */
 function inflate_collapsed_events_array( $events ) {
 	$inflated = array(
-		'version' => 2, // Core versions the cron array; without this, Core will attempt to "upgrade" the value
+		'version' => 2, // Core versions the cron array; without this, Core will attempt to "upgrade" the value.
 	);
 
 	if ( empty( $events ) ) {
@@ -75,10 +75,10 @@ function inflate_collapsed_events_array( $events ) {
 	}
 
 	foreach ( $events as $event ) {
-		// Object for convenience
+		// Object for convenience.
 		$event = (object) $event;
 
-		// Set up where this event belongs in the overall structure
+		// Set up where this event belongs in the overall structure.
 		if ( ! isset( $inflated[ $event->timestamp ] ) ) {
 			$inflated[ $event->timestamp ] = array();
 		}
@@ -87,7 +87,7 @@ function inflate_collapsed_events_array( $events ) {
 			$inflated[ $event->timestamp ][ $event->action ] = array();
 		}
 
-		// Store this event
+		// Store this event.
 		$inflated[ $event->timestamp ][ $event->action ][ $event->instance ] = $event->args;
 	}
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -19,6 +19,10 @@ require_once $_tests_dir . '/includes/functions.php';
 function _manually_load_plugin() {
 	define( 'WP_CRON_CONTROL_SECRET', 'testtesttest' );
 
+	// Nonsense values to test constraints and aid testing
+	define( 'CRON_CONTROL_CACHE_BUCKET_SIZE', 0 );
+	define( 'CRON_CONTROL_MAX_CACHE_BUCKETS', PHP_INT_MAX / 2 );
+
 	require dirname( dirname( __FILE__ ) ) . '/cron-control.php';
 
 	// Plugin loads after `wp_install()` is called, so we compensate

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -19,7 +19,7 @@ require_once $_tests_dir . '/includes/functions.php';
 function _manually_load_plugin() {
 	define( 'WP_CRON_CONTROL_SECRET', 'testtesttest' );
 
-	// Nonsense values to test constraints and aid testing
+	// Nonsense values to test constraints and aid testing.
 	define( 'CRON_CONTROL_CACHE_BUCKET_SIZE', 0 );
 	define( 'CRON_CONTROL_MAX_CACHE_BUCKETS', PHP_INT_MAX / 2 );
 

--- a/tests/test-misc.php
+++ b/tests/test-misc.php
@@ -32,13 +32,21 @@ class Misc_Tests extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Expected values for certain constants
+	 * Expected values for certain Core constants
 	 */
-	function test_constants() {
+	function test_core_constants() {
 		$this->assertTrue( defined( 'DISABLE_WP_CRON' ) );
 		$this->assertTrue( defined( 'ALTERNATE_WP_CRON' ) );
 
 		$this->assertTrue( constant( 'DISABLE_WP_CRON' ) );
 		$this->assertFalse( constant( 'ALTERNATE_WP_CRON' ) );
+	}
+
+	/**
+	 * Confirm that constants are properly constrained
+	 */
+	function test_event_cache_constants() {
+		$this->assertEquals( 256 * \KB_IN_BYTES, \Automattic\WP\Cron_Control\CACHE_BUCKET_SIZE );
+		$this->assertEquals( 250,                \Automattic\WP\Cron_Control\MAX_CACHE_BUCKETS );
 	}
 }

--- a/tests/test-utils.php
+++ b/tests/test-utils.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Class Utils_Tests
+ *
+ * @package Automattic_Cron_Control
+ */
+
+namespace Automattic\WP\Cron_Control\Tests;
+
+use Automattic\WP\Cron_Control;
+
+/**
+ * Sample test case.
+ */
+class Utils_Tests extends \WP_UnitTestCase {
+	/**
+	 * Prepare test environment
+	 */
+	function setUp() {
+		parent::setUp();
+
+		// make sure the schedule is clear
+		_set_cron_array( array() );
+	}
+
+	/**
+	 * Clean up after our tests
+	 */
+	function tearDown() {
+		// make sure the schedule is clear
+		_set_cron_array( array() );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Test functions that manipulate Core's cron format
+	 */
+	function test_events_array_collapse_and_inflate() {
+		$event_one = array(
+			'timestamp' => strtotime( '+15 minutes' ),
+			'action'    => 'test_event_1',
+			'args'      => array(
+				'test' => true,
+			),
+		);
+		wp_schedule_single_event( $event_one['timestamp'], $event_one['action'], $event_one['args'] );
+
+		$event_two = array(
+			'timestamp' => $event_one['timestamp'],
+			'action'    => 'test_event_2',
+			'args'      => array(
+				'fake_event' => 1,
+				'fake_args'  => array(
+					'thing' => 12,
+				),
+			),
+		);
+		wp_schedule_single_event( $event_two['timestamp'], $event_two['action'], $event_two['args'] );
+
+		$event_three = array(
+			'timestamp' => strtotime( '+30 minutes' ),
+			'action'    => 'test_event_3',
+			'args'      => array(
+				'post_id' => 1234,
+			),
+		);
+		wp_schedule_single_event( $event_three['timestamp'], $event_three['action'], $event_three['args'] );
+
+		$cron = get_option( 'cron' );
+
+		$collapsed = Cron_Control\collapse_events_array( $cron );
+
+		$this->assertEquals( count( $collapsed ), 3 );
+
+		$inflated = Cron_Control\inflate_collapsed_events_array( $collapsed );
+
+		$this->assertEquals( $cron, $inflated );
+	}
+}

--- a/tests/test-utils.php
+++ b/tests/test-utils.php
@@ -76,5 +76,11 @@ class Utils_Tests extends \WP_UnitTestCase {
 		$inflated = Cron_Control\inflate_collapsed_events_array( $collapsed );
 
 		$this->assertEquals( $cron, $inflated );
+
+		_set_cron_array( $inflated );
+
+		$this->assertEquals( $event_one['timestamp'], wp_next_scheduled( $event_one['action'], $event_one['args'] ) );
+		$this->assertEquals( $event_two['timestamp'], wp_next_scheduled( $event_two['action'], $event_two['args'] ) );
+		$this->assertEquals( $event_three['timestamp'], wp_next_scheduled( $event_three['action'], $event_three['args'] ) );
 	}
 }

--- a/tests/test-utils.php
+++ b/tests/test-utils.php
@@ -71,7 +71,7 @@ class Utils_Tests extends \WP_UnitTestCase {
 
 		$collapsed = Cron_Control\collapse_events_array( $cron );
 
-		$this->assertEquals( count( $collapsed ), 3 );
+		$this->assertEquals( 3, count( $collapsed ) );
 
 		$inflated = Cron_Control\inflate_collapsed_events_array( $collapsed );
 

--- a/tests/tests/class-utils-tests.php
+++ b/tests/tests/class-utils-tests.php
@@ -1,16 +1,15 @@
 <?php
 /**
- * Class Utils_Tests
+ * Test plugin's utility functions
  *
- * @package Automattic_Cron_Control
+ * @package a8c_Cron_Control
  */
 
 namespace Automattic\WP\Cron_Control\Tests;
-
 use Automattic\WP\Cron_Control;
 
 /**
- * Sample test case.
+ * Class Utils_Tests
  */
 class Utils_Tests extends \WP_UnitTestCase {
 	/**
@@ -19,7 +18,7 @@ class Utils_Tests extends \WP_UnitTestCase {
 	function setUp() {
 		parent::setUp();
 
-		// make sure the schedule is clear
+		// make sure the schedule is clear.
 		_set_cron_array( array() );
 	}
 
@@ -27,7 +26,7 @@ class Utils_Tests extends \WP_UnitTestCase {
 	 * Clean up after our tests
 	 */
 	function tearDown() {
-		// make sure the schedule is clear
+		// make sure the schedule is clear.
 		_set_cron_array( array() );
 
 		parent::tearDown();


### PR DESCRIPTION
When the cron option exceeds a given size, break it into smaller slices that can be cached individually. If option size does not exceed limit, caching is unchanged.

Fixes #37 