### PR TITLE
Allow additional internal events via a constant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+composer.lock
+vendor
+.DS_Store
+Thumbs.db
+wp-cli.local.yml
+node_modules/
+*.sql
+*.tar.gz
+*.zip

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,10 +27,6 @@ matrix:
       env: WP_VERSION=latest
     - php: 7.0
       env: WP_VERSION=trunk
-    - php: 5.6
-      env: WP_VERSION=latest
-    - php: 5.6
-      env: WP_VERSION=trunk
     # PHPCS
     - php: 7.1
       env: WP_TRAVISCI=phpcs

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,54 @@
+module.exports = function( grunt ) {
+
+	'use strict';
+	var banner = '/**\n * <%= pkg.homepage %>\n * Copyright (c) <%= grunt.template.today("yyyy") %>\n * This file is generated automatically. Do not edit.\n */\n';
+	// Project configuration
+	grunt.initConfig( {
+
+		pkg: grunt.file.readJSON( 'package.json' ),
+
+		addtextdomain: {
+			options: {
+				textdomain: 'automattic-cron-control',
+			},
+			update_all_domains: {
+				options: {
+					updateDomains: true
+				},
+				src: [ '*.php', '**/*.php', '!node_modules/**', '!php-tests/**', '!bin/**' ]
+			}
+		},
+
+		wp_readme_to_markdown: {
+			your_target: {
+				files: {
+					'README.md': 'readme.txt'
+				}
+			},
+		},
+
+		makepot: {
+			target: {
+				options: {
+					domainPath: '/languages',
+					mainFile: 'cron-control.php',
+					potFilename: 'cron-control.pot',
+					potHeaders: {
+						poedit: true,
+						'x-poedit-keywordslist': true
+					},
+					type: 'wp-plugin',
+					updateTimestamp: true
+				}
+			}
+		},
+	} );
+
+	grunt.loadNpmTasks( 'grunt-wp-i18n' );
+	grunt.loadNpmTasks( 'grunt-wp-readme-to-markdown' );
+	grunt.registerTask( 'i18n', ['addtextdomain', 'makepot'] );
+	grunt.registerTask( 'readme', ['wp_readme_to_markdown'] );
+
+	grunt.util.linefeed = '\n';
+
+};

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Cron Control #
 **Contributors:** automattic, ethitter  
-**Tags:** support, user  
+**Tags:** cron, cron control, concurrency, parallel, async  
 **Requires at least:** 4.4  
 **Tested up to:** 4.9  
 **Requires PHP:** 7.0  

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,11 @@
+{
+  "name": "automattic/cron-control",
+  "description": "Execute WordPress cron events in parallel, with custom event storage for high-volume cron.",
+  "license": "GPL-2.0",
+  "require": {
+    "php": ">=7.0.0"
+  },
+  "require-dev": {
+    "wp-cli/wp-cli": "*"
+  }
+}

