### PR TITLE
Add json format option for runner daemon logs

### DIFF
--- a/runner/README.md
+++ b/runner/README.md
@@ -20,6 +20,8 @@ In addition to the REST API endpoints that can be used to run events, a Go-based
   * Heartbeat interval in seconds (default `60`)
 * `-log` string
   * Log path, omit to log to Stdout (default `os.Stdout`)
+* `-log-format` string
+  * Log format, either `text` or `json` (default `text`)  
 * `-network` int
   * WordPress network ID, `0` to disable (default `0`)
 * `-workers-get` int

--- a/runner/logger.go
+++ b/runner/logger.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"runtime"
+	"time"
+)
+
+type LogMessage struct {
+	Level   string `json:"level"`
+	Message string `json:"message"`
+	Type    string `json:"type"`
+}
+
+func (m LogMessage) toJsonString() string {
+	jsonStruct, err := json.Marshal(m)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	return string(jsonStruct)
+}
+
+type CronRunnerLogger struct {
+	Format      string
+	Destination string
+	Type        string
+	logger      *log.Logger
+}
+
+func NewCronRunnerLogger(format, dest string) *CronRunnerLogger {
+	logOpts := 0
+
+	var logWriter logWriter
+	var logger *log.Logger
+
+	if dest == "os.Stdout" {
+		if format == "json" {
+			logWriter = NewLogWriter("cron-control", "cron-control-runner", false)
+		} else {
+			// original log format
+			logWriter = NewLogWriter("cron-control", "cron-control-runner", true)
+		}
+		logger = log.New(logWriter, "", logOpts)
+	} else {
+		fileWriter := NewFileWriter(dest, "cron-control", "cron-control-runner")
+
+		logger = log.New(fileWriter, "", logOpts)
+	}
+
+	return &CronRunnerLogger{
+		format,
+		dest,
+		"cron-control-runner",
+		logger,
+	}
+}
+
+func (crl *CronRunnerLogger) Printf(format string, v ...interface{}) {
+	if crl.Format == "json" {
+		msgStr := fmt.Sprintf(format, v)
+
+		// Should be using level specific functions to set the `Level` (i.e.: `Debugf()`) but we're
+		// doing it this way fit with how `logger` is used in `runner.go`
+		msg := LogMessage{"DEBUG", msgStr, crl.Type}
+
+		crl.logger.Print(msg.toJsonString())
+	} else {
+		crl.logger.Printf(format, v)
+	}
+}
+
+func (crl *CronRunnerLogger) Println(v ...interface{}) {
+	crl.Printf(fmt.Sprintln(v...))
+}
+
+/**
+ * Custom writer to set the format we want when logging to STDOUT
+ */
+type logWriter struct {
+	App           string
+	AppType       string
+	EmulateStdLog bool
+}
+
+func NewLogWriter(app, appType string, emulateStdLog bool) logWriter {
+	return logWriter{app, appType, emulateStdLog}
+}
+
+func (w logWriter) Write(bytes []byte) (int, error) {
+	if w.EmulateStdLog {
+		// This logic is basically to emulate the original log format
+		timeStr := time.Now().UTC().Format("2018/09/30 08:45:04")
+
+		var shortFile string
+		_, file, no, ok := runtime.Caller(5)
+		if ok {
+			shortFile = fmt.Sprintf("%s:%d", filepath.Base(file), no)
+		} else {
+			shortFile = "unknown"
+		}
+
+		return fmt.Printf("DEBUG: %s %s: "+string(bytes), timeStr, shortFile)
+	}
+
+	timeStr := time.Now().UTC().Format("2006-01-02T15:04:05.999Z")
+	namespace := fmt.Sprintf("%s:%s", w.App, w.AppType)
+
+	return fmt.Printf("%s %s: "+string(bytes), timeStr, namespace)
+}
+
+/**
+ * Custom writer to get the format we want when logging to a file
+ */
+type fileWriter struct {
+	App     string
+	AppType string
+	File    *os.File
+}
+
+func NewFileWriter(path, app, appType string) fileWriter {
+	path, err := filepath.Abs(path)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	logFile, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0644)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	return fileWriter{app, appType, logFile}
+}
+
+func (f fileWriter) Write(bytes []byte) (int, error) {
+	timeStr := time.Now().UTC().Format("2006-01-02T15:04:05.999Z")
+	namespace := fmt.Sprintf("%s:%s", f.App, f.AppType)
+	msg := fmt.Sprintf("%s %s: "+string(bytes), timeStr, namespace)
+
+	return f.File.Write([]byte(msg))
+}

