### PR TITLE
Pass status code to wp_send_json_error()

### DIFF
--- a/includes/class-main.php
+++ b/includes/class-main.php
@@ -86,17 +86,13 @@ class Main extends Singleton {
 
 	/**
 	 * Block direct cron execution as early as possible
+	 *
+	 * NOTE: We cannot influence the response if php-fpm is in use, as WP core calls fastcgi_finish_request() very early on
 	 */
 	public function block_direct_cron() {
 		if ( false !== stripos( $_SERVER['REQUEST_URI'], '/wp-cron.php' ) || false !== stripos( $_SERVER['SCRIPT_NAME'], '/wp-cron.php' ) ) {
-			status_header( 403 );
-			wp_send_json_error(
-				/* translators: 1: Plugin name */
-				new \WP_Error( 'forbidden', sprintf( __( 'Normal cron execution is blocked when the %s plugin is active.', 'automattic-cron-control' ), 'Cron Control' ) ),
-				array(
-					'status' => 400,
-				)
-			);
+			$wp_error = new \WP_Error( 'forbidden', __( 'Normal cron execution is blocked when the Cron Control plugin is active.', 'automattic-cron-control' ) );
+			wp_send_json_error( $wp_error, 403 );
 		}
 	}
 


### PR DESCRIPTION
WP 4.7 added the ability to pass the status code to `wp_send_json_error()` / `wp_send_json()`:
https://developer.wordpress.org/reference/functions/wp_send_json_error/

Seemed odd to be setting a 403 and then passing 400 with the WP_Error, so just stripping out that part.