### PR TITLE
Reduce number of queries from get_option

### DIFF
--- a/includes/class-events-store.php
+++ b/includes/class-events-store.php
@@ -34,6 +34,8 @@ class Events_Store extends Singleton {
 	);
 
 	const CACHE_KEY = 'a8c_cron_ctrl_option';
+	
+	private $invalid_cache = false;
 
 	/**
 	 * Whether or not event creation is temporarily blocked
@@ -257,11 +259,12 @@ class Events_Store extends Singleton {
 		// remotely multiple times per request (even from the
 		// object cache).
 		static $cron_array;
-		if ( $cron_array ) {
+		if ( $cron_array && ! $this->invalid_cache ) {
 			return $cron_array;
 		}
 		
 		// Use cached value when available.
+		$this->invalid_cache = false;
 		$cached_option = $this->get_cached_option();
 
 		if ( false !== $cached_option ) {
@@ -800,6 +803,7 @@ class Events_Store extends Singleton {
 	 * Delete the cached representation of the cron option
 	 */
 	public function flush_internal_caches() {
+		$this->invalid_cache = true;
 		return wp_cache_delete( self::CACHE_KEY );
 	}
 

--- a/includes/class-events-store.php
+++ b/includes/class-events-store.php
@@ -265,7 +265,7 @@ class Events_Store extends Singleton {
 
 		// Get events to re-render as the cron option.
 		$page     = 1;
-		$quantity = 100;
+		$quantity = 5000;
 
 		do {
 			$jobs = $this->get_jobs(

--- a/includes/class-events-store.php
+++ b/includes/class-events-store.php
@@ -40,7 +40,7 @@ class Events_Store extends Singleton {
 	 *
 	 * @var bool
 	 */
-	private $invalid_cache = false;
+	private $is_option_cache_valid = false;
 
 	/**
 	 * Whether or not event creation is temporarily blocked
@@ -264,12 +264,12 @@ class Events_Store extends Singleton {
 		// remotely multiple times per request (even from the
 		// object cache).
 		static $cron_array;
-		if ( $cron_array && ! $this->invalid_cache ) {
+		if ( $cron_array && true === $this->is_option_cache_valid ) {
 			return $cron_array;
 		}
 
 		// Use cached value when available.
-		$this->invalid_cache = false;
+		$this->is_option_cache_valid = true;
 		$cached_option = $this->get_cached_option();
 
 		if ( false !== $cached_option ) {
@@ -808,7 +808,7 @@ class Events_Store extends Singleton {
 	 * Delete the cached representation of the cron option
 	 */
 	public function flush_internal_caches() {
-		$this->invalid_cache = true;
+		$this->is_option_cache_valid = false;
 		return wp_cache_delete( self::CACHE_KEY );
 	}
 

--- a/includes/class-events-store.php
+++ b/includes/class-events-store.php
@@ -251,6 +251,16 @@ class Events_Store extends Singleton {
 	 * Override cron option requests with data from custom table
 	 */
 	public function get_option() {
+		
+		// If this thread has already generated the cron array,
+		// use the copy from local memory. Don't fetch this list
+		// remotely multiple times per request (even from the
+		// object cache).
+		static $cron_array;
+		if ( $cron_array ) {
+			return $cron_array;
+		}
+		
 		// Use cached value when available.
 		$cached_option = $this->get_cached_option();
 

--- a/includes/class-events-store.php
+++ b/includes/class-events-store.php
@@ -34,7 +34,12 @@ class Events_Store extends Singleton {
 	);
 
 	const CACHE_KEY = 'a8c_cron_ctrl_option';
-	
+
+	/**
+	 * Whether the static option cache is invalid
+	 *
+	 * @var bool
+	 */
 	private $invalid_cache = false;
 
 	/**
@@ -253,7 +258,7 @@ class Events_Store extends Singleton {
 	 * Override cron option requests with data from custom table
 	 */
 	public function get_option() {
-		
+
 		// If this thread has already generated the cron array,
 		// use the copy from local memory. Don't fetch this list
 		// remotely multiple times per request (even from the
@@ -262,7 +267,7 @@ class Events_Store extends Singleton {
 		if ( $cron_array && ! $this->invalid_cache ) {
 			return $cron_array;
 		}
-		
+
 		// Use cached value when available.
 		$this->invalid_cache = false;
 		$cached_option = $this->get_cached_option();

--- a/includes/class-events-store.php
+++ b/includes/class-events-store.php
@@ -268,8 +268,9 @@ class Events_Store extends Singleton {
 			return $cron_array;
 		}
 
-		// Use cached value when available.
 		$this->is_option_cache_valid = true;
+
+		// Use cached value when available.
 		$cached_option = $this->get_cached_option();
 
 		if ( false !== $cached_option ) {

--- a/includes/wp-cli.php
+++ b/includes/wp-cli.php
@@ -65,7 +65,7 @@ function stop_the_insanity() {
 	$wp_object_cache->cache          = array();
 
 	if ( is_callable( $wp_object_cache, '__remoteset' ) ) {
-		$wp_object_cache->__remoteset(); // important!
+		$wp_object_cache->__remoteset();
 	}
 }
 

--- a/includes/wp-cli/class-events.php
+++ b/includes/wp-cli/class-events.php
@@ -58,7 +58,6 @@ class Events extends \WP_CLI_Command {
 				\WP_CLI::log( sprintf( __( 'Displaying %1$s of %2$s entries, page %3$s of %4$s', 'automattic-cron-control' ), number_format_i18n( $total_events_to_display ), number_format_i18n( $events['total_items'] ), number_format_i18n( $events['page'] ), number_format_i18n( $events['total_pages'] ) ) );
 			}
 
-			// And reformat!
 			$format = 'table';
 			if ( isset( $assoc_args['format'] ) ) {
 				$format = $assoc_args['format'];
@@ -136,7 +135,6 @@ class Events extends \WP_CLI_Command {
 		/* translators: 1: Event ID, 2: Event action, 3. Event instance */
 		\WP_CLI::log( sprintf( __( 'Found event %1$d with action `%2$s` and instance identifier `%3$s`', 'automattic-cron-control' ), $args[0], $event->action, $event->instance ) );
 
-		// Proceed?
 		$now = time();
 		if ( $event->timestamp > $now ) {
 			/* translators: 1: Time in UTC, 2: Human time diff */
@@ -211,7 +209,6 @@ class Events extends \WP_CLI_Command {
 
 		$offset = absint( ( $page - 1 ) * $limit );
 
-		// Query!
 		$items = \Automattic\WP\Cron_Control\get_events(
 			array(
 				'status'     => $event_status,


### PR DESCRIPTION
By reducing the number of queries by 50x, we will reduce the time spent in this function and increase performance. I'm going with 5000 because we consider it an upper limit for the number of jobs you can have. If sites have more than 5000 pending events, cron gets disabled and there are some alerts.

Fixes #163 