--- a/runner/logger.go
+++ b/runner/logger.go
@@ -62,7 +62,7 @@ func NewCronRunnerLogger(format, dest string) *CronRunnerLogger {
 
 func (crl *CronRunnerLogger) Printf(format string, v ...interface{}) {
 	if crl.Format == "json" {
-		msgStr := fmt.Sprintf(format, v)
+		msgStr := fmt.Sprintf(format, v...)
 
 		// Should be using level specific functions to set the `Level` (i.e.: `Debugf()`) but we're
 		// doing it this way fit with how `logger` is used in `runner.go`
@@ -70,12 +70,22 @@ func (crl *CronRunnerLogger) Printf(format string, v ...interface{}) {
 
 		crl.logger.Print(msg.toJsonString())
 	} else {
-		crl.logger.Printf(format, v)
+		crl.logger.Printf(format, v...)
 	}
 }
 
 func (crl *CronRunnerLogger) Println(v ...interface{}) {
-	crl.Printf(fmt.Sprintln(v...))
+	str := fmt.Sprintln(v...)
+
+	if crl.Format == "json" {
+		// Should be using level specific functions to set the `Level` (i.e.: `Debugf()`) but we're
+		// doing it this way fit with how `logger` is used in `runner.go`
+		msg := LogMessage{"DEBUG", str, crl.Type}
+
+		crl.logger.Println(msg.toJsonString())
+	} else {
+		crl.logger.Println(str)
+	}
 }
 
 /**
@@ -110,7 +120,7 @@ func (w logWriter) Write(bytes []byte) (int, error) {
 	timeStr := time.Now().UTC().Format("2006-01-02T15:04:05.999Z")
 	namespace := fmt.Sprintf("%s:%s", w.App, w.AppType)
 
-	return fmt.Printf("%s %s: "+string(bytes), timeStr, namespace)
+	return fmt.Printf("%s %s "+string(bytes), timeStr, namespace)
 }
 
 /**
@@ -139,7 +149,7 @@ func NewFileWriter(path, app, appType string) fileWriter {
 func (f fileWriter) Write(bytes []byte) (int, error) {
 	timeStr := time.Now().UTC().Format("2006-01-02T15:04:05.999Z")
 	namespace := fmt.Sprintf("%s:%s", f.App, f.AppType)
-	msg := fmt.Sprintf("%s %s: "+string(bytes), timeStr, namespace)
+	msg := fmt.Sprintf("%s %s "+string(bytes), timeStr, namespace)
 
 	return f.File.Write([]byte(msg))
 }

--- a/runner/logger.go
+++ b/runner/logger.go
@@ -103,7 +103,7 @@ func NewLogWriter(app, appType string, emulateStdLog bool) logWriter {
 
 func (w logWriter) Write(bytes []byte) (int, error) {
 	if w.EmulateStdLog {
-		// This logic is basically to emulate the original log format
+		// This logic is basically to emulate the original log format for backwards compatibility
 		timeStr := time.Now().UTC().Format("2018/09/30 08:45:04")
 
 		var shortFile string


### PR DESCRIPTION
# Description
Add JSON formatting option for logs in cron control runner daemon.
Fixes #157 

# Steps to Test or Reproduce

Make and run the runner with the `-log-format json` option flag. This will change log output to the format:
```
<timestamp> <namespace> <JSON>
Example:
2018-09-12T13:20:24.856Z cron-control:cron-control-runner {"level":"DEBUG","message":"Starting with 1 event-retreival worker(s) and 5 event worker(s)","type":"cron-control-runner"}
```