### PR TITLE
Allow sorting to be enforced when listing events, but default to unsorted

### DIFF
--- a/includes/wp-cli/class-events.php
+++ b/includes/wp-cli/class-events.php
@@ -191,9 +191,10 @@ class Events extends \WP_CLI_Command {
 
 		// Query
 		$items = \Automattic\WP\Cron_Control\get_events( array(
-			'status'   => $event_status,
-			'quantity' => $limit,
-			'page'     => $page,
+			'status'     => $event_status,
+			'quantity'   => $limit,
+			'page'       => $page,
+			'force_sort' => true,
 		) );
 
 		// Bail if we don't get results


### PR DESCRIPTION
We generally don't need sorted events, making the filesort a waste of time and resources.

Fixes #104