### PR TITLE
Improve date internationalization

### DIFF
--- a/includes/wp-cli/class-events.php
+++ b/includes/wp-cli/class-events.php
@@ -122,7 +122,7 @@ class Events extends \WP_CLI_Command {
 		// Proceed?
 		$now = time();
 		if ( $event->timestamp > $now ) {
-			\WP_CLI::warning( sprintf( __( 'This event is not scheduled to run until %1$s GMT (%2$s)', 'automattic-cron-control' ), date( TIME_FORMAT, $event->timestamp ), $this->calculate_interval( $event->timestamp - $now ) ) );
+			\WP_CLI::warning( sprintf( __( 'This event is not scheduled to run until %1$s GMT (%2$s)', 'automattic-cron-control' ), date_i18n( TIME_FORMAT, $event->timestamp ), $this->calculate_interval( $event->timestamp - $now ) ) );
 		}
 
 		\WP_CLI::confirm( sprintf( __( 'Run this event?', 'automattic-cron-control' ) ) );
@@ -222,9 +222,9 @@ class Events extends \WP_CLI_Command {
 				'ID'                => $event->ID,
 				'action'            => $event->action,
 				'instance'          => $event->instance,
-				'next_run_gmt'      => date( TIME_FORMAT, $event->timestamp ),
+				'next_run_gmt'      => date_i18n( TIME_FORMAT, $event->timestamp ),
 				'next_run_relative' => '',
-				'last_updated_gmt'  => date( TIME_FORMAT, strtotime( $event->last_modified ) ),
+				'last_updated_gmt'  => date_i18n( TIME_FORMAT, strtotime( $event->last_modified ) ),
 				'recurrence'        => __( 'Non-repeating', 'automattic-cron-control' ),
 				'internal_event'    => '',
 				'schedule_name'     => __( 'n/a', 'automattic-cron-control' ),
@@ -369,7 +369,7 @@ class Events extends \WP_CLI_Command {
 				\WP_CLI::warning( __( 'This is an event created by the Cron Control plugin. It will recreated automatically.', 'automattic-cron-control' ) );
 			}
 
-			\WP_CLI::log( sprintf( __( 'Execution time: %s GMT', 'automattic-cron-control' ), date( TIME_FORMAT, $event->timestamp ) ) );
+			\WP_CLI::log( sprintf( __( 'Execution time: %s GMT', 'automattic-cron-control' ), date_i18n( TIME_FORMAT, $event->timestamp ) ) );
 			\WP_CLI::log( sprintf( __( 'Action: %s', 'automattic-cron-control' ), $event->action ) );
 			\WP_CLI::log( sprintf( __( 'Instance identifier: %s', 'automattic-cron-control' ), $event->instance ) );
 			\WP_CLI::log( '' );

--- a/includes/wp-cli/class-lock.php
+++ b/includes/wp-cli/class-lock.php
@@ -55,7 +55,7 @@ class Lock extends \WP_CLI_Command {
 			$timestamp = \Automattic\WP\Cron_Control\Lock::get_lock_timestamp( $lock_name );
 
 			\WP_CLI::log( sprintf( __( 'Previous value: %s', 'automattic-cron-control' ), number_format_i18n( $lock ) ) );
-			\WP_CLI::log( sprintf( __( 'Previously modified: %s GMT', 'automattic-cron-control' ), date( TIME_FORMAT, $timestamp ) ) . "\n" );
+			\WP_CLI::log( sprintf( __( 'Previously modified: %s GMT', 'automattic-cron-control' ), date_i18n( TIME_FORMAT, $timestamp ) ) . "\n" );
 
 			\WP_CLI::confirm( sprintf( __( 'Are you sure you want to reset this lock?', 'automattic-cron-control' ) ) );
 			\WP_CLI::log( '' );
@@ -70,7 +70,7 @@ class Lock extends \WP_CLI_Command {
 		$timestamp = \Automattic\WP\Cron_Control\Lock::get_lock_timestamp( $lock_name );
 
 		\WP_CLI::log( sprintf( __( 'Current value: %s', 'automattic-cron-control' ), number_format_i18n( $lock ) ) );
-		\WP_CLI::log( sprintf( __( 'Last modified: %s GMT', 'automattic-cron-control' ), date( TIME_FORMAT, $timestamp ) ) );
+		\WP_CLI::log( sprintf( __( 'Last modified: %s GMT', 'automattic-cron-control' ), date_i18n( TIME_FORMAT, $timestamp ) ) );
 	}
 }
 

--- a/includes/wp-cli/class-rest-api.php
+++ b/includes/wp-cli/class-rest-api.php
@@ -82,7 +82,7 @@ class REST_API extends \WP_CLI_Command {
 				'timestamp'      => $event_data->timestamp,
 				'action'         => $event_data->action,
 				'instance'       => $event_data->instance,
-				'scheduled_for'  => date( TIME_FORMAT, $event_data->timestamp ),
+				'scheduled_for'  => date_i18n( TIME_FORMAT, $event_data->timestamp ),
 				'internal_event' => \Automattic\WP\Cron_Control\is_internal_event( $event_data->action ) ? __( 'true', 'automattic-cron-control' ) : '',
 				'schedule_name'  => false === $event_data->schedule ? __( 'n/a', 'automattic-cron-control' ) : $event_data->schedule,
 				'event_args'     => maybe_serialize( $event_data->args ),


### PR DESCRIPTION
As noted in #114, `date()` should be replaced with `date_i18n()` anywhere that's already supporting translation.