### PR TITLE
Swap error_log with trigger_error

### DIFF
--- a/includes/class-main.php
+++ b/includes/class-main.php
@@ -76,7 +76,7 @@ class Main extends Singleton {
 			if ( defined( $constant ) ) {
 				if ( constant( $constant ) !== $expected_value ) {
 					/* translators: 1: Plugin name, 2: Constant name */
-					error_log( sprintf( __( '%1$s: %2$s set to unexpected value; must be corrected for proper behaviour.', 'automattic-cron-control' ), 'Cron Control', $constant ) );
+					trigger_error( sprintf( __( '%1$s: %2$s set to unexpected value; must be corrected for proper behaviour.', 'automattic-cron-control' ), 'Cron Control', $constant ), E_USER_WARNING );
 				}
 			} else {
 				define( $constant, $expected_value );


### PR DESCRIPTION
`error_log` outputs a generic format that is hard to parse. Switching to `trigger_error` makes it easier to parse and ingest into systems like Logstash.

## To Test

- Add `define( 'DISABLE_WP_CRON', false );`
- Load a WordPress page
- Verify that a user warning is triggered for the constant value being unexpected.