### PR TITLE
Add Cron Runner graceful service exit

### DIFF
--- a/runner/init.sh
+++ b/runner/init.sh
@@ -48,7 +48,7 @@ case $1 in
   if [ -e $PIDFILE ]; then
    status_of_proc -p $PIDFILE $DAEMON "Stoppping the $NAME process" && status="0" || status="$?"
    if [ "$status" = 0 ]; then
-    start-stop-daemon --stop --quiet --oknodo --pidfile $PIDFILE
+    start-stop-daemon --stop --retry=TERM/60/KILL/5 --quiet --oknodo --pidfile $PIDFILE
     /bin/rm -rf $PIDFILE
    fi
   else

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -295,6 +295,8 @@ func getMultisiteSites() ([]site, error) {
 
 func queueSiteEvents(workerID int, sites <-chan site, queue chan<- event) {
 	gEventRetrieversRunning[workerID-1] = true
+	logger.Printf("started retriever %d\n", workerID)
+
 OuterLoop:
 	for site := range sites {
 		if gRestart {
@@ -341,6 +343,7 @@ func getSiteEvents(site string) ([]event, error) {
 
 func runEvents(workerID int, events <-chan event) {
 	gEventWorkersRunning[workerID-1] = true
+	logger.Printf("started event worker %d\n", workerID)
 
 	for event := range events {
 		if gRestart {

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -469,6 +469,7 @@ func waitForEpoch(whom string, epoch_sec int64) {
 	// all Cron Runners having their epochs at exactly the same time.
 	_, found := gRandomDeltaMap[whom]
 	if !found {
+		rand.Seed(time.Now().UnixNano() + epoch_sec)
 		gRandomDeltaMap[whom] = rand.Int63n(tEpochNano)
 	}
 

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -42,7 +42,7 @@ var (
 
 	getEventsInterval int
 
-	heartbeatInt int
+	heartbeatInt int64
 
 	disabledLoopCount    uint64
 	eventRunErrCount     uint64
@@ -58,8 +58,8 @@ var (
 	gSiteRetrieverRunning   bool
 )
 
-const getEventsBreak time.Duration = time.Second
-const runEventsBreak time.Duration = time.Second * 10
+const getEventsBreakSec time.Duration = time.Second
+const runEventsBreakSec int64 = 10
 
 func init() {
 	flag.StringVar(&wpCliPath, "cli", "/usr/local/bin/wp", "Path to WP-CLI binary")
@@ -68,7 +68,7 @@ func init() {
 	flag.IntVar(&numGetWorkers, "workers-get", 1, "Number of workers to retrieve events")
 	flag.IntVar(&numRunWorkers, "workers-run", 5, "Number of workers to run events")
 	flag.IntVar(&getEventsInterval, "get-events-interval", 60, "Seconds between event retrieval")
-	flag.IntVar(&heartbeatInt, "heartbeat", 60, "Heartbeat interval in seconds")
+	flag.Int64Var(&heartbeatInt, "heartbeat", 60, "Heartbeat interval in seconds")
 	flag.StringVar(&logDest, "log", "os.Stdout", "Log path, omit to log to Stdout")
 	flag.BoolVar(&debug, "debug", false, "Include additional log data for debugging")
 	flag.Parse()

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -174,6 +174,29 @@ func heartbeat() {
 		atomic.SwapUint64(&eventRunErrCount, 0)
 		logger.Printf("<heartbeat eventsSucceededSinceLast=%d eventsErroredSinceLast=%d>", successCount, errCount)
 	}
+
+ExitLoop:
+	for {
+		time.Sleep(time.Duration(1) * time.Second)
+		if gSiteRetrieverRunning {
+			logger.Println("site retriever is still running")
+			continue
+		}
+		for workerID, r := range gEventRetrieversRunning {
+			if true == r {
+				logger.Printf("event retriever ID %d still running\n", workerID)
+				continue ExitLoop
+			}
+		}
+		for workerID, r := range gEventWorkersRunning {
+			if true == r {
+				logger.Printf("event worker ID %d still running\n", workerID)
+				continue ExitLoop
+			}
+		}
+		logger.Println(".:sayonara:.")
+		os.Exit(0)
+	}
 }
 
 func getSites() ([]site, error) {

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -119,10 +119,10 @@ func spawnEventWorkers(queue <-chan event) {
 }
 
 func retrieveSitesPeriodically(sites chan<- site) {
-	loopInterval := time.Duration(getEventsInterval) * time.Second
 	gSiteRetrieverRunning = true
 
-	for range time.Tick(loopInterval) {
+	for {
+		waitForEpoch("retrieveSitesPeriodically", int64(getEventsInterval))
 		siteList, err := getSites()
 		if err != nil {
 			continue
@@ -142,9 +142,8 @@ func heartbeat() {
 		return
 	}
 
-	interval := time.Duration(heartbeatInt) * time.Second
-
-	for range time.Tick(interval) {
+	for {
+		waitForEpoch("heartbeat", heartbeatInt)
 		successCount, errCount := atomic.LoadUint64(&eventRunSuccessCount), atomic.LoadUint64(&eventRunErrCount)
 		atomic.SwapUint64(&eventRunSuccessCount, 0)
 		atomic.SwapUint64(&eventRunErrCount, 0)

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -360,7 +360,8 @@ func runEvents(workerID int, events <-chan event) {
 			continue
 		}
 
-		subcommand := []string{"cron-control", "orchestrate", "runner-only", "run", fmt.Sprintf("--timestamp=%d", event.Timestamp), fmt.Sprintf("--action=%s", event.Action), fmt.Sprintf("--instance=%s", event.Instance), fmt.Sprintf("--url=%s", event.URL)}
+		subcommand := []string{"cron-control", "orchestrate", "runner-only", "run", fmt.Sprintf("--timestamp=%d", event.Timestamp),
+			fmt.Sprintf("--action=%s", event.Action), fmt.Sprintf("--instance=%s", event.Instance), fmt.Sprintf("--url=%s", event.URL)}
 
 		_, err := runWpCliCmd(subcommand)
 

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -59,7 +59,7 @@ var (
 	gRandomDeltaMap         map[string]int64
 )
 
-const getEventsBreakSec time.Duration = time.Second
+const getEventsBreakSec time.Duration = 1 * time.Second
 const runEventsBreakSec int64 = 10
 
 func init() {

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -298,7 +298,7 @@ func queueSiteEvents(workerID int, sites <-chan site, queue chan<- event) {
 OuterLoop:
 	for site := range sites {
 		if gRestart {
-			logger.Printf("exiting event retriever ID %d", workerID)
+			logger.Printf("exiting event retriever ID %d\n", workerID)
 			break
 		}
 		if debug {
@@ -344,7 +344,7 @@ func runEvents(workerID int, events <-chan event) {
 
 	for event := range events {
 		if gRestart {
-			logger.Printf("exiting event worker ID %d", workerID)
+			logger.Printf("exiting event worker ID %d\n", workerID)
 			break
 		}
 		if now := time.Now(); event.Timestamp > int(now.Unix()) {
@@ -374,7 +374,7 @@ func runEvents(workerID int, events <-chan event) {
 
 		waitForEpoch("runEvents", runEventsBreakSec)
 		if gRestart {
-			logger.Printf("exiting event worker ID %d", workerID)
+			logger.Printf("exiting event worker ID %d\n", workerID)
 			break
 		}
 

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -182,9 +182,9 @@ func heartbeat(sites chan<- site, queue chan<- event) {
 		for workerID, r := range gEventWorkersRunning {
 			if r {
 				logger.Printf("event worker ID %d still running\n", workerID+1)
-				StillRunning = true
 				logger.Printf("sending empty event for worker %d\n", workerID+1)
 				queue <- event{}
+				StillRunning = true
 			}
 		}
 		if StillRunning {


### PR DESCRIPTION
* Move away from ranging over timer ticks to a `waitForEpoch` utility function, which allows us to keep an eye on signal handling.
* Add global variables to monitor service routines and worker running states for graceful exit.