### PR TITLE
Preserve keys when slicing the array

### DIFF
--- a/includes/class-events-store.php
+++ b/includes/class-events-store.php
@@ -783,7 +783,7 @@ class Events_Store extends Singleton {
 
 		for ( $i = 1; $i <= $buckets; $i++ ) {
 			$offset    = ( $i - 1 ) * $segment_size;
-			$slice     = array_slice( $option_flat, $offset, $segment_size );
+			$slice     = array_slice( $option_flat, $offset, $segment_size, true );
 			$cache_key = $this->get_cache_key_for_slice( $incrementer, $i );
 
 			wp_cache_set( $cache_key, $slice, null, 1 * \HOUR_IN_SECONDS );


### PR DESCRIPTION
In PHP, the array union operator (+) ignores even numerical keys from the second array if those are already present in the left hand one. Thus in case we are slicing an array w/o preserving keys, we are then trying to merge two arrays with identical numerical keys. And thus, no union is happening.

This commit is fixing the issue by preserving the keys. Another apporach would be to use `array_merge` which is appending identical numberic keys instead of ignoring those, but preserving the keys feels like a better approach, when we are dealing with cached and sliced array.

This should make #165 obsolet