### PR TITLE
Always output command failures, otherwise the runner fails silently.

### DIFF
--- a/runner/runner.go
+++ b/runner/runner.go
@@ -324,8 +324,9 @@ func runWpCliCmd(subcommand []string) (string, error) {
 	wpOutStr := string(wpOut)
 
 	if err != nil {
+		logger.Printf("%s - %s", err, wpOutStr)
+
 		if debug {
-			logger.Printf("%s - %s", err, wpOutStr)
 			logger.Println(fmt.Sprintf("%+v", subcommand))
 		}
 


### PR DESCRIPTION
Without this, the `-debug` flag is needed to know why no events are run, which isn't ideal.