--- a/includes/class-internal-events.php
+++ b/includes/class-internal-events.php
@@ -20,7 +20,7 @@ class Internal_Events extends Singleton {
 	 *
 	 * @var array
 	 */
-	private $internal_jobs = array();
+	private $internal_events = array();
 
 	/**
 	 * Schedules for internal events
@@ -29,7 +29,7 @@ class Internal_Events extends Singleton {
 	 *
 	 * @var array
 	 */
-	private $internal_jobs_schedules = array();
+	private $internal_events_schedules = array();
 
 	/**
 	 * Register hooks
@@ -44,8 +44,8 @@ class Internal_Events extends Singleton {
 		add_action( 'rest_api_init',  array( $this, 'schedule_internal_events' ) );
 		add_filter( 'cron_schedules', array( $this, 'register_internal_events_schedules' ) );
 
-		foreach ( $this->internal_jobs as $internal_job ) {
-			add_action( $internal_job['action'], $internal_job['callback'] );
+		foreach ( $this->internal_events as $internal_event ) {
+			add_action( $internal_event['action'], $internal_event['callback'] );
 		}
 	}
 
@@ -53,7 +53,7 @@ class Internal_Events extends Singleton {
 	 * Populate internal events, allowing for additions
 	 */
 	private function prepare_internal_events() {
-		$internal_jobs = array(
+		$internal_events = array(
 			array(
 				'schedule' => 'a8c_cron_control_minute',
 				'action'   => 'a8c_cron_control_force_publish_missed_schedules',
@@ -78,7 +78,7 @@ class Internal_Events extends Singleton {
 
 		// Allow additional internal events to be specified, ensuring the above cannot be overwritten.
 		if ( defined( 'CRON_CONTROL_ADDITIONAL_INTERNAL_EVENTS' ) && is_array( \CRON_CONTROL_ADDITIONAL_INTERNAL_EVENTS ) ) {
-			$internal_actions = wp_list_pluck( $internal_jobs, 'action' );
+			$internal_actions = wp_list_pluck( $internal_events, 'action' );
 
 			foreach ( \CRON_CONTROL_ADDITIONAL_INTERNAL_EVENTS as $additional ) {
 				if ( in_array( $additional['action'], $internal_actions, true ) ) {
@@ -89,18 +89,18 @@ class Internal_Events extends Singleton {
 					continue;
 				}
 
-				$internal_jobs[] = $additional;
+				$internal_events[] = $additional;
 			}
 		}
 
-		$this->internal_jobs = $internal_jobs;
+		$this->internal_events = $internal_events;
 	}
 
 	/**
 	 * Allow custom internal events to provide their own schedules
 	 */
 	private function prepare_internal_events_schedules() {
-		$internal_jobs_schedules = array(
+		$internal_events_schedules = array(
 			'a8c_cron_control_minute' => array(
 				'interval' => 1 * MINUTE_IN_SECONDS,
 				'display' => __( 'Cron Control internal job - every minute', 'automattic-cron-control' ),
@@ -114,7 +114,7 @@ class Internal_Events extends Singleton {
 		// Allow additional schedules for custom events, ensuring the above cannot be overwritten.
 		if ( defined( 'CRON_CONTROL_ADDITIONAL_INTERNAL_EVENTS_SCHEDULES' ) && is_array( \CRON_CONTROL_ADDITIONAL_INTERNAL_EVENTS_SCHEDULES ) ) {
 			foreach ( \CRON_CONTROL_ADDITIONAL_INTERNAL_EVENTS_SCHEDULES as $name => $attrs ) {
-				if ( array_key_exists( $name, $internal_jobs_schedules ) ) {
+				if ( array_key_exists( $name, $internal_events_schedules ) ) {
 					continue;
 				}
 
@@ -122,42 +122,42 @@ class Internal_Events extends Singleton {
 					continue;
 				}
 
-				$internal_jobs_schedules[ $name ] = $attrs;
+				$internal_events_schedules[ $name ] = $attrs;
 			}
 		}
 
-		$this->internal_jobs_schedules = $internal_jobs_schedules;
+		$this->internal_events_schedules = $internal_events_schedules;
 	}
 
 	/**
-	 * Include custom schedules used for internal jobs
+	 * Include custom schedules used for internal events
 	 *
 	 * @param array $schedules List of registered event intervals.
 	 * @return array
 	 */
 	public function register_internal_events_schedules( $schedules ) {
-		return array_merge( $schedules, $this->internal_jobs_schedules );
+		return array_merge( $schedules, $this->internal_events_schedules );
 	}
 
 	/**
-	 * Schedule internal jobs
+	 * Schedule internal events
 	 */
 	public function schedule_internal_events() {
 		$when = strtotime( sprintf( '+%d seconds', JOB_QUEUE_WINDOW_IN_SECONDS ) );
 
 		$schedules = wp_get_schedules();
 
-		foreach ( $this->internal_jobs as $job_args ) {
-			if ( ! wp_next_scheduled( $job_args['action'] ) ) {
-				$interval = array_key_exists( $job_args['schedule'], $schedules ) ? $schedules[ $job_args['schedule'] ]['interval'] : 0;
+		foreach ( $this->internal_events as $event_args ) {
+			if ( ! wp_next_scheduled( $event_args['action'] ) ) {
+				$interval = array_key_exists( $event_args['schedule'], $schedules ) ? $schedules[ $event_args['schedule'] ]['interval'] : 0;
 
 				$args = array(
-					'schedule' => $job_args['schedule'],
+					'schedule' => $event_args['schedule'],
 					'args'     => array(),
 					'interval' => $interval,
 				);
 
-				schedule_event( $when, $job_args['action'], $args );
+				schedule_event( $when, $event_args['action'], $args );
 			}
 		}
 	}
@@ -173,7 +173,7 @@ class Internal_Events extends Singleton {
 	 * @return bool
 	 */
 	public function is_internal_event( $action ) {
-		return in_array( $action, wp_list_pluck( $this->internal_jobs, 'action' ), true );
+		return in_array( $action, wp_list_pluck( $this->internal_events, 'action' ), true );
 	}
 
 	/**
@@ -256,32 +256,32 @@ class Internal_Events extends Singleton {
 		// Confirm internal events are scheduled for when they're expected.
 		$schedules = wp_get_schedules();
 
-		foreach ( $this->internal_jobs as $internal_job ) {
-			$timestamp = wp_next_scheduled( $internal_job['action'] );
+		foreach ( $this->internal_events as $internal_event ) {
+			$timestamp = wp_next_scheduled( $internal_event['action'] );
 
 			// Will reschedule on its own.
 			if ( false === $timestamp ) {
 				continue;
 			}
 
-			$job_details = get_event_by_attributes( array(
+			$event_details = get_event_by_attributes( array(
 				'timestamp' => $timestamp,
-				'action'    => $internal_job['action'],
+				'action'    => $internal_event['action'],
 				'instance'  => md5( maybe_serialize( array() ) ),
 			) );
 
-			if ( $job_details->schedule !== $internal_job['schedule'] ) {
+			if ( $event_details->schedule !== $internal_event['schedule'] ) {
 				if ( $timestamp <= time() ) {
 					$timestamp = time() + ( 1 * \MINUTE_IN_SECONDS );
 				}
 
 				$args = array(
-					'schedule' => $internal_job['schedule'],
-					'args'     => $job_details->args,
-					'interval' => $schedules[ $internal_job['schedule'] ]['interval'],
+					'schedule' => $internal_event['schedule'],
+					'args'     => $event_details->args,
+					'interval' => $schedules[ $internal_event['schedule'] ]['interval'],
 				);
 
-				schedule_event( $timestamp, $job_details->action, $args, $job_details->ID );
+				schedule_event( $timestamp, $event_details->action, $args, $event_details->ID );
 			}
 		}
 	}

--- a/includes/class-internal-events.php
+++ b/includes/class-internal-events.php
@@ -40,8 +40,13 @@ class Internal_Events extends Singleton {
 		$this->prepare_internal_events_schedules();
 
 		// Register hooks.
-		add_action( 'admin_init',     array( $this, 'schedule_internal_events' ) );
-		add_action( 'rest_api_init',  array( $this, 'schedule_internal_events' ) );
+		if ( defined( 'WP_CLI' ) && \WP_CLI ) {
+			add_action( 'wp_loaded', array( $this, 'schedule_internal_events' ) );
+		} else {
+			add_action( 'admin_init',    array( $this, 'schedule_internal_events' ) );
+			add_action( 'rest_api_init', array( $this, 'schedule_internal_events' ) );
+		}
+
 		add_filter( 'cron_schedules', array( $this, 'register_internal_events_schedules' ) );
 
 		foreach ( $this->internal_events as $internal_event ) {

--- a/includes/wp-cli/class-one-time-fixers.php
+++ b/includes/wp-cli/class-one-time-fixers.php
@@ -144,7 +144,7 @@ class One_Time_Fixers extends \WP_CLI_Command {
 			}
 
 			/* translators: 1: Event count for this batch */
-			\WP_CLI::log( sprintf( __( 'Found %s items in this batch' ), number_format_i18n( count( $items ) ) ) );
+			\WP_CLI::log( sprintf( __( 'Found %s items in this batch', 'automattic-cron-control' ), number_format_i18n( count( $items ) ) ) );
 
 			foreach ( $items as $item ) {
 				\WP_CLI::log( "{$item->ID}, `{$item->post_title}`" );

--- a/languages/cron-control.pot
+++ b/languages/cron-control.pot
@@ -1,0 +1,589 @@
+# Copyright (C) 2017 Erick Hitter, Automattic
+# This file is distributed under the same license as the Cron Control package.
+msgid ""
+msgstr ""
+"Project-Id-Version: Cron Control 1.5\n"
+"Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/cron-control\n"
+"POT-Creation-Date: 2017-10-03 20:24:01+00:00\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"PO-Revision-Date: 2017-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"X-Generator: grunt-wp-i18n 0.5.4\n"
+"X-Poedit-KeywordsList: "
+"__;_e;_x:1,2c;_ex:1,2c;_n:1,2;_nx:1,2,4c;_n_noop:1,2;_nx_noop:1,2,3c;esc_"
+"attr__;esc_html__;esc_attr_e;esc_html_e;esc_attr_x:1,2c;esc_html_x:1,2c;\n"
+"Language: en\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Poedit-Country: United States\n"
+"X-Poedit-SourceCharset: UTF-8\n"
+"X-Poedit-Basepath: ../\n"
+"X-Poedit-SearchPath-0: .\n"
+"X-Poedit-Bookmarks: \n"
+"X-Textdomain-Support: yes\n"
+
+#: includes/class-events.php:256
+msgid "Invalid or incomplete request data."
+msgstr ""
+
+#: includes/class-events.php:264
+#. translators: 1: Job identifier
+msgid "Job with identifier `%1$s` is not scheduled to run yet."
+msgstr ""
+
+#: includes/class-events.php:280
+#. translators: 1: Job identifier
+msgid "Job with identifier `%1$s` could not be found."
+msgstr ""
+
+#: includes/class-events.php:294
+#. translators: 1: Event action, 2: Event arguments
+msgid ""
+"No resources available to run the job with action `%1$s` and arguments "
+"`%2$s`."
+msgstr ""
+
+#: includes/class-events.php:322
+#. translators: 1: Event action, 2: Event arguments, 3: Throwable error, 4:
+#. Line number that raised Throwable error
+msgid ""
+"Callback for job with action `%1$s` and arguments `%2$s` raised a Throwable "
+"- %3$s in %4$s on line %5$d."
+msgstr ""
+
+#: includes/class-events.php:340
+#. translators: 1: Event action, 2: Event arguments
+msgid "Job with action `%1$s` and arguments `%2$s` executed."
+msgstr ""
+
+#: includes/class-internal-events.php:111
+msgid "Cron Control internal job - every minute"
+msgstr ""
+
+#: includes/class-internal-events.php:115
+msgid "Cron Control internal job - every 10 minutes"
+msgstr ""
+
+#: includes/class-main.php:79
+#. translators: 1: Plugin name, 2: Constant name
+msgid "%1$s: %2$s set to unexpected value; must be corrected for proper behaviour."
+msgstr ""
+
+#: includes/class-main.php:94
+#. translators: 1: Plugin name
+msgid "Normal cron execution is blocked when the %s plugin is active."
+msgstr ""
+
+#: includes/class-main.php:125
+#. translators: 1: Plugin name, 2: Constant name
+msgid "<strong>%1$s</strong>: To use this plugin, define the constant %2$s."
+msgstr ""
+
+#: includes/class-rest-api.php:90
+msgid "Automatic event execution is disabled indefinitely."
+msgstr ""
+
+#: includes/class-rest-api.php:93
+#. translators: 1: Time automatic execution is disabled until, 2: Unix
+#. timestamp
+msgid "Automatic event execution is disabled until %1$s UTC (%2$d)."
+msgstr ""
+
+#: includes/class-rest-api.php:124
+msgid "Secret must be specified with all requests"
+msgstr ""
+
+#: includes/wp-cli/class-cache.php:25
+msgid "Internal caches cleared"
+msgstr ""
+
+#: includes/wp-cli/class-cache.php:27
+msgid "No caches to clear"
+msgstr ""
+
+#: includes/wp-cli/class-events.php:30
+msgid "Invalid page requested"
+msgstr ""
+
+#: includes/wp-cli/class-events.php:39
+msgid ""
+"Entries are purged automatically, so this cannot be relied upon as a record "
+"of past event execution."
+msgstr ""
+
+#: includes/wp-cli/class-events.php:44
+msgid "No events to display"
+msgstr ""
+
+#: includes/wp-cli/class-events.php:55
+#. translators: 1: Number of events to display
+msgid "Displaying %s entry"
+msgid_plural "Displaying all %s entries"
+msgstr[0] ""
+msgstr[1] ""
+
+#: includes/wp-cli/class-events.php:58
+#. translators: 1: Entries on this page, 2: Total entries, 3: Current page, 4:
+#. Total pages
+msgid "Displaying %1$s of %2$s entries, page %3$s of %4$s"
+msgstr ""
+
+#: includes/wp-cli/class-events.php:109
+msgid ""
+"Specify something to delete, or see the `cron-control-fixers` command to "
+"remove all data."
+msgstr ""
+
+#: includes/wp-cli/class-events.php:123
+msgid "Specify the ID of an event to run"
+msgstr ""
+
+#: includes/wp-cli/class-events.php:131
+#. translators: 1: Event ID
+msgid ""
+"Failed to locate event %d. Please confirm that the entry exists and that "
+"the ID is that of an event."
+msgstr ""
+
+#: includes/wp-cli/class-events.php:135
+#. translators: 1: Event ID, 2: Event action, 3. Event instance
+msgid "Found event %1$d with action `%2$s` and instance identifier `%3$s`"
+msgstr ""
+
+#: includes/wp-cli/class-events.php:141
+#. translators: 1: Time in UTC, 2: Human time diff
+msgid "This event is not scheduled to run until %1$s UTC (%2$s)"
+msgstr ""
+
+#: includes/wp-cli/class-events.php:144
+msgid "Run this event?"
+msgstr ""
+
+#: includes/wp-cli/class-events.php:158
+msgid "Failed to run event"
+msgstr ""
+
+#: includes/wp-cli/class-events.php:193
+msgid "Invalid status specified"
+msgstr ""
+
+#: includes/wp-cli/class-events.php:222
+msgid "Problem retrieving events"
+msgstr ""
+
+#: includes/wp-cli/class-events.php:250
+msgid "Non-repeating"
+msgstr ""
+
+#: includes/wp-cli/class-events.php:252 includes/wp-cli/class-rest-api.php:94
+msgid "n/a"
+msgstr ""
+
+#: includes/wp-cli/class-events.php:260 includes/wp-cli/class-rest-api.php:93
+msgid "true"
+msgstr ""
+
+#: includes/wp-cli/class-events.php:335
+msgid "%s year"
+msgid_plural "%s years"
+msgstr[0] ""
+msgstr[1] ""
+
+#: includes/wp-cli/class-events.php:336
+msgid "%s month"
+msgid_plural "%s months"
+msgstr[0] ""
+msgstr[1] ""
+
+#: includes/wp-cli/class-events.php:337
+msgid "%s week"
+msgid_plural "%s weeks"
+msgstr[0] ""
+msgstr[1] ""
+
+#: includes/wp-cli/class-events.php:338
+msgid "%s day"
+msgid_plural "%s days"
+msgstr[0] ""
+msgstr[1] ""
+
+#: includes/wp-cli/class-events.php:339
+msgid "%s hour"
+msgid_plural "%s hours"
+msgstr[0] ""
+msgstr[1] ""
+
+#: includes/wp-cli/class-events.php:340
+msgid "%s minute"
+msgid_plural "%s minutes"
+msgstr[0] ""
+msgstr[1] ""
+
+#: includes/wp-cli/class-events.php:341
+msgid "%s second"
+msgid_plural "%s seconds"
+msgstr[0] ""
+msgstr[1] ""
+
+#: includes/wp-cli/class-events.php:389
+msgid "Invalid event ID"
+msgstr ""
+
+#: includes/wp-cli/class-events.php:392
+msgid "Locating event..."
+msgstr ""
+
+#: includes/wp-cli/class-events.php:400 includes/wp-cli/class-events.php:448
+msgid ""
+"This is an event created by the Cron Control plugin. It will recreated "
+"automatically."
+msgstr ""
+
+#: includes/wp-cli/class-events.php:404
+#. translators: 1: Event execution time in UTC
+msgid "Execution time: %s UTC"
+msgstr ""
+
+#: includes/wp-cli/class-events.php:406
+#. translators: 1: Event action
+msgid "Action: %s"
+msgstr ""
+
+#: includes/wp-cli/class-events.php:408
+#. translators: 1: Event instance
+msgid "Instance identifier: %s"
+msgstr ""
+
+#: includes/wp-cli/class-events.php:410 includes/wp-cli/class-events.php:528
+msgid "Are you sure you want to delete this event?"
+msgstr ""
+
+#: includes/wp-cli/class-events.php:419
+#. translators: 1: Event ID
+msgid "Failed to delete event %d"
+msgstr ""
+
+#: includes/wp-cli/class-events.php:423
+#. translators: 1: Event ID
+msgid "Removed event %d"
+msgstr ""
+
+#: includes/wp-cli/class-events.php:429
+#. translators: 1: Event ID
+msgid ""
+"Failed to delete event %d. Please confirm that the entry exists and that "
+"the ID is that of an event."
+msgstr ""
+
+#: includes/wp-cli/class-events.php:443
+#: includes/wp-cli/class-orchestrate-runner.php:67
+msgid "Invalid action"
+msgstr ""
+
+#: includes/wp-cli/class-events.php:456
+msgid "Gathering events..."
+msgstr ""
+
+#: includes/wp-cli/class-events.php:463
+#. translators: 1: Total event count
+msgid "Found %s event to check"
+msgid_plural "Found %s events to check"
+msgstr[0] ""
+msgstr[1] ""
+
+#: includes/wp-cli/class-events.php:466
+#. translators: 1: Event action
+msgid "Searching events for those with the action `%s`"
+msgstr ""
+
+#: includes/wp-cli/class-events.php:500
+#. translators: 1: Event action
+msgid "No events with action `%s` found"
+msgstr ""
+
+#: includes/wp-cli/class-events.php:507
+#. translators: 1: Event count, 2: Event action
+msgid "Found %1$s event with action `%2$s`:"
+msgid_plural "Found %1$s events with action `%2$s`:"
+msgstr[0] ""
+msgstr[1] ""
+
+#: includes/wp-cli/class-events.php:524
+#. translators: 1: Event count
+msgid "Events are not displayed as there are more than %s to remove"
+msgstr ""
+
+#: includes/wp-cli/class-events.php:531
+msgid "Deleting events"
+msgstr ""
+
+#: includes/wp-cli/class-events.php:568
+msgid "RESULTS:"
+msgstr ""
+
+#: includes/wp-cli/class-events.php:572
+#. translators: 1: Event ID
+msgid "Deleted one event: %d"
+msgstr ""
+
+#: includes/wp-cli/class-events.php:576
+#. translators: 1: Events deleted
+msgid "Deleted %s events"
+msgstr ""
+
+#: includes/wp-cli/class-events.php:579
+#. translators: 1: Expected deleted-event count, 2: Actual deleted-event count
+msgid ""
+"Expected to delete %1$s events, but could only delete %2$s events. It's "
+"likely that some events were executed while this command ran."
+msgstr ""
+
+#: includes/wp-cli/class-events.php:593
+msgid "Events that couldn't be deleted:"
+msgstr ""
+
+#: includes/wp-cli/class-events.php:596
+msgid "Events deleted:"
+msgstr ""
+
+#: includes/wp-cli/class-events.php:621
+#. translators: 1: Event count
+msgid "Found %s completed event to remove. Continue?"
+msgid_plural "Found %s completed events to remove. Continue?"
+msgstr[0] ""
+msgstr[1] ""
+
+#: includes/wp-cli/class-events.php:625
+msgid "Entries removed"
+msgstr ""
+
+#: includes/wp-cli/class-lock.php:25
+msgid "This lock limits the number of events run concurrently."
+msgstr ""
+
+#: includes/wp-cli/class-lock.php:40
+msgid "Specify an action"
+msgstr ""
+
+#: includes/wp-cli/class-lock.php:48
+msgid ""
+"This lock prevents concurrent executions of events with the same action, "
+"regardless of the action's arguments."
+msgstr ""
+
+#: includes/wp-cli/class-lock.php:67
+#. translators: 1: Lock limit
+msgid "Maximum: %s"
+msgstr ""
+
+#: includes/wp-cli/class-lock.php:71
+msgid "Resetting lock..."
+msgstr ""
+
+#: includes/wp-cli/class-lock.php:77
+#. translators: 1: Previous lock value
+msgid "Previous value: %s"
+msgstr ""
+
+#: includes/wp-cli/class-lock.php:79
+#. translators: 1: Previous lock timestamp
+msgid "Previously modified: %s UTC"
+msgstr ""
+
+#: includes/wp-cli/class-lock.php:81
+msgid "Are you sure you want to reset this lock?"
+msgstr ""
+
+#: includes/wp-cli/class-lock.php:85
+msgid "Lock reset"
+msgstr ""
+
+#: includes/wp-cli/class-lock.php:86
+msgid "New lock values:"
+msgstr ""
+
+#: includes/wp-cli/class-lock.php:94
+#. translators: 1: Current lock value
+msgid "Current value: %s"
+msgstr ""
+
+#: includes/wp-cli/class-lock.php:96
+#. translators: 1: Current lock timestamp
+msgid "Last modified: %s UTC"
+msgstr ""
+
+#: includes/wp-cli/class-one-time-fixers.php:33
+#: includes/wp-cli/class-one-time-fixers.php:97
+msgid "CRON CONTROL"
+msgstr ""
+
+#: includes/wp-cli/class-one-time-fixers.php:40
+#. translators: 1: Event count
+msgid "Found %s total items"
+msgstr ""
+
+#: includes/wp-cli/class-one-time-fixers.php:43
+msgid "Stopping as this is a dry run!"
+msgstr ""
+
+#: includes/wp-cli/class-one-time-fixers.php:46
+#: includes/wp-cli/class-one-time-fixers.php:106
+msgid "No entries found...aborting!"
+msgstr ""
+
+#: includes/wp-cli/class-one-time-fixers.php:51
+msgid "This process will remove all data for the Cron Control plugin"
+msgstr ""
+
+#: includes/wp-cli/class-one-time-fixers.php:52
+#: includes/wp-cli/class-one-time-fixers.php:104
+#: includes/wp-cli/class-one-time-fixers.php:112
+msgid "Proceed?"
+msgstr ""
+
+#: includes/wp-cli/class-one-time-fixers.php:53
+#: includes/wp-cli/class-one-time-fixers.php:113
+msgid "Starting..."
+msgstr ""
+
+#: includes/wp-cli/class-one-time-fixers.php:68
+#. translators: 1: Plugin name
+msgid "Cleared the %s cache"
+msgstr ""
+
+#: includes/wp-cli/class-one-time-fixers.php:75
+#: includes/wp-cli/class-one-time-fixers.php:175
+msgid "All done."
+msgstr ""
+
+#: includes/wp-cli/class-one-time-fixers.php:103
+#. translators: 1: Event count
+msgid "Found %s item"
+msgid_plural "Found %s total items"
+msgstr[0] ""
+msgstr[1] ""
+
+#: includes/wp-cli/class-one-time-fixers.php:111
+msgid "This process will remove all CPT data for the Cron Control plugin"
+msgstr ""
+
+#: includes/wp-cli/class-one-time-fixers.php:124
+#. translators: 1: Batch size
+msgid "Processing in batches of %s"
+msgstr ""
+
+#: includes/wp-cli/class-one-time-fixers.php:136
+#. translators: 1: Current page, 2: total pages
+msgid "Processing page %1$s of %2$s"
+msgstr ""
+
+#: includes/wp-cli/class-one-time-fixers.php:142
+msgid "No more items found!"
+msgstr ""
+
+#: includes/wp-cli/class-one-time-fixers.php:147
+#. translators: 1: Event count for this batch
+msgid "Found %s items in this batch"
+msgstr ""
+
+#: includes/wp-cli/class-orchestrate-runner.php:29
+#: includes/wp-cli/class-orchestrate-runner.php:55
+msgid "Automatic event execution is disabled"
+msgstr ""
+
+#: includes/wp-cli/class-orchestrate-runner.php:63
+msgid "Invalid timestamp"
+msgstr ""
+
+#: includes/wp-cli/class-orchestrate-runner.php:71
+msgid "Invalid instance"
+msgstr ""
+
+#: includes/wp-cli/class-orchestrate-runner.php:77
+#. translators: 1: Event execution time in UTC, 2: Human time diff
+msgid ""
+"Given timestamp is for %1$s UTC, %2$s from now. The event's existence was "
+"not confirmed, and no attempt was made to execute it."
+msgstr ""
+
+#: includes/wp-cli/class-orchestrate.php:26
+msgid "Automatic execution is enabled"
+msgstr ""
+
+#: includes/wp-cli/class-orchestrate.php:30
+msgid "Automatic execution is disabled indefinitely"
+msgstr ""
+
+#: includes/wp-cli/class-orchestrate.php:35
+#. translators: 1: Human time diff, 2: Time execution is disabled until
+msgid "Automatic execution is disabled for %1$s (until %2$s UTC)"
+msgstr ""
+
+#: includes/wp-cli/class-orchestrate.php:61
+msgid "Enabled"
+msgstr ""
+
+#: includes/wp-cli/class-orchestrate.php:65
+msgid "Could not enable automatic execution. Please check the current status."
+msgstr ""
+
+#: includes/wp-cli/class-orchestrate.php:70
+msgid "Disabled"
+msgstr ""
+
+#: includes/wp-cli/class-orchestrate.php:74
+#: includes/wp-cli/class-orchestrate.php:85
+msgid "Could not disable automatic execution. Please check the current status."
+msgstr ""
+
+#: includes/wp-cli/class-orchestrate.php:81
+#. translators: 1: Human time diff, 2: Time execution is disabled until
+msgid "Disabled for %1$s (until %2$s UTC)"
+msgstr ""
+
+#: includes/wp-cli/class-orchestrate.php:87
+msgid "Timestamp is in the past."
+msgstr ""
+
+#: includes/wp-cli/class-orchestrate.php:91
+msgid "Please provide a valid action."
+msgstr ""
+
+#: includes/wp-cli/class-rest-api.php:41
+msgid "No events in the current queue"
+msgstr ""
+
+#: includes/wp-cli/class-rest-api.php:49
+#. translators: 1: Event count
+msgid "Displaying %s event"
+msgid_plural "Displaying %s events"
+msgstr[0] ""
+msgstr[1] ""
+
+#: includes/wp-cli/class-rest-api.php:55
+msgid "Invalid output format requested"
+msgstr ""
+
+#: includes/wp-cli.php:32
+msgid "Cron Control installation completed. Please try again."
+msgstr ""
+
+#. Plugin Name of the plugin/theme
+msgid "Cron Control"
+msgstr ""
+
+#. Plugin URI of the plugin/theme
+msgid "https://vip.wordpress.com/"
+msgstr ""
+
+#. Description of the plugin/theme
+msgid ""
+"Execute WordPress cron events in parallel, using a custom post type for "
+"event storage."
+msgstr ""
+
+#. Author of the plugin/theme
+msgid "Erick Hitter, Automattic"
+msgstr ""

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "cron-control",
+  "version": "1.5.0",
+  "main": "Gruntfile.js",
+  "author": "Automatic",
+  "devDependencies": {
+    "grunt": "~0.4.5",
+    "grunt-wp-i18n": "~0.5.0",
+    "grunt-wp-readme-to-markdown": "~1.0.0"
+  }
+}

--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === Cron Control ===
 Contributors: automattic, ethitter
-Tags: support, user
+Tags: cron, cron control, concurrency, parallel, async
 Requires at least: 4.4
 Tested up to: 4.9
 Requires PHP: 7.0

--- a/readme.txt
+++ b/readme.txt
@@ -1,34 +1,34 @@
-# Cron Control #
-**Contributors:** automattic, ethitter  
-**Tags:** support, user  
-**Requires at least:** 4.4  
-**Tested up to:** 4.9  
-**Requires PHP:** 7.0  
-**Stable tag:** 0.1.0  
-**License:** GPLv2 or later  
-**License URI:** http://www.gnu.org/licenses/gpl-2.0.html  
+=== Cron Control ===
+Contributors: automattic, ethitter
+Tags: support, user
+Requires at least: 4.4
+Tested up to: 4.9
+Requires PHP: 7.0
+Stable tag: 0.1.0
+License: GPLv2 or later
+License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
 Execute WordPress cron events in parallel, with custom event storage for high-volume cron.
 
-## Description ##
+== Description ==
 
 Execute WordPress cron events in parallel, with custom event storage for high-volume cron.
 
 Using REST API endpoints (requires WordPress 4.4+), or a Golang daemon, an event queue is produced and events are triggered.
 
-## Installation ##
+== Installation ==
 
 1. Define `WP_CRON_CONTROL_SECRET` in `wp-config.php`
 1. Upload the `cron-control` directory to the `/wp-content/mu-plugins/` directory
 1. Create a file at `/wp-content/mu-plugins/cron-control.php` to load `/wp-content/mu-plugins/cron-control/cron-control.php`
 
-## Frequently Asked Questions ##
+== Frequently Asked Questions ==
 
-### Why is PHP 7 required? ###
+= Why is PHP 7 required? =
 
 To be able to catch fatal errors triggered by event callbacks, and define arrays in constants (such as for adding "Internal Events"), PHP 7 is necessary.
 
-### Adding Internal Events ###
+= Adding Internal Events =
 
 **This should be done sparingly as "Internal Events" bypass certain locks and limits built into the plugin.** Overuse will lead to unexpected resource usage, and likely resource exhaustion.
 
@@ -58,7 +58,7 @@ array(
 
 Take care to reference the full namespace when appropriate.
 
-### Increasing Event Concurrency ###
+= Increasing Event Concurrency =
 
 In some circumstances, multiple events with the same action can safely run in parallel. This is usually not the case, largely due to Core's alloptions, but sometimes an event is written in a way that we can support concurrent executions.
 
@@ -72,10 +72,10 @@ return $wh;
 } );
 ```
 
-## Changelog ##
+== Changelog ==
 
-### 1.5 ###
+= 1.5 =
 * Convert from custom post type to custom table with proper indices
 
-### 1.0 ###
+= 1.0 =
 * Initial release

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -19,6 +19,14 @@ require_once $_tests_dir . '/includes/functions.php';
 function _manually_load_plugin() {
 	define( 'WP_CRON_CONTROL_SECRET', 'testtesttest' );
 
+	define( 'CRON_CONTROL_ADDITIONAL_INTERNAL_EVENTS', array(
+		array(
+			'schedule' => 'hourly',
+			'action'   => 'cron_control_additional_internal_event',
+			'callback' => '__return_true',
+		),
+	) );
+
 	require dirname( dirname( __FILE__ ) ) . '/cron-control.php';
 
 	// Plugin loads after `wp_install()` is called, so we compensate.

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -31,7 +31,6 @@ function _manually_load_plugin() {
 	define( 'CRON_CONTROL_CACHE_BUCKET_SIZE', 0 );
 	define( 'CRON_CONTROL_MAX_CACHE_BUCKETS', PHP_INT_MAX / 2 );
 
-
 	require dirname( dirname( __FILE__ ) ) . '/cron-control.php';
 
 	// Plugin loads after `wp_install()` is called, so we compensate.

--- a/tests/tests/class-internal-events-tests.php
+++ b/tests/tests/class-internal-events-tests.php
@@ -6,11 +6,14 @@
  */
 
 namespace Automattic\WP\Cron_Control\Tests;
+use Automattic\WP\Cron_Control;
+use Automattic\WP\Cron_Control\Internal_Events;
+use WP_UnitTestCase;
 
 /**
  * Internal Events tests
  */
-class Internal_Events_Tests extends \WP_UnitTestCase {
+class Internal_Events_Tests extends WP_UnitTestCase {
 	/**
 	 * Prepare test environment
 	 */
@@ -19,6 +22,8 @@ class Internal_Events_Tests extends \WP_UnitTestCase {
 
 		// make sure the schedule is clear.
 		_set_cron_array( array() );
+
+		Internal_Events::instance()->schedule_internal_events();
 	}
 
 	/**
@@ -34,17 +39,36 @@ class Internal_Events_Tests extends \WP_UnitTestCase {
 	/**
 	 * Internal events should be scheduled
 	 */
-	function test_events() {
-		\Automattic\WP\Cron_Control\Internal_Events::instance()->schedule_internal_events();
+	function test_events_scheduled() {
+		$events = Cron_Control\collapse_events_array( get_option( 'cron' ) );
 
-		$events = \Automattic\WP\Cron_Control\collapse_events_array( get_option( 'cron' ) );
+		$expected = 4; // Number of events created by the Internal_Events::prepare_internal_events() method, which is private.
+		$expected += count( CRON_CONTROL_ADDITIONAL_INTERNAL_EVENTS );
 
-		// Check that the plugin scheduled the expected number of events.
-		$this->assertEquals( count( $events ), 4 );
+		$this->assertEquals( count( $events ), $expected, 'Incorrect number of Internal Events registered' );
+	}
 
-		// Confirm that the scheduled jobs came from the Internal Events class.
+	/**
+	 * Test that all scheduled events are from the Internal Events class
+	 */
+	function test_events_are_internal() {
+		$events = Cron_Control\collapse_events_array( get_option( 'cron' ) );
+
 		foreach ( $events as $event ) {
-			$this->assertTrue( \Automattic\WP\Cron_Control\is_internal_event( $event['action'] ) );
+			$this->assertTrue( Cron_Control\is_internal_event( $event['action'] ), sprintf( 'Action `%s` is not an Internal Event', $event['action'] ) );
+		}
+	}
+
+	/**
+	 * Test that additional Internal Events can be added
+	 */
+	function test_add_events() {
+		$additional = CRON_CONTROL_ADDITIONAL_INTERNAL_EVENTS;
+
+		foreach ( $additional as $added ) {
+			$next = wp_next_scheduled( $added['action'], array() );
+
+			$this->assertInternalType( 'int', $next, sprintf( 'Additional Internal Event `%s` not scheduled', $added['action'] ) );
 		}
 	}
 }

--- a/tests/tests/class-internal-events-tests.php
+++ b/tests/tests/class-internal-events-tests.php
@@ -43,7 +43,7 @@ class Internal_Events_Tests extends WP_UnitTestCase {
 		$events = Cron_Control\collapse_events_array( get_option( 'cron' ) );
 
 		$expected = 4; // Number of events created by the Internal_Events::prepare_internal_events() method, which is private.
-		$expected += count( CRON_CONTROL_ADDITIONAL_INTERNAL_EVENTS );
+		$expected += count( \CRON_CONTROL_ADDITIONAL_INTERNAL_EVENTS );
 
 		$this->assertEquals( count( $events ), $expected, 'Incorrect number of Internal Events registered' );
 	}
@@ -63,7 +63,7 @@ class Internal_Events_Tests extends WP_UnitTestCase {
 	 * Test that additional Internal Events can be added
 	 */
 	function test_add_events() {
-		$additional = CRON_CONTROL_ADDITIONAL_INTERNAL_EVENTS;
+		$additional = \CRON_CONTROL_ADDITIONAL_INTERNAL_EVENTS;
 
 		foreach ( $additional as $added ) {
 			$next = wp_next_scheduled( $added['action'], array() );


### PR DESCRIPTION
It could be helpful to allow a limited number of custom "internal events" while maintaining/protecting the plugin's events.