### PR TITLE
Exit without an error status when event is not found

### DIFF
--- a/includes/wp-cli/class-events.php
+++ b/includes/wp-cli/class-events.php
@@ -128,7 +128,9 @@ class Events extends \WP_CLI_Command {
 
 		if ( ! is_object( $event ) ) {
 			/* translators: 1: Event ID */
-			\WP_CLI::error( sprintf( __( 'Failed to locate event %d. Please confirm that the entry exists and that the ID is that of an event.', 'automattic-cron-control' ), $args[0] ) );
+			\WP_CLI::warning( sprintf( __( 'Failed to locate event %d. Please confirm that the entry exists and that the ID is that of an event.', 'automattic-cron-control' ), $args[0] ) );
+
+			exit;
 		}
 
 		/* translators: 1: Event ID, 2: Event action, 3. Event instance */

--- a/includes/wp-cli/class-events.php
+++ b/includes/wp-cli/class-events.php
@@ -128,9 +128,7 @@ class Events extends \WP_CLI_Command {
 
 		if ( ! is_object( $event ) ) {
 			/* translators: 1: Event ID */
-			\WP_CLI::warning( sprintf( __( 'Failed to locate event %d. Please confirm that the entry exists and that the ID is that of an event.', 'automattic-cron-control' ), $args[0] ) );
-
-			exit;
+			\WP_CLI::error( sprintf( __( 'Failed to locate event %d. Please confirm that the entry exists and that the ID is that of an event.', 'automattic-cron-control' ), $args[0] ) );
 		}
 
 		/* translators: 1: Event ID, 2: Event action, 3. Event instance */

--- a/includes/wp-cli/class-orchestrate-runner.php
+++ b/includes/wp-cli/class-orchestrate-runner.php
@@ -84,7 +84,13 @@ class Orchestrate_Runner extends \WP_CLI_Command {
 		$run = \Automattic\WP\Cron_Control\run_event( $timestamp, $action, $instance );
 
 		if ( is_wp_error( $run ) ) {
-			\WP_CLI::error( $run->get_error_message() );
+			$error_data = $run->get_error_data();
+
+			if ( isset( $error_data['status'] ) && 404 === $error_data['status'] ) {
+				\WP_CLI::success( $run->get_error_message() );
+			} else {
+				\WP_CLI::error( $run->get_error_message() );
+			}
 		} elseif ( isset( $run['success'] ) && true === $run['success'] ) {
 			\WP_CLI::success( $run['message'] );
 		} else {

--- a/includes/wp-cli/class-orchestrate-runner.php
+++ b/includes/wp-cli/class-orchestrate-runner.php
@@ -87,7 +87,9 @@ class Orchestrate_Runner extends \WP_CLI_Command {
 			$error_data = $run->get_error_data();
 
 			if ( isset( $error_data['status'] ) && 404 === $error_data['status'] ) {
-				\WP_CLI::success( $run->get_error_message() );
+				\WP_CLI::warning( $run->get_error_message() );
+
+				exit;
 			} else {
 				\WP_CLI::error( $run->get_error_message() );
 			}


### PR DESCRIPTION
This situation is ‘normal’ in multi-process runners, as one runner may
have picked up the job before another job attempts it.

When that happens, we shouldn’t treat it as an error - rather log it,
and exit normally.

Fixes #150