### PR TITLE
 Ignore the "no resource" errors for sitemap generation

### DIFF
--- a/runner/runner.go
+++ b/runner/runner.go
@@ -485,7 +485,6 @@ func waitForEpoch(whom string, epoch_sec int64) {
 	for i := tDelta; time.Now().UnixNano() < tNextEpoch; i += tDelta {
 		if i > tEpochNano*2 {
 			// if we ever loop here for more than 2 full epochs, bail out
-			logger.Printf("Error in the epoch wait loop for %s\n", whom)
 			break
 		}
 		if gRestart {

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"strings"
 	"sync/atomic"
 	"syscall"
 	"time"
@@ -406,7 +407,9 @@ func runWpCliCmd(subcommand []string) (string, error) {
 			logger.Printf("%s - %s", err, wpOutStr)
 			logger.Println(fmt.Sprintf("%+v", subcommand))
 		}
-
+		if strings.Contains(wpOutStr, "Error: No resources available to run the job with action `msm_cron_generate_sitemap_for_year_month_day`") {
+			return wpOutStr, nil
+		}
 		return wpOutStr, err
 	}
 


### PR DESCRIPTION
We do not want to count these as errors and have error stats generated, so we simply ignore any errors of this ilk since they are expected to hit the limit and be done in batches.