### PR TITLE
Ensure the plugin's CLI namespace gets a proper top-level representation

### DIFF
--- a/includes/wp-cli.php
+++ b/includes/wp-cli.php
@@ -72,6 +72,7 @@ function stop_the_insanity() {
 /**
  * Load commands
  */
+require __DIR__ . '/wp-cli/class-main.php';
 require __DIR__ . '/wp-cli/class-cache.php';
 require __DIR__ . '/wp-cli/class-events.php';
 require __DIR__ . '/wp-cli/class-lock.php';

--- a/includes/wp-cli/class-main.php
+++ b/includes/wp-cli/class-main.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Top-level CLI command
+ *
+ * Mostly exists for WP-CLI to provide better documentation
+ *
+ * @package a8c_Cron_Control
+ */
+
+namespace Automattic\WP\Cron_Control\CLI;
+use WP_CLI;
+
+/**
+ * Manage Cron Control, including its data store, caches, and locks
+ */
+class Main extends \WP_CLI_Command {}
+WP_CLI::add_command( 'cron-control', 'Automattic\WP\Cron_Control\CLI\Main' );


### PR DESCRIPTION
Since we nest many commands under one namespace, there isn't actually a command registered as `cron-control`, which breaks some output. For example, there's no tip shown when `wp` is called.

This is trivial, but it's always bothered me. :)