### PR TITLE
Correct how query is prepared, per WP 4.8.3

### DIFF
--- a/includes/class-events-store.php
+++ b/includes/class-events-store.php
@@ -480,14 +480,11 @@ class Events_Store extends Singleton {
 		}
 
 		// Do not sort, otherwise index isn't used.
-		$query = $wpdb->prepare( "SELECT * FROM {$this->get_table_name()} WHERE timestamp = %d AND {$action_column} = %s AND instance = %s", $attrs['timestamp'], $action_value, $attrs['instance'] );  // Cannot prepare table or column names. @codingStandardsIgnoreLine
-
-		// Final query preparations.
-		if ( 'any' !== $attrs['status'] ) {
-			$query .= $wpdb->prepare( ' AND status = %s', $attrs['status'] );
+		if ( 'any' === $attrs['status'] ) {
+			$query = $wpdb->prepare( "SELECT * FROM {$this->get_table_name()} WHERE timestamp = %d AND {$action_column} = %s AND instance = %s LIMIT 1", $attrs['timestamp'], $action_value, $attrs['instance'] );  // Cannot prepare table or column names. @codingStandardsIgnoreLine
+		} else {
+			$query = $wpdb->prepare( "SELECT * FROM {$this->get_table_name()} WHERE timestamp = %d AND {$action_column} = %s AND instance = %s AND status = %s LIMIT 1", $attrs['timestamp'], $action_value, $attrs['instance'], $attrs['status'] );  // Cannot prepare table or column names. @codingStandardsIgnoreLine
 		}
-
-		$query .= ' LIMIT 1';
 
 		// Query and format results.
 		$job = $wpdb->get_row( $query ); // Already prepared. @codingStandardsIgnoreLine

--- a/tests/tests/class-events-store-tests.php
+++ b/tests/tests/class-events-store-tests.php
@@ -171,4 +171,49 @@ class Events_Store_Tests extends \WP_UnitTestCase {
 		$this->assertEquals( 4,   $cached['buckets'] );
 		$this->assertEquals( 100, $cached['event_count'] );
 	}
+
+	/**
+	 * Test retrieving an event without requesting a status
+	 */
+	function test_get_job_by_attributes() {
+		$event = Utils::create_test_event();
+
+		$event_from_store = \Automattic\WP\Cron_Control\get_event_by_attributes( [
+			'timestamp' => $event['timestamp'],
+			'action'    => $event['action'],
+			'instance'  => md5( maybe_serialize( $event['args'] ) ),
+		] );
+
+		$this->assertInternalType( 'object', $event_from_store );
+	}
+
+	/**
+	 * Test retrieving an event with any status
+	 */
+	function test_get_job_by_attributes_with_any_status() {
+		$event = Utils::create_test_event();
+
+		$event_from_store = \Automattic\WP\Cron_Control\get_event_by_attributes( [
+			'timestamp' => $event['timestamp'],
+			'action'    => $event['action'],
+			'instance'  => md5( maybe_serialize( $event['args'] ) ),
+			'status'    => 'any',
+		] );
+
+		$this->assertInternalType( 'object', $event_from_store );
+	}
+
+	/**
+	 * Test retrieving an event with insufficient information
+	 */
+	function test_get_job_by_attributes_with_insufficient_args() {
+		$event = Utils::create_test_event();
+
+		$event_from_store = \Automattic\WP\Cron_Control\get_event_by_attributes( [
+			'timestamp' => $event['timestamp'],
+			'action'    => $event['action'],
+		] );
+
+		$this->assertFalse( $event_from_store );
+	}
 }


### PR DESCRIPTION
Don't prepare query piecemeal, as it's the wrong way to use `$wpdb->prepare()`.