### PR TITLE
Add CLI command and function to delete events by schedule

### DIFF
--- a/includes/class-events-store.php
+++ b/includes/class-events-store.php
@@ -861,7 +861,7 @@ class Events_Store extends Singleton {
 	/**
 	 * Remove entries by schedule
 	 *
-	 * @param bool $count_first Should events be counted before they're deleted.
+	 * @param string $schedule Should events be counted before they're deleted.
 	 */
 	public function delete_events_by_schedule( $schedule ) {
 		global $wpdb;

--- a/includes/class-events-store.php
+++ b/includes/class-events-store.php
@@ -857,6 +857,41 @@ class Events_Store extends Singleton {
 
 		return (int) $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(ID) FROM {$this->get_table_name()} WHERE status = %s", $status ) ); // Cannot prepare table name. @codingStandardsIgnoreLine
 	}
+
+	/**
+	 * Remove entries for non-recurring events that have been run
+	 *
+	 * @param bool $count_first Should events be counted before they're deleted.
+	 */
+	public function delete_events_by_schedule( $schedule ) {
+		global $wpdb;
+
+		return $wpdb->delete(
+			$this->get_table_name(), array(
+				'schedule' => $schedule,
+			)
+		);
+	}
+
+	/**
+	 * Count number of events with a given schedule
+	 *
+	 * @param string $schedule Event schedule to count.
+	 * @return int|false
+	 */
+	public function count_events_by_schedule( $schedule ) {
+		global $wpdb;
+
+		$sql = '';
+
+		if ( is_null( $schedule ) ) {
+			$sql = "SELECT COUNT(ID) FROM {$this->get_table_name()} WHERE schedule IS NULL"; // Cannot prepare table name. @codingStandardsIgnoreLine
+		} else {
+			$sql = $wpdb->prepare( "SELECT COUNT(ID) FROM {$this->get_table_name()} WHERE schedule = %s", $schedule ); // Cannot prepare table name. @codingStandardsIgnoreLine
+		}
+
+		return (int) $wpdb->get_var( $sql );
+	}
 }
 
 Events_Store::instance();

--- a/includes/class-events-store.php
+++ b/includes/class-events-store.php
@@ -859,7 +859,7 @@ class Events_Store extends Singleton {
 	}
 
 	/**
-	 * Remove entries for non-recurring events that have been run
+	 * Remove entries by schedule
 	 *
 	 * @param bool $count_first Should events be counted before they're deleted.
 	 */

--- a/includes/class-events-store.php
+++ b/includes/class-events-store.php
@@ -861,7 +861,7 @@ class Events_Store extends Singleton {
 	/**
 	 * Remove entries by schedule
 	 *
-	 * @param string $schedule Should events be counted before they're deleted.
+	 * @param string|null $schedule The schedule to remove events for
 	 */
 	public function delete_events_by_schedule( $schedule ) {
 		global $wpdb;
@@ -876,7 +876,7 @@ class Events_Store extends Singleton {
 	/**
 	 * Count number of events with a given schedule
 	 *
-	 * @param string $schedule Event schedule to count.
+	 * @param string|null $schedule Event schedule to count.
 	 * @return int|false
 	 */
 	public function count_events_by_schedule( $schedule ) {

--- a/includes/class-events-store.php
+++ b/includes/class-events-store.php
@@ -866,11 +866,15 @@ class Events_Store extends Singleton {
 	public function delete_events_by_schedule( $schedule ) {
 		global $wpdb;
 
-		return $wpdb->delete(
+		$result = $wpdb->delete(
 			$this->get_table_name(), array(
 				'schedule' => $schedule,
 			)
 		);
+
+		$this->flush_internal_caches();
+
+		return $result;
 	}
 
 	/**

--- a/includes/class-events-store.php
+++ b/includes/class-events-store.php
@@ -885,12 +885,10 @@ class Events_Store extends Singleton {
 		$sql = '';
 
 		if ( is_null( $schedule ) ) {
-			$sql = "SELECT COUNT(ID) FROM {$this->get_table_name()} WHERE schedule IS NULL"; // Cannot prepare table name. @codingStandardsIgnoreLine
+			return (int) $wpdb->get_var( "SELECT COUNT(ID) FROM {$this->get_table_name()} WHERE schedule IS NULL" ); // Cannot prepare table name. @codingStandardsIgnoreLine
 		} else {
-			$sql = $wpdb->prepare( "SELECT COUNT(ID) FROM {$this->get_table_name()} WHERE schedule = %s", $schedule ); // Cannot prepare table name. @codingStandardsIgnoreLine
+			return (int) $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(ID) FROM {$this->get_table_name()} WHERE schedule = %s", $schedule ) ); // Cannot prepare table name. @codingStandardsIgnoreLine
 		}
-
-		return (int) $wpdb->get_var( $sql );
 	}
 }
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -150,7 +150,7 @@ function count_events_by_status( $status ) {
  * Count events with a given schedule
  *
  * @param string $schedule Schedule to count.
- * @return int|false
+ * @return int|null
  */
 function count_events_by_schedule( $schedule ) {
 	return Events_Store::instance()->count_events_by_schedule( $schedule );

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -147,6 +147,16 @@ function count_events_by_status( $status ) {
 }
 
 /**
+ * Count events with a given schedule
+ *
+ * @param string $schedule Schedule to count.
+ * @return int|false
+ */
+function count_events_by_schedule( $schedule ) {
+	return Events_Store::instance()->count_events_by_schedule( $schedule );
+}
+
+/**
  * Flush plugin's internal caches
  *
  * FOR INTERNAL USE ONLY - see WP-CLI; all other cache clearance should happen automatically through the `Events_Store` class

--- a/includes/wp-cli/class-events.php
+++ b/includes/wp-cli/class-events.php
@@ -85,7 +85,7 @@ class Events extends \WP_CLI_Command {
 	 * Remove events
 	 *
 	 * @subcommand delete
-	 * @synopsis [--event_id=<event_id>] [--action=<action>] [--completed]
+	 * @synopsis [--event_id=<event_id>] [--action=<action>] [--completed] [--schedule=<schedule>]
 	 * @param array $args Array of positional arguments.
 	 * @param array $assoc_args Array of flags.
 	 */
@@ -99,6 +99,11 @@ class Events extends \WP_CLI_Command {
 		// Remove all events with a given action.
 		if ( isset( $assoc_args['action'] ) ) {
 			$this->delete_event_by_action( $args, $assoc_args );
+			return;
+		}
+
+		if ( isset( $assoc_args['schedule'] ) ) {
+			$this->delete_events_by_schedule( $args, $assoc_args );
 			return;
 		}
 
@@ -631,6 +636,27 @@ class Events extends \WP_CLI_Command {
 		\WP_CLI::confirm( sprintf( _n( 'Found %s completed event to remove. Continue?', 'Found %s completed events to remove. Continue?', $count, 'automattic-cron-control' ), number_format_i18n( $count ) ) );
 
 		\Automattic\WP\Cron_Control\Events_Store::instance()->purge_completed_events( false );
+
+		\WP_CLI::success( __( 'Entries removed', 'automattic-cron-control' ) );
+	}
+
+	/**
+	 * Delete events that have a particular schedule
+	 *
+	 * @param array $args Array of positional arguments.
+	 * @param array $assoc_args Array of flags.
+	 */
+	private function delete_events_by_schedule( $args, $assoc_args ) {
+		if ( 'null' === strtolower( $assoc_args['schedule'] ) ) {
+			$assoc_args['schedule'] = null;
+		}
+
+		$count = \Automattic\WP\Cron_Control\count_events_by_schedule( $assoc_args['schedule'] );
+
+		/* translators: 1: Event count */
+		\WP_CLI::confirm( sprintf( _n( 'Found %s single event to remove. Continue?', 'Found %s single events to remove. Continue?', $count, 'automattic-cron-control' ), number_format_i18n( $count ) ) );
+
+		\Automattic\WP\Cron_Control\Events_Store::instance()->delete_events_by_schedule( $assoc_args['schedule'] );
 
 		\WP_CLI::success( __( 'Entries removed', 'automattic-cron-control' ) );
 	}

--- a/includes/wp-cli/class-events.php
+++ b/includes/wp-cli/class-events.php
@@ -656,7 +656,7 @@ class Events extends \WP_CLI_Command {
 		$count = \Automattic\WP\Cron_Control\count_events_by_schedule( $assoc_args['schedule'] );
 
 		/* translators: 1: Event count */
-		\WP_CLI::confirm( sprintf( _n( 'Found %s single event to remove. Continue?', 'Found %s single events to remove. Continue?', $count, 'automattic-cron-control' ), number_format_i18n( $count ) ) );
+		\WP_CLI::confirm( sprintf( _n( 'Found %s event to remove. Continue?', 'Found %s events to remove. Continue?', $count, 'automattic-cron-control' ), number_format_i18n( $count ) ) );
 
 		\Automattic\WP\Cron_Control\Events_Store::instance()->delete_events_by_schedule( $assoc_args['schedule'] );
 

--- a/includes/wp-cli/class-events.php
+++ b/includes/wp-cli/class-events.php
@@ -647,6 +647,8 @@ class Events extends \WP_CLI_Command {
 	 * @param array $assoc_args Array of flags.
 	 */
 	private function delete_events_by_schedule( $args, $assoc_args ) {
+		// If the schedule option is the string 'null', we want to delete events with
+		// no recurring schedule
 		if ( 'null' === strtolower( $assoc_args['schedule'] ) ) {
 			$assoc_args['schedule'] = null;
 		}

--- a/tests/tests/class-events-store-tests.php
+++ b/tests/tests/class-events-store-tests.php
@@ -221,6 +221,11 @@ class Events_Store_Tests extends \WP_UnitTestCase {
 	 * Test deleting events by schedule
 	 */
 	function test_delete_events_by_schedule() {
+		$timestamp_base = time() + ( 1 * \HOUR_IN_SECONDS );
+
+		$dummy_text = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam enim ante, maximus nec nisi ut, finibus ultrices orci. Maecenas suscipit, est eu suscipit sagittis, enim massa dignissim augue, sagittis gravida dolor nulla ut mi. Phasellus venenatis bibendum cursus. Aliquam a erat purus. Nulla elit nunc, egestas eget eros iaculis, interdum tincidunt elit. Vivamus vel blandit nisl. Proin in ornare dolor, convallis porta sem. Mauris rutrum nibh et ornare egestas. Mauris ultricies diam at nunc tristique rutrum. Aliquam varius non leo vel luctus. Vestibulum sagittis scelerisque ante, non faucibus nibh accumsan sed.';
+		$args       = array_fill( 0, 15, $dummy_text );
+
 		// Single events
 		for ( $i = 1; $i <= 100; $i++ ) {
 			$timestamp = $timestamp_base + $i;

--- a/tests/tests/class-events-store-tests.php
+++ b/tests/tests/class-events-store-tests.php
@@ -239,6 +239,6 @@ class Events_Store_Tests extends \WP_UnitTestCase {
 		// Ensure we have none now
 		$count = \Automattic\WP\Cron_Control\count_events_by_schedule( null );
 
-		$this->assertEquals( $count, 0 );
+		$this->assertEquals( 0, $count );
 	}
 }

--- a/tests/tests/class-events-store-tests.php
+++ b/tests/tests/class-events-store-tests.php
@@ -216,4 +216,24 @@ class Events_Store_Tests extends \WP_UnitTestCase {
 
 		$this->assertFalse( $event_from_store );
 	}
+
+	/**
+	 * Test deleting events by schedule
+	 */
+	function test_delete_events_by_schedule() {
+		// Single events
+		for ( $i = 1; $i <= 100; $i++ ) {
+			$timestamp = $timestamp_base + $i;
+			$action    = 'excessive_test_event_' . $i;
+			wp_schedule_single_event( $timestamp, $action, $args );
+		}
+
+		// Delete them
+		\Automattic\WP\Cron_Control\Events_Store::instance()->delete_events_by_schedule( 'null');
+
+		// Ensure we have none now
+		$count = \Automattic\WP\Cron_Control\count_events_by_schedule( null );
+
+		$this->assertEquals( $count, 0 );
+	}
 }

--- a/tests/tests/class-events-store-tests.php
+++ b/tests/tests/class-events-store-tests.php
@@ -234,7 +234,7 @@ class Events_Store_Tests extends \WP_UnitTestCase {
 		}
 
 		// Delete them
-		\Automattic\WP\Cron_Control\Events_Store::instance()->delete_events_by_schedule( 'null');
+		\Automattic\WP\Cron_Control\Events_Store::instance()->delete_events_by_schedule( null );
 
 		// Ensure we have none now
 		$count = \Automattic\WP\Cron_Control\count_events_by_schedule( null );


### PR DESCRIPTION
Sometimes it's useful to remove all events that have a given schedule. 

Specifically, we want to use this to clean out all one-time events when syncing a database between a production and pre-production environment on VIP Go.