### PR TITLE
Fix timestamp localization

### DIFF
--- a/includes/class-rest-api.php
+++ b/includes/class-rest-api.php
@@ -78,7 +78,7 @@ class REST_API extends Singleton {
 			if ( 1 === $run_disabled ) {
 				$message = __( 'Automatic event execution is disabled indefinitely.', 'automattic-cron-control' );
 			} else {
-				$message = sprintf( __( 'Automatic event execution is disabled until %s UTC (%d).', 'automattic-cron-control' ), date_i18n( 'Y-m-d H:i:s', $run_disabled ), $run_disabled );
+				$message = sprintf( __( 'Automatic event execution is disabled until %s UTC (%d).', 'automattic-cron-control' ), date_i18n( TIME_FORMAT, $run_disabled ), $run_disabled );
 			}
 
 			return rest_ensure_response( new \WP_Error( 'automatic-execution-disabled', $message, array( 'status' => 403, ) ) );

--- a/includes/class-rest-api.php
+++ b/includes/class-rest-api.php
@@ -78,7 +78,7 @@ class REST_API extends Singleton {
 			if ( 1 === $run_disabled ) {
 				$message = __( 'Automatic event execution is disabled indefinitely.', 'automattic-cron-control' );
 			} else {
-				$message = sprintf( __( 'Automatic event execution is disabled until %s (%d).', 'automattic-cron-control' ), date( 'Y-m-d H:i:s T', $run_disabled ), $run_disabled );
+				$message = sprintf( __( 'Automatic event execution is disabled until %s UTC (%d).', 'automattic-cron-control' ), date_i18n( 'Y-m-d H:i:s', $run_disabled ), $run_disabled );
 			}
 
 			return rest_ensure_response( new \WP_Error( 'automatic-execution-disabled', $message, array( 'status' => 403, ) ) );

--- a/includes/constants.php
+++ b/includes/constants.php
@@ -33,3 +33,10 @@ const JOB_LOCK_EXPIRY_IN_MINUTES  = 30;
  */
 const LOCK_DEFAULT_LIMIT              = 10;
 const LOCK_DEFAULT_TIMEOUT_IN_MINUTES = 10;
+
+/**
+ * Consistent time format across plugin
+ *
+ * Excludes timestamp as UTC is used throughout
+ */
+const TIME_FORMAT = 'Y-m-d H:i:s';

--- a/includes/wp-cli.php
+++ b/includes/wp-cli.php
@@ -37,8 +37,10 @@ prepare_environment();
 
 /**
  * Consistent time format across commands
+ *
+ * Defined here for backwards compatibility, as it was here before it was in the primary namespace
  */
-const TIME_FORMAT = 'Y-m-d H:i:s';
+const TIME_FORMAT = \Automattic\WP\Cron_Control\TIME_FORMAT;
 
 /**
  *  Clear all of the caches for memory management

--- a/includes/wp-cli/class-events.php
+++ b/includes/wp-cli/class-events.php
@@ -122,7 +122,7 @@ class Events extends \WP_CLI_Command {
 		// Proceed?
 		$now = time();
 		if ( $event->timestamp > $now ) {
-			\WP_CLI::warning( sprintf( __( 'This event is not scheduled to run until %1$s GMT (%2$s)', 'automattic-cron-control' ), date( TIME_FORMAT, $event->timestamp ), $this->calculate_interval( $event->timestamp - $now ) ) );
+			\WP_CLI::warning( sprintf( __( 'This event is not scheduled to run until %1$s UTC (%2$s)', 'automattic-cron-control' ), date_i18n( TIME_FORMAT, $event->timestamp ), $this->calculate_interval( $event->timestamp - $now ) ) );
 		}
 
 		\WP_CLI::confirm( sprintf( __( 'Run this event?', 'automattic-cron-control' ) ) );
@@ -221,9 +221,9 @@ class Events extends \WP_CLI_Command {
 				'ID'                => $event->ID,
 				'action'            => $event->action,
 				'instance'          => $event->instance,
-				'next_run_gmt'      => date( TIME_FORMAT, $event->timestamp ),
+				'next_run_gmt'      => date_i18n( TIME_FORMAT, $event->timestamp ),
 				'next_run_relative' => '',
-				'last_updated_gmt'  => date( TIME_FORMAT, strtotime( $event->last_modified ) ),
+				'last_updated_gmt'  => date_i18n( TIME_FORMAT, strtotime( $event->last_modified ) ),
 				'recurrence'        => __( 'Non-repeating', 'automattic-cron-control' ),
 				'internal_event'    => '',
 				'schedule_name'     => __( 'n/a', 'automattic-cron-control' ),
@@ -368,7 +368,7 @@ class Events extends \WP_CLI_Command {
 				\WP_CLI::warning( __( 'This is an event created by the Cron Control plugin. It will recreated automatically.', 'automattic-cron-control' ) );
 			}
 
-			\WP_CLI::log( sprintf( __( 'Execution time: %s GMT', 'automattic-cron-control' ), date( TIME_FORMAT, $event->timestamp ) ) );
+			\WP_CLI::log( sprintf( __( 'Execution time: %s UTC', 'automattic-cron-control' ), date_i18n( TIME_FORMAT, $event->timestamp ) ) );
 			\WP_CLI::log( sprintf( __( 'Action: %s', 'automattic-cron-control' ), $event->action ) );
 			\WP_CLI::log( sprintf( __( 'Instance identifier: %s', 'automattic-cron-control' ), $event->instance ) );
 			\WP_CLI::log( '' );

--- a/includes/wp-cli/class-lock.php
+++ b/includes/wp-cli/class-lock.php
@@ -55,7 +55,7 @@ class Lock extends \WP_CLI_Command {
 			$timestamp = \Automattic\WP\Cron_Control\Lock::get_lock_timestamp( $lock_name );
 
 			\WP_CLI::log( sprintf( __( 'Previous value: %s', 'automattic-cron-control' ), number_format_i18n( $lock ) ) );
-			\WP_CLI::log( sprintf( __( 'Previously modified: %s GMT', 'automattic-cron-control' ), date( TIME_FORMAT, $timestamp ) ) . "\n" );
+			\WP_CLI::log( sprintf( __( 'Previously modified: %s UTC', 'automattic-cron-control' ), date_i18n( TIME_FORMAT, $timestamp ) ) . "\n" );
 
 			\WP_CLI::confirm( sprintf( __( 'Are you sure you want to reset this lock?', 'automattic-cron-control' ) ) );
 			\WP_CLI::log( '' );
@@ -70,7 +70,7 @@ class Lock extends \WP_CLI_Command {
 		$timestamp = \Automattic\WP\Cron_Control\Lock::get_lock_timestamp( $lock_name );
 
 		\WP_CLI::log( sprintf( __( 'Current value: %s', 'automattic-cron-control' ), number_format_i18n( $lock ) ) );
-		\WP_CLI::log( sprintf( __( 'Last modified: %s GMT', 'automattic-cron-control' ), date( TIME_FORMAT, $timestamp ) ) );
+		\WP_CLI::log( sprintf( __( 'Last modified: %s UTC', 'automattic-cron-control' ), date_i18n( TIME_FORMAT, $timestamp ) ) );
 	}
 }
 

--- a/includes/wp-cli/class-orchestrate-runner.php
+++ b/includes/wp-cli/class-orchestrate-runner.php
@@ -62,7 +62,7 @@ class Orchestrate_Runner extends \WP_CLI_Command {
 
 		$now = time();
 		if ( $timestamp > $now ) {
-			\WP_CLI::error( sprintf( __( 'Given timestamp is for %1$s GMT, %2$s from now. The event\'s existence was not confirmed, and no attempt was made to execute it.', 'automattic-cron-control' ), date( TIME_FORMAT, $timestamp ), human_time_diff( $now, $timestamp ) ) );
+			\WP_CLI::error( sprintf( __( 'Given timestamp is for %1$s UTC, %2$s from now. The event\'s existence was not confirmed, and no attempt was made to execute it.', 'automattic-cron-control' ), date_i18n( TIME_FORMAT, $timestamp ), human_time_diff( $now, $timestamp ) ) );
 		}
 
 		// Prepare environment

--- a/includes/wp-cli/class-orchestrate-runner.php
+++ b/includes/wp-cli/class-orchestrate-runner.php
@@ -62,7 +62,7 @@ class Orchestrate_Runner extends \WP_CLI_Command {
 
 		$now = time();
 		if ( $timestamp > $now ) {
-			\WP_CLI::error( sprintf( __( 'Given timestamp is for %1$s GMT, %2$s from now. The event\'s existence was not confirmed, and no attempt was made to execute it.', 'automattic-cron-control' ), date_i18n( TIME_FORMAT, $timestamp ), human_time_diff( $now, $timestamp ) ) );
+			\WP_CLI::error( sprintf( __( 'Given timestamp is for %1$s GMT, %2$s from now. The event\'s existence was not confirmed, and no attempt was made to execute it.', 'automattic-cron-control' ), date( TIME_FORMAT, $timestamp ), human_time_diff( $now, $timestamp ) ) );
 		}
 
 		// Prepare environment

--- a/includes/wp-cli/class-orchestrate.php
+++ b/includes/wp-cli/class-orchestrate.php
@@ -24,7 +24,7 @@ class Orchestrate extends \WP_CLI_Command {
 				break;
 
 			default :
-				$status = sprintf( __( 'Automatic execution is disabled until %s', 'automattic-cron-control' ), date_i18n( 'Y-m-d H:i:s T', $status ) );
+				$status = sprintf( __( 'Automatic execution is disabled until %s', 'automattic-cron-control' ), date( 'Y-m-d H:i:s T', $status ) );
 				break;
 		}
 
@@ -67,7 +67,7 @@ class Orchestrate extends \WP_CLI_Command {
 				$updated = \Automattic\WP\Cron_Control\Events::instance()->update_run_status( $disable_ts );
 
 				if ( $updated ) {
-					\WP_CLI::success( sprintf( __( 'Disabled until %s', 'automattic-cron-control' ), date_i18n( 'Y-m-d H:i:s T', $disable_ts ) ) );
+					\WP_CLI::success( sprintf( __( 'Disabled until %s', 'automattic-cron-control' ), date( 'Y-m-d H:i:s T', $disable_ts ) ) );
 					return;
 				}
 

--- a/includes/wp-cli/class-orchestrate.php
+++ b/includes/wp-cli/class-orchestrate.php
@@ -24,7 +24,7 @@ class Orchestrate extends \WP_CLI_Command {
 				break;
 
 			default :
-				$status = sprintf( __( 'Automatic execution is disabled until %s', 'automattic-cron-control' ), date( 'Y-m-d H:i:s T', $status ) );
+				$status = sprintf( __( 'Automatic execution is disabled until %s UTC', 'automattic-cron-control' ), date_i18n( TIME_FORMAT, $status ) );
 				break;
 		}
 
@@ -67,7 +67,7 @@ class Orchestrate extends \WP_CLI_Command {
 				$updated = \Automattic\WP\Cron_Control\Events::instance()->update_run_status( $disable_ts );
 
 				if ( $updated ) {
-					\WP_CLI::success( sprintf( __( 'Disabled until %s', 'automattic-cron-control' ), date( 'Y-m-d H:i:s T', $disable_ts ) ) );
+					\WP_CLI::success( sprintf( __( 'Disabled until %s UTC', 'automattic-cron-control' ), date_i18n( TIME_FORMAT, $disable_ts ) ) );
 					return;
 				}
 

--- a/includes/wp-cli/class-rest-api.php
+++ b/includes/wp-cli/class-rest-api.php
@@ -82,7 +82,7 @@ class REST_API extends \WP_CLI_Command {
 				'timestamp'      => $event_data->timestamp,
 				'action'         => $event_data->action,
 				'instance'       => $event_data->instance,
-				'scheduled_for'  => date( TIME_FORMAT, $event_data->timestamp ),
+				'scheduled_for'  => date_i18n( TIME_FORMAT, $event_data->timestamp ),
 				'internal_event' => \Automattic\WP\Cron_Control\is_internal_event( $event_data->action ) ? __( 'true', 'automattic-cron-control' ) : '',
 				'schedule_name'  => false === $event_data->schedule ? __( 'n/a', 'automattic-cron-control' ) : $event_data->schedule,
 				'event_args'     => maybe_serialize( $event_data->args ),


### PR DESCRIPTION
Currently, a UTC date will be displayed with a localized timezone, which is rather misleading. By moving the timezone (always UTC) to the translated string, the date itself can be localized without a misleading timezone be shown.

Fixes #138