### PR TITLE
Enable the running of remote wp cli commands

### DIFF
--- a/runner/logger.go
+++ b/runner/logger.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"path"
+	"sync"
+	"time"
+)
+
+type LogType int
+
+const (
+	Text LogType = iota
+	JSON
+)
+
+type LogEntry struct {
+	Timestamp string `json:"ts"`
+	Message   string `json:"msg"`
+}
+
+type Logger struct {
+	FileName string
+	Type     LogType
+	l        *log.Logger
+	f        *os.File
+	logMutex *sync.Mutex
+}
+
+func (self *Logger) Init() {
+	self.logMutex = &sync.Mutex{}
+
+	if "os.Stdout" == self.FileName {
+		self.l = log.New(os.Stdout, "", log.Ldate|log.Ltime|log.LUTC|log.Lshortfile)
+		return
+	}
+
+	err := self.dirCreateIfNotExists(self.FileName)
+	if nil != err {
+		fmt.Printf("Error creating the logging directory: %s\n", err.Error())
+		os.Exit(1)
+	}
+
+	err = self.openLogFile()
+	if nil != err {
+		fmt.Printf("Error opening the log file: %s\n", err.Error())
+		os.Exit(1)
+	}
+}
+
+func (self *Logger) Println(v ...interface{}) {
+	self.logMutex.Lock()
+	var err error
+
+	switch self.Type {
+	case Text:
+		err = self.l.Output(2, fmt.Sprintln(v...))
+	case JSON:
+		str := fmt.Sprintln(v...)
+		if 0 < len(str) && '\n' == str[len(str)-1] {
+			str = str[:len(str)-1]
+		}
+		var buf []byte
+		var jsonErr error
+		buf, jsonErr = json.Marshal(LogEntry{Message: str, Timestamp: time.Now().Format("2006/01/02 15:04:05.000")})
+		if nil == jsonErr {
+			_, err = self.f.WriteString(string(buf) + "\n")
+		}
+	}
+
+	if nil != err {
+		fmt.Println(err.Error())
+		self.f.Close()
+		self.openLogFile()
+	}
+	self.logMutex.Unlock()
+}
+
+func (self *Logger) Printf(str string, v ...interface{}) {
+	self.logMutex.Lock()
+	var err error
+	switch self.Type {
+	case Text:
+		err = self.l.Output(2, fmt.Sprintf(str, v...))
+	case JSON:
+		if 0 < len(str) && '\n' == str[len(str)-1] {
+			str = str[:len(str)-1]
+		}
+		var buf []byte
+		var jsonErr error
+		buf, jsonErr = json.Marshal(LogEntry{Message: fmt.Sprintf(str, v...), Timestamp: time.Now().Format("2006/01/02 15:04:05.000")})
+		if nil == jsonErr {
+			_, err = self.f.WriteString(string(buf) + "\n")
+		}
+	}
+	if nil != err {
+		fmt.Println(err.Error())
+		self.f.Close()
+		self.openLogFile()
+	}
+	self.logMutex.Unlock()
+}
+
+func (self *Logger) Fatal(v ...interface{}) {
+	self.Println(v...)
+	os.Exit(1)
+}
+
+func (self *Logger) Fatalf(str string, v ...interface{}) {
+	self.Printf(str, v...)
+	os.Exit(1)
+}
+
+func (self *Logger) dirCreateIfNotExists(FileName string) error {
+	dir := path.Dir(FileName)
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		err = os.MkdirAll(dir, 0777)
+		if nil != err {
+			return errors.New(fmt.Sprintf("error creating the log directory: %s", err.Error()))
+		}
+	}
+	return nil
+}
+
+func (self *Logger) openLogFile() error {
+	f, err := os.OpenFile(self.FileName, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
+	if nil != err {
+		return errors.New(fmt.Sprintf("error opening logfile: %s", err.Error()))
+	}
+	self.f = f
+
+	if Text == self.Type {
+		self.l = log.New(self.f, "", log.Ldate|log.Ltime|log.LUTC|log.Lshortfile)
+	}
+	return nil
+}

--- a/runner/remote.go
+++ b/runner/remote.go
@@ -87,7 +87,6 @@ func authConn(conn *net.TCPConn) {
 		}
 
 		size := len(data)
-		logger.Print("received data:", string(data[:size]))
 
 		newlineChars := 1
 		if 1 < size && 0xd == (data[size-2 : size-1])[0] {

--- a/runner/remote.go
+++ b/runner/remote.go
@@ -15,7 +15,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/kr/pty"
+	"github.com/creack/pty"
 	"golang.org/x/crypto/ssh/terminal"
 )
 

--- a/runner/remote.go
+++ b/runner/remote.go
@@ -74,7 +74,7 @@ func authConn(conn *net.TCPConn) {
 	var Guid string
 
 	for {
-		conn.SetDeadline(time.Now().Add(time.Duration(5 * time.Second.Nanoseconds())))
+		conn.SetReadDeadline(time.Now().Add(time.Duration(5 * time.Second.Nanoseconds())))
 
 		logger.Println("waiting for auth data")
 

--- a/runner/remote.go
+++ b/runner/remote.go
@@ -727,11 +727,6 @@ func runWpCliCmdRemote(conn *net.TCPConn, Guid string, rows uint16, cols uint16,
 		logger.Println("closing watcher and read file")
 		watcher.Close()
 		readFile.Close()
-
-		if nil != conn {
-			logger.Println("closing the connection on exit of the file read")
-			conn.Close()
-		}
 	}()
 
 	err = watcher.Watch(logFileName)

--- a/runner/remote.go
+++ b/runner/remote.go
@@ -108,7 +108,6 @@ func authConn(conn *net.TCPConn) {
 			return
 		}
 
-		logger.Printf("read %d\n", read)
 		if 0 != read {
 			if nil == data {
 				data = make([]byte, read)
@@ -157,7 +156,7 @@ func authConn(conn *net.TCPConn) {
 
 	if token != gRemoteToken {
 		conn.Write([]byte("invalid auth handshake"))
-		logger.Printf("error incorrect handshake string: %s\n", string(data[:size]))
+		logger.Printf("error incorrect handshake string")
 		conn.Close()
 		return
 	}

--- a/runner/remote.go
+++ b/runner/remote.go
@@ -788,9 +788,12 @@ func runWpCliCmdRemote(conn *net.TCPConn, Guid string, rows uint16, cols uint16,
 		conn = nil
 	}()
 
-	cmd.Process.Wait()
+	state, err := cmd.Process.Wait()
+	if nil != err {
+		logger.Printf("error from the wp command: %s\n", err.Error())
+	}
 
-	if nil != cmd.Process {
+	if !state.Exited() {
 		logger.Println("terminating the wp command")
 		cmd.Process.Kill()
 	}

--- a/runner/remote.go
+++ b/runner/remote.go
@@ -36,7 +36,7 @@ var (
 
 func waitForConnect() {
 	padlock = &sync.Mutex{}
-	guidRegex = regexp.MustCompile("^[a-fA-F0-9]+$")
+	guidRegex = regexp.MustCompile("^[a-fA-F0-9\\-]+$")
 	if nil == guidRegex {
 		logger.Println("Failed to compile the Guid regex")
 		return

--- a/runner/remote.go
+++ b/runner/remote.go
@@ -23,7 +23,6 @@ import (
 )
 
 type WpCliProcess struct {
-	Guid          string
 	Cmd           *exec.Cmd
 	Tty           *os.File
 	Running       bool
@@ -623,7 +622,6 @@ func runWpCliCmdRemote(conn *net.TCPConn, Guid string, rows uint16, cols uint16,
 
 	padlock.Lock()
 	wpcli := &WpCliProcess{}
-	wpcli.Guid = Guid
 	wpcli.Cmd = cmd
 	wpcli.BytesLogged = 0
 	wpcli.BytesStreamed = make(map[string]int64)

--- a/runner/remote.go
+++ b/runner/remote.go
@@ -384,7 +384,10 @@ func processTCPConnectionData(conn *net.TCPConn, wpcli *WpCliProcess) {
 				continue
 			}
 
+			wpcli.padlock.Lock()
 			err = pty.Setsize(wpcli.Tty, &pty.Winsize{Rows: uint16(rows), Cols: uint16(cols)})
+			wpcli.padlock.Unlock()
+
 			if nil != err {
 				logger.Printf("error performing window resize: %s\n", err.Error())
 			} else {
@@ -393,7 +396,10 @@ func processTCPConnectionData(conn *net.TCPConn, wpcli *WpCliProcess) {
 			continue
 		}
 
+		wpcli.padlock.Lock()
 		written, err = wpcli.Tty.Write(data[:size])
+		wpcli.padlock.Unlock()
+
 		if nil != err {
 			if io.EOF != err {
 				logger.Printf("error writing to the WP CLI tty: %s\n", err.Error())

--- a/runner/remote.go
+++ b/runner/remote.go
@@ -508,7 +508,7 @@ func attachWpCliCmdRemote(conn *net.TCPConn, wpcli *WpCliProcess, Guid string, r
 		}
 
 		// Used to monitor when the connection is disconnected or the CLI command finishes
-		ticker := time.Tick(time.Duration(1 * time.Second.Nanoseconds()))
+		ticker := time.Tick(time.Duration(500 * time.Millisecond.Nanoseconds()))
 
 	Watcher_Loop:
 		for {
@@ -672,7 +672,7 @@ func runWpCliCmdRemote(conn *net.TCPConn, Guid string, rows uint16, cols uint16,
 		var buf []byte = make([]byte, 8192)
 
 		// Used to monitor when the connection is disconnected or the CLI command finishes
-		ticker := time.Tick(time.Duration(1 * time.Second.Nanoseconds()))
+		ticker := time.Tick(time.Duration(500 * time.Millisecond.Nanoseconds()))
 
 	Exit_Loop:
 		for {
@@ -802,8 +802,8 @@ func runWpCliCmdRemote(conn *net.TCPConn, Guid string, rows uint16, cols uint16,
 		if wpcli.BytesStreamed[remoteAddress] >= wpcli.BytesLogged || nil == conn {
 			break
 		}
-		logger.Printf("waiting for remaining bytes to be written to a client: at %d - have %d\n", wpcli.BytesStreamed[remoteAddress], wpcli.BytesLogged)
-		time.Sleep(time.Duration(500 * time.Millisecond.Nanoseconds()))
+		logger.Printf("waiting for remaining bytes to be sent to a client: at %d - have %d\n", wpcli.BytesStreamed[remoteAddress], wpcli.BytesLogged)
+		time.Sleep(time.Duration(200 * time.Millisecond.Nanoseconds()))
 	}
 
 	if nil != conn {

--- a/runner/remote.go
+++ b/runner/remote.go
@@ -817,7 +817,7 @@ func streamLogs(conn *net.TCPConn, Guid string) {
 		logFileName = fmt.Sprintf("%s/wp-cli-%s", logDir, Guid)
 	}
 
-	if _, err := os.Stat(logFileName); nil == err {
+	if _, err := os.Stat(logFileName); nil != err {
 		conn.Write([]byte(fmt.Sprintf("The WP CLI log file for Guid %s does not exist\n", Guid)))
 		logger.Printf("The logfile %s does not exist\n", logFileName)
 		conn.Close()

--- a/runner/remote.go
+++ b/runner/remote.go
@@ -784,10 +784,8 @@ func runWpCliCmdRemote(conn *net.TCPConn, Guid string, rows uint16, cols uint16,
 
 	go func() {
 		processTCPConnectionData(conn, wpcli)
-
 		conn.Close()
 		conn = nil
-		logger.Printf("%+v\n", wpcli)
 	}()
 
 	cmd.Process.Wait()

--- a/runner/remote.go
+++ b/runner/remote.go
@@ -778,7 +778,7 @@ func runWpCliCmdRemote(conn *net.TCPConn, Guid string, rows uint16, cols uint16,
 		if wpcli.BytesStreamed[remoteAddress] >= wpcli.BytesLogged || nil == conn {
 			break
 		}
-		time.Sleep(time.Duration(1 * time.Second.Nanoseconds()))
+		time.Sleep(time.Duration(500 * time.Millisecond.Nanoseconds()))
 		logger.Printf("waiting for remaining bytes to be written to a client: at %d - have %d\n", wpcli.BytesStreamed, wpcli.BytesLogged)
 	}
 

--- a/runner/remote.go
+++ b/runner/remote.go
@@ -1,0 +1,357 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/kr/pty"
+	"golang.org/x/crypto/ssh/terminal"
+)
+
+var (
+	blackListed1stLevel = []string{"admin", "cli", "config", "core", "db", "dist-archive",
+		"eval-file", "eval", "find", "i18n", "scaffold", "server", "package", "profile"}
+
+	blackListed2ndLevel = map[string][]string{
+		"media":    {"regenerate"},
+		"theme":    {"install", "update", "delete"},
+		"plugin":   {"install", "update", "delete"},
+		"language": {"install", "update", "delete"},
+		"vip":      {"support-user"},
+	}
+
+	guidRegex *regexp.Regexp
+	padlock   *sync.Mutex
+)
+
+func waitForConnect() {
+	padlock = &sync.Mutex{}
+	guidRegex = regexp.MustCompile("^[a-fA-F0-9]+$")
+	if nil == guidRegex {
+		logger.Println("Failed to compile the Guid regex")
+		return
+	}
+
+	addr, err := net.ResolveTCPAddr("tcp4", "0.0.0.0:22122")
+	if err != nil {
+		logger.Printf("error resolving listen address: %s\n", err.Error())
+		return
+	}
+
+	listener, err := net.ListenTCP("tcp4", addr)
+	if err != nil {
+		logger.Printf("error listening on %s: %s\n", addr.String(), err.Error())
+		return
+	}
+	defer listener.Close()
+
+	for {
+		logger.Println("listening...")
+		conn, err := listener.AcceptTCP()
+		logger.Println("connection: ", conn.LocalAddr().String())
+		if err != nil {
+			logger.Printf("error accepting connection: %s\n", err.Error())
+			continue
+		}
+		go authConn(conn)
+	}
+}
+
+func authConn(conn *net.TCPConn) {
+	elems := make([]string, 0)
+	var rows, cols uint64
+	var Guid string
+
+	for {
+		data := make([]byte, 256)
+		conn.SetReadBuffer(len(gRemoteToken) + 2)
+		conn.SetDeadline(time.Now().Add(time.Duration(5 * time.Second.Nanoseconds())))
+
+		logger.Println("waiting for auth data")
+		size, err := conn.Read(data)
+
+		logger.Print("received data:", string(data[:size]))
+
+		newlineChars := 1
+		if 1 < size && 0xd == (data[size-2 : size-1])[0] {
+			newlineChars = 2
+		}
+
+		if err != nil {
+			logger.Printf("error reading handshake reply: %s\n", err.Error())
+			conn.Close()
+			return
+		}
+
+		elems = strings.Split(string(data[:size-newlineChars]), ";")
+
+		if 5 != len(elems) {
+			logger.Println("error handshake format incorrect")
+			conn.Close()
+			return
+		}
+
+		if len(elems[0]) != len(gRemoteToken) {
+			logger.Printf("error incorrect handshake reply size: %d != %d\n", len(gRemoteToken), len(elems[0]))
+			conn.Close()
+			return
+		}
+
+		rows, err = strconv.ParseUint(elems[2], 10, 16)
+		if nil != err {
+			logger.Printf("error incorrect console rows setting: %s\n", err.Error())
+			conn.Close()
+			return
+		}
+
+		cols, err = strconv.ParseUint(elems[3], 10, 16)
+		if nil != err {
+			logger.Printf("error incorrect console columns setting: %s\n", err.Error())
+			conn.Close()
+			return
+		}
+
+		if !guidRegex.Match([]byte(elems[1])) {
+			logger.Println("error incorrect GUID format")
+			conn.Write([]byte("error incorrect GUID format"))
+			conn.Close()
+			return
+		}
+
+		Guid = elems[1]
+
+		if elems[0] == gRemoteToken {
+			logger.Println("handshake complete!")
+			break
+		}
+
+		logger.Printf("error incorrect handshake string: %s\n", string(data[:size]))
+	}
+
+	conn.SetDeadline(time.Now().Add(time.Duration(600 * time.Second.Nanoseconds())))
+	conn.SetKeepAlivePeriod(time.Duration(30 * time.Second.Nanoseconds()))
+	conn.SetKeepAlive(true)
+
+	wpCliCmd, err := validateAndProcessCommand(elems[4])
+	if nil != err {
+		logger.Println(err.Error())
+		conn.Write([]byte(err.Error()))
+		conn.Close()
+		return
+	}
+	runWpCliCmdRemote(conn, Guid, uint16(rows), uint16(cols), wpCliCmd)
+}
+
+func validateAndProcessCommand(calledCmd string) (string, error) {
+	cmdParts := strings.Fields(strings.TrimSpace(calledCmd))
+
+	for _, command := range blackListed1stLevel {
+		if strings.ToLower(strings.TrimSpace(cmdParts[0])) == command {
+			return "", errors.New(fmt.Sprintf("WP CLI command '%s' is not permitted\n", command))
+		}
+	}
+
+	if 1 == len(cmdParts) {
+		return strings.TrimSpace(cmdParts[0]), nil
+	}
+
+	for command, blacklistedMap := range blackListed2ndLevel {
+		for _, subCommand := range blacklistedMap {
+			if strings.ToLower(strings.TrimSpace(cmdParts[0])) == command &&
+				strings.ToLower(strings.TrimSpace(cmdParts[1])) == subCommand {
+				return "", errors.New(fmt.Sprintf("WP CLI command '%s %s' is not permitted\n", command, subCommand))
+			}
+		}
+	}
+
+	return strings.Join(cmdParts, " "), nil
+}
+
+func runWpCliCmdRemote(conn *net.TCPConn, Guid string, rows uint16, cols uint16, wpCliCmdString string) error {
+	cmdArgs := make([]string, 0)
+	cmdArgs = append(cmdArgs, strings.Fields("--path="+wpPath)...)
+	cmdArgs = append(cmdArgs, strings.Fields(wpCliCmdString)...)
+
+	cmd := exec.Command("/usr/local/bin/wp", cmdArgs...)
+
+	cmd.Env = append(os.Environ(), "TERM=xterm-256color")
+
+	logger.Printf("launching %s - rows: %d, cols: %d, args: %s\n", Guid, rows, cols, strings.Join(cmdArgs, " "))
+
+	var logFileName string
+	if "os.Stdout" == logDest {
+		logFileName = fmt.Sprintf("/tmp/wp-cli-%s", Guid)
+	} else {
+		logFileName = fmt.Sprintf("%s/wp-cli-%s", logDest, Guid)
+	}
+
+	if _, err := os.Stat(logFileName); nil == err {
+		logger.Printf("Removing existing GUid logfile %s", logFileName)
+		os.Remove(logFileName)
+	}
+
+	logger.Printf("Opening logfile %s", logFileName)
+	logFile, err := os.OpenFile(logFileName, os.O_APPEND|os.O_WRONLY|os.O_CREATE|os.O_SYNC, 0666)
+
+	if nil != err {
+		conn.Write([]byte("unable to launch the remote WP CLI process: " + err.Error()))
+		conn.Close()
+		return errors.New(fmt.Sprintf("error launching the WP CLI process: %s\n", err.Error()))
+	}
+
+	tty, err := pty.StartWithSize(cmd, &pty.Winsize{Rows: rows, Cols: cols})
+	if nil != err {
+		conn.Write([]byte("unable to launch the remote WP CLI process."))
+		logFile.Close()
+		conn.Close()
+		return errors.New(fmt.Sprintf("error launching the WP CLI process: %s\n", err.Error()))
+	}
+
+	defer func() {
+		cmd.Process.Kill()
+		cmd.Process.Wait()
+		tty.Close()
+		logFile.Close()
+	}()
+
+	prevState, err := terminal.MakeRaw(int(tty.Fd()))
+	if nil != err {
+		conn.Write([]byte("unable to initialize the remote WP CLI process."))
+		conn.Close()
+		return errors.New(fmt.Sprintf("error initializing the WP CLI process: %s\n", err.Error()))
+	}
+	defer func() { _ = terminal.Restore(int(tty.Fd()), prevState) }()
+
+	go func() {
+		var written, read int
+		var err error
+		var buf []byte = make([]byte, 4096)
+
+		for {
+			read, err = tty.Read(buf)
+
+			if nil != err {
+				if io.EOF != err {
+					logger.Printf("error reading WP CLI stdout: %s\n", err.Error())
+					break
+				}
+			}
+			if 0 == read {
+				continue
+			}
+
+			padlock.Lock()
+			written, err = logFile.Write(buf[:read])
+			padlock.Unlock()
+			if nil != err {
+				logger.Printf("error writing to the local logfile: %s\n", err.Error())
+			}
+
+			written, err = conn.Write(buf[:read])
+			if nil != err {
+				logger.Printf("error writing to client connection: %s\n", err.Error())
+				break
+			}
+			if written != read {
+				logger.Printf("error writing to client connection: %s\n", err.Error())
+				break
+			}
+		}
+		conn.Close()
+	}()
+
+	go func() {
+		data := make([]byte, 4096)
+		var size, written int
+		var err error
+
+		conn.SetReadBuffer(4096)
+
+		for {
+			conn.SetDeadline(time.Now().Add(time.Duration(600 * time.Second.Nanoseconds())))
+			size, err = conn.Read(data)
+
+			if nil != err {
+				if io.EOF == err {
+					logger.Println("WP CLI client connection closed")
+					conn.Close()
+				} else {
+					logger.Printf("error reading from the WP CLI client: %s\n", err.Error())
+				}
+				break
+			}
+
+			if 0 == size {
+				logger.Println("ignoring data of length 0")
+				continue
+			}
+
+			if 4 < len(data) && "\xc2\x9b8;" == string(data[:4]) && 't' == data[size-1:][0] {
+				cmdParts := strings.Split(string(data[4:size]), ";")
+
+				rows, err := strconv.ParseUint(cmdParts[0], 10, 16)
+				if nil != err {
+					logger.Printf("error reading rows resize data from the WP CLI client: %s\n", err.Error())
+					continue
+				}
+				cols, err := strconv.ParseUint(cmdParts[1][:len(cmdParts[1])-1], 10, 16)
+				if nil != err {
+					logger.Printf("error reading columns resize data from the WP CLI client: %s\n", err.Error())
+					continue
+				}
+
+				err = pty.Setsize(tty, &pty.Winsize{Rows: uint16(rows), Cols: uint16(cols)})
+				if nil != err {
+					logger.Printf("error performing window resize: %s\n", err.Error())
+				} else {
+					logger.Printf("set new window size: %dx%d\n", rows, cols)
+				}
+				continue
+			}
+
+			padlock.Lock()
+			written, err = logFile.Write(data[:size])
+			padlock.Unlock()
+			if nil != err {
+				logger.Printf("error writing to the local logfile: %s\n", err.Error())
+			}
+
+			written, err = tty.Write(data[:size])
+			if nil != err {
+				if io.ErrClosedPipe == err {
+					logger.Println("error reading from the WP CLI client: closed pipe")
+					break
+				}
+				if io.ErrUnexpectedEOF == err {
+					logger.Println("error reading from the WP CLI client: unexpected EOF")
+					break
+				}
+				if io.EOF != err {
+					panic(err)
+				}
+			}
+			if written != size {
+				logger.Println("error writing to WP CLI client: not enough data written")
+				break
+			}
+		}
+
+		logger.Println("terminating the wp command")
+		if nil != cmd.Process {
+			cmd.Process.Kill()
+		}
+	}()
+
+	cmd.Process.Wait()
+
+	return nil
+}

--- a/runner/remote.go
+++ b/runner/remote.go
@@ -355,6 +355,11 @@ func runWpCliCmdRemote(conn *net.TCPConn, Guid string, rows uint16, cols uint16,
 				continue
 			}
 
+			if 1 == size && 0x3 == data[0] {
+				logger.Println("Ctrl-C received, exiting")
+				break
+			}
+
 			if 4 < len(data) && "\xc2\x9b8;" == string(data[:4]) && 't' == data[size-1:][0] {
 				cmdParts := strings.Split(string(data[4:size]), ";")
 

--- a/runner/remote.go
+++ b/runner/remote.go
@@ -153,6 +153,10 @@ func authConn(conn *net.TCPConn) {
 }
 
 func validateAndProcessCommand(calledCmd string) (string, error) {
+	if 0 == len(strings.TrimSpace(calledCmd)) {
+		return "", errors.New("No WP CLI command specified")
+	}
+
 	cmdParts := strings.Fields(strings.TrimSpace(calledCmd))
 
 	for _, command := range blackListed1stLevel {

--- a/runner/remote.go
+++ b/runner/remote.go
@@ -198,7 +198,11 @@ func authConn(conn *net.TCPConn) {
 		return
 	}
 
-	runWpCliCmdRemote(conn, Guid, uint16(rows), uint16(cols), wpCliCmd)
+	err = runWpCliCmdRemote(conn, Guid, uint16(rows), uint16(cols), wpCliCmd)
+	if nil != err {
+		logger.Println(err.Error())
+	}
+}
 
 func authenticateProtocolHeader1(dataString string) (string, string, uint16, uint16, string, error) {
 	var token, guid string

--- a/runner/remote.go
+++ b/runner/remote.go
@@ -13,13 +13,29 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/creack/pty"
+	"github.com/howeyc/fsnotify"
 	"golang.org/x/crypto/ssh/terminal"
 )
 
+type WpCliProcess struct {
+	Guid          string
+	Cmd           *exec.Cmd
+	Tty           *os.File
+	Running       bool
+	LogFileName   string
+	BytesLogged   int64
+	BytesStreamed int64
+}
+
 var (
+	gGUIDttys map[string]*WpCliProcess
+	padlock   *sync.Mutex
+	guidRegex *regexp.Regexp
+
 	blackListed1stLevel = []string{"admin", "cli", "config", "core", "db", "dist-archive",
 		"eval-file", "eval", "find", "i18n", "scaffold", "server", "package", "profile"}
 
@@ -30,13 +46,12 @@ var (
 		"language": {"install", "update", "delete"},
 		"vip":      {"support-user"},
 	}
-
-	guidRegex *regexp.Regexp
-	padlock   *sync.Mutex
 )
 
 func waitForConnect() {
+	gGUIDttys = make(map[string]*WpCliProcess)
 	padlock = &sync.Mutex{}
+
 	guidRegex = regexp.MustCompile("^[a-fA-F0-9\\-]+$")
 	if nil == guidRegex {
 		logger.Println("Failed to compile the Guid regex")
@@ -147,6 +162,17 @@ func authConn(conn *net.TCPConn) {
 	conn.SetKeepAlivePeriod(time.Duration(30 * time.Second.Nanoseconds()))
 	conn.SetKeepAlive(true)
 
+	padlock.Lock()
+	wpCliProcess, found := gGUIDttys[Guid]
+	padlock.Unlock()
+
+	if found {
+		// Reattach to the running WP-CLi command
+		attachWpCliCmdRemote(conn, wpCliProcess, uint16(rows), uint16(cols))
+		return
+	}
+
+	// The Guid is not currently running
 	wpCliCmd, err := validateAndProcessCommand(elems[4])
 	if nil != err {
 		logger.Println(err.Error())
@@ -224,6 +250,195 @@ func getCleanWpCliArgumentArray(wpCliCmdString string) ([]string, error) {
 	return cleanArgs, nil
 }
 
+func processTCPConnectionData(conn *net.TCPConn, wpcli *WpCliProcess) {
+	data := make([]byte, 8192)
+	var size, written int
+	var err error
+
+	conn.SetReadBuffer(8192)
+	for {
+		size, err = (*conn).Read(data)
+
+		if nil != err {
+			if io.EOF == err {
+				logger.Println("client connection closed")
+			} else if !strings.Contains(err.Error(), "use of closed network connection") {
+				logger.Printf("error reading from the client connection: %s\n", err.Error())
+			}
+			break
+		}
+
+		if 0 == size {
+			logger.Println("ignoring data of length 0")
+			continue
+		}
+
+		if 1 == size && 0x3 == data[0] {
+			logger.Println("Ctrl-C received, terminating the WP-CLI and exiting")
+			wpcli.Cmd.Process.Kill()
+			break
+		}
+
+		if 4 < len(data) && "\xc2\x9b8;" == string(data[:4]) && 't' == data[size-1:][0] {
+			cmdParts := strings.Split(string(data[4:size]), ";")
+
+			rows, err := strconv.ParseUint(cmdParts[0], 10, 16)
+			if nil != err {
+				logger.Printf("error reading rows resize data from the WP CLI client: %s\n", err.Error())
+				continue
+			}
+			cols, err := strconv.ParseUint(cmdParts[1][:len(cmdParts[1])-1], 10, 16)
+			if nil != err {
+				logger.Printf("error reading columns resize data from the WP CLI client: %s\n", err.Error())
+				continue
+			}
+
+			err = pty.Setsize(wpcli.Tty, &pty.Winsize{Rows: uint16(rows), Cols: uint16(cols)})
+			if nil != err {
+				logger.Printf("error performing window resize: %s\n", err.Error())
+			} else {
+				logger.Printf("set new window size: %dx%d\n", rows, cols)
+			}
+			continue
+		}
+
+		written, err = wpcli.Tty.Write(data[:size])
+		if nil != err {
+			if io.EOF != err {
+				logger.Printf("error writing to the WP CLI tty: %s\n", err.Error())
+				break
+			}
+		}
+		if written != size {
+			logger.Println("error writing to the WP CLI tty: not enough data written")
+			break
+		}
+	}
+}
+
+func attachWpCliCmdRemote(conn *net.TCPConn, wpcli *WpCliProcess, rows uint16, cols uint16) error {
+	logger.Printf("resuming %s - rows: %d, cols: %d\n", wpcli.Guid, rows, cols)
+	connectionActive := true
+
+	err := pty.Setsize(wpcli.Tty, &pty.Winsize{Rows: uint16(rows), Cols: uint16(cols)})
+	if nil != err {
+		logger.Printf("error performing window resize: %s\n", err.Error())
+	} else {
+		logger.Printf("set new window size: %dx%d\n", rows, cols)
+	}
+
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		conn.Write([]byte("unable to reattach to the WP CLI processs"))
+		conn.Close()
+		return errors.New(fmt.Sprintf("error reattaching to the WP CLI process: %s\n", err.Error()))
+	}
+
+	go func() {
+		var written, read int
+		var buf []byte = make([]byte, 8192)
+
+		readFile, err := os.OpenFile(wpcli.LogFileName, os.O_RDONLY, os.ModeCharDevice)
+		if nil != err {
+			logger.Printf("error opening the read file for the catchup stream: %s\n", err.Error())
+			conn.Close()
+			return
+		}
+		defer readFile.Close()
+
+		logger.Printf("Seeking %s to %d for the catchup stream", wpcli.LogFileName, wpcli.BytesStreamed)
+		readFile.Seek(wpcli.BytesStreamed, 0)
+
+	Catchup_Loop:
+		for {
+			if !connectionActive {
+				logger.Println("client connection is closed, exiting this catchup loop")
+				break Catchup_Loop
+			}
+			read, err = readFile.Read(buf)
+
+			if nil != err {
+				logger.Printf("error reading file for the catchup stream: %s\n", err.Error())
+				break Catchup_Loop
+			}
+
+			if 0 == read {
+				logger.Printf("error reading file for the stream: %s\n", err.Error())
+				break Catchup_Loop
+			}
+
+			written, err = conn.Write(buf[:read])
+			if nil != err {
+				logger.Printf("error writing to client connection: %s\n", err.Error())
+				return
+			}
+
+			atomic.AddInt64(&wpcli.BytesStreamed, int64(written))
+
+			if wpcli.BytesStreamed == wpcli.BytesLogged {
+				break Catchup_Loop
+			}
+		}
+
+		// Used to monitor when the connection is disconnected or the CLI command finishes
+		ticker := time.Tick(time.Duration(1 * time.Second.Nanoseconds()))
+
+	Watcher_Loop:
+		for {
+			if !connectionActive || !wpcli.Running {
+				logger.Println("client connection is closed, exiting this watcher loop")
+				break Watcher_Loop
+			}
+			if !wpcli.Running {
+				logger.Println("WP CLI command finished, exiting this watcher loop")
+				break Watcher_Loop
+			}
+
+			select {
+			case <-ticker:
+				// We are just tick-tocking
+			case ev := <-watcher.Event:
+				if ev.IsDelete() {
+					break Watcher_Loop
+				}
+				if !ev.IsModify() {
+					continue
+				}
+
+				read, err = readFile.Read(buf)
+				if 0 == read {
+					continue
+				}
+
+				written, err = conn.Write(buf[:read])
+				if nil != err {
+					logger.Printf("error writing to client connection: %s\n", err.Error())
+					break Watcher_Loop
+				}
+				atomic.AddInt64(&wpcli.BytesStreamed, int64(written))
+			case err := <-watcher.Error:
+				logger.Printf("error scanning the logfile: %s", err.Error())
+			}
+		}
+
+		logger.Println("closing connection at the end of the file read")
+		conn.Close()
+	}()
+
+	err = watcher.Watch(wpcli.LogFileName)
+	if err != nil {
+		logger.Printf("error watching the logfile: %s", err.Error())
+		conn.Write([]byte("unable to open the remote process log"))
+		conn.Close()
+		return errors.New(fmt.Sprintf("error watching the logfile: %s\n", err.Error()))
+	}
+
+	processTCPConnectionData(conn, wpcli)
+	conn.Close()
+	connectionActive = false
+	return nil
+}
+
 func runWpCliCmdRemote(conn *net.TCPConn, Guid string, rows uint16, cols uint16, wpCliCmdString string) error {
 	cmdArgs := make([]string, 0)
 	cmdArgs = append(cmdArgs, strings.Fields("--path="+wpPath)...)
@@ -238,7 +453,6 @@ func runWpCliCmdRemote(conn *net.TCPConn, Guid string, rows uint16, cols uint16,
 	cmdArgs = append(cmdArgs, cleanArgs...)
 
 	cmd := exec.Command("/usr/local/bin/wp", cmdArgs...)
-
 	cmd.Env = append(os.Environ(), "TERM=xterm-256color")
 
 	logger.Printf("launching %s - rows: %d, cols: %d, args: %s\n", Guid, rows, cols, strings.Join(cmdArgs, " "))
@@ -256,13 +470,20 @@ func runWpCliCmdRemote(conn *net.TCPConn, Guid string, rows uint16, cols uint16,
 		os.Remove(logFileName)
 	}
 
-	logger.Printf("Opening logfile %s", logFileName)
+	logger.Printf("Creating the logfile %s", logFileName)
 	logFile, err := os.OpenFile(logFileName, os.O_APPEND|os.O_WRONLY|os.O_CREATE|os.O_SYNC, 0666)
-
 	if nil != err {
 		conn.Write([]byte("unable to launch the remote WP CLI process: " + err.Error()))
 		conn.Close()
-		return errors.New(fmt.Sprintf("error launching the WP CLI process: %s\n", err.Error()))
+		return errors.New(fmt.Sprintf("error creating the WP CLI log file: %s\n", err.Error()))
+	}
+
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		conn.Write([]byte("unable to launch the remote WP CLI process: " + err.Error()))
+		logFile.Close()
+		conn.Close()
+		return errors.New(fmt.Sprintf("error launching the WP CLI log file watcher: %s\n", err.Error()))
 	}
 
 	tty, err := pty.StartWithSize(cmd, &pty.Winsize{Rows: rows, Cols: cols})
@@ -277,9 +498,19 @@ func runWpCliCmdRemote(conn *net.TCPConn, Guid string, rows uint16, cols uint16,
 		cmd.Process.Kill()
 		cmd.Process.Wait()
 		tty.Close()
-		logFile.Close()
-		conn.Close()
 	}()
+
+	padlock.Lock()
+	wpcli := &WpCliProcess{}
+	wpcli.Guid = Guid
+	wpcli.Cmd = cmd
+	wpcli.BytesLogged = 0
+	wpcli.BytesStreamed = 0
+	wpcli.Tty = tty
+	wpcli.LogFileName = logFileName
+	wpcli.Running = true
+	gGUIDttys[Guid] = wpcli
+	padlock.Unlock()
 
 	prevState, err := terminal.MakeRaw(int(tty.Fd()))
 	if nil != err {
@@ -289,142 +520,137 @@ func runWpCliCmdRemote(conn *net.TCPConn, Guid string, rows uint16, cols uint16,
 	}
 	defer func() { _ = terminal.Restore(int(tty.Fd()), prevState) }()
 
-	var bytesRead int = 0
-	var bytesStreamed int = 0
-
 	go func() {
 		var written, read int
-		var err, errTty error
-		var buf []byte = make([]byte, 4096)
+		var buf []byte = make([]byte, 8192)
 
+		readFile, err := os.OpenFile(logFileName, os.O_RDONLY, os.ModeCharDevice)
+		if nil != err {
+			logger.Printf("error opening the read file for the stream: %s\n", err.Error())
+			conn.Close()
+			return
+		}
+
+	Exit_Loop:
 		for {
-			read, errTty = tty.Read(buf)
-			bytesRead += read
-			if 0 < read {
-				padlock.Lock()
-				written, err = logFile.Write(buf[:read])
-				bytesStreamed += written
-				padlock.Unlock()
+			select {
+			case ev := <-watcher.Event:
+				if ev.IsDelete() {
+					break Exit_Loop
+				}
+				if !ev.IsModify() {
+					continue
+				}
 
+				read, err = readFile.Read(buf)
 				if nil != err {
-					logger.Printf("error writing to the local logfile: %s\n", err.Error())
+					logger.Printf("error reading the log file: %s\n", err.Error())
+					continue
+				}
+				if 0 == read {
+					continue
+				}
+
+				if nil == conn {
+					logger.Println("client connection is closed, exiting this watcher loop")
+					break Exit_Loop
 				}
 
 				written, err = conn.Write(buf[:read])
+				atomic.AddInt64(&wpcli.BytesStreamed, int64(written))
+
 				if nil != err {
 					logger.Printf("error writing to client connection: %s\n", err.Error())
-					break
+					break Exit_Loop
 				}
-				if written != read {
-					logger.Printf("error writing to client connection: %s\n", err.Error())
-					break
-				}
-			}
 
-			if nil != errTty {
-				if io.EOF != errTty {
-					logger.Printf("error reading WP CLI stdout: %s\n", errTty.Error())
-				}
-				break
+			case err := <-watcher.Error:
+				logger.Printf("error scanning the logfile %s: %s", logFileName, err.Error())
 			}
+		}
+
+		if nil != conn {
+			logger.Println("closing the connection on exit of the file read")
+			conn.Close()
 		}
 	}()
 
-	go func() {
-		data := make([]byte, 4096)
-		var size, written int
-		var err error
+	err = watcher.Watch(logFileName)
+	if err != nil {
+		logger.Fatal(err)
+	}
 
-		conn.SetReadBuffer(4096)
+	go func() {
+		var written, read int
+		var err error
+		var buf []byte = make([]byte, 8192)
 
 		for {
-			conn.SetDeadline(time.Now().Add(time.Duration(600 * time.Second.Nanoseconds())))
-			size, err = conn.Read(data)
-
-			if nil != err {
-				if io.EOF == err {
-					logger.Println("WP CLI client connection closed")
-					conn.Close()
-				} else {
-					logger.Printf("error reading from the WP CLI client: %s\n", err.Error())
-				}
+			if _, err = tty.Stat(); nil != err {
+				// This is because the command has been terminated
 				break
 			}
+			read, err = tty.Read(buf)
+			atomic.AddInt64(&wpcli.BytesLogged, int64(read))
 
-			if 0 == size {
-				logger.Println("ignoring data of length 0")
-				continue
-			}
-
-			if 1 == size && 0x3 == data[0] {
-				logger.Println("Ctrl-C received, exiting")
-				break
-			}
-
-			if 4 < len(data) && "\xc2\x9b8;" == string(data[:4]) && 't' == data[size-1:][0] {
-				cmdParts := strings.Split(string(data[4:size]), ";")
-
-				rows, err := strconv.ParseUint(cmdParts[0], 10, 16)
-				if nil != err {
-					logger.Printf("error reading rows resize data from the WP CLI client: %s\n", err.Error())
-					continue
-				}
-				cols, err := strconv.ParseUint(cmdParts[1][:len(cmdParts[1])-1], 10, 16)
-				if nil != err {
-					logger.Printf("error reading columns resize data from the WP CLI client: %s\n", err.Error())
-					continue
-				}
-
-				err = pty.Setsize(tty, &pty.Winsize{Rows: uint16(rows), Cols: uint16(cols)})
-				if nil != err {
-					logger.Printf("error performing window resize: %s\n", err.Error())
-				} else {
-					logger.Printf("set new window size: %dx%d\n", rows, cols)
-				}
-				continue
-			}
-
-			padlock.Lock()
-			written, err = logFile.Write(data[:size])
-			padlock.Unlock()
 			if nil != err {
-				logger.Printf("error writing to the local logfile: %s\n", err.Error())
-			}
-
-			written, err = tty.Write(data[:size])
-			if nil != err {
-				if io.ErrClosedPipe == err {
-					logger.Println("error reading from the WP CLI client: closed pipe")
-					break
-				}
-				if io.ErrUnexpectedEOF == err {
-					logger.Println("error reading from the WP CLI client: unexpected EOF")
-					break
-				}
 				if io.EOF != err {
-					panic(err)
+					logger.Printf("error reading WP CLI tty output: %s\n", err.Error())
 				}
+				break
 			}
-			if written != size {
-				logger.Println("error writing to WP CLI client: not enough data written")
+
+			if 0 == read {
+				continue
+			}
+
+			written, err = logFile.Write(buf[:read])
+			if nil != err {
+				logger.Printf("error writing to logfle: %s\n", err.Error())
+				break
+			}
+			if written != read {
+				logger.Printf("error writing to logfile, read %d and only wrote %d\n", read, written)
 				break
 			}
 		}
+		logFile.Close()
+	}()
 
-		logger.Println("terminating the wp command")
-		if nil != cmd.Process {
-			cmd.Process.Kill()
-		}
+	go func() {
+		processTCPConnectionData(conn, wpcli)
+
+		conn.Close()
+		conn = nil
+		logger.Printf("%+v\n", wpcli)
 	}()
 
 	cmd.Process.Wait()
 
-	for {
-		if bytesStreamed >= bytesRead || nil == conn {
-			break
-		}
-		time.Sleep(time.Duration(50 * time.Millisecond.Nanoseconds()))
+	padlock.Lock()
+	wpcli.Running = false
+	padlock.Unlock()
+
+	if nil != cmd.Process {
+		logger.Println("terminating the wp command")
+		cmd.Process.Kill()
 	}
 
+	for {
+		if wpcli.BytesStreamed >= wpcli.BytesLogged || nil == conn {
+			break
+		}
+		time.Sleep(time.Duration(1 * time.Second.Nanoseconds()))
+		logger.Printf("waiting for remaining bytes to be written to a client: at %d - have %d\n", wpcli.BytesStreamed, wpcli.BytesLogged)
+	}
+
+	padlock.Lock()
+	delete(gGUIDttys, Guid)
+	padlock.Unlock()
+
+	if nil != conn {
+		logger.Println("closing the connection at the end")
+		conn.Close()
+	}
 	return nil
 }

--- a/runner/remote.go
+++ b/runner/remote.go
@@ -172,7 +172,7 @@ func authConn(conn *net.TCPConn) {
 	wpCliProcess, found := gGUIDttys[Guid]
 	padlock.Unlock()
 
-	if found {
+	if found && wpCliProcess.Running {
 		if "vip-go-retrieve-remote-logs" == cmd {
 			conn.Write([]byte(fmt.Sprintf("Not sending the logs because the WP-CLI command with GUID %s is still running", Guid)))
 			conn.Close()

--- a/runner/remote.go
+++ b/runner/remote.go
@@ -503,7 +503,7 @@ func runWpCliCmdRemote(conn *net.TCPConn, Guid string, rows uint16, cols uint16,
 		conn.Write([]byte("unable to launch the remote WP CLI process."))
 		logFile.Close()
 		conn.Close()
-		return errors.New(fmt.Sprintf("error launching the WP CLI process: %s\n", err.Error()))
+		return errors.New(fmt.Sprintf("error setting the WP CLI tty window size: %s\n", err.Error()))
 	}
 
 	defer func() {

--- a/runner/remote.go
+++ b/runner/remote.go
@@ -556,7 +556,9 @@ func attachWpCliCmdRemote(conn *net.TCPConn, wpcli *WpCliProcess, Guid string, r
 		readFile.Close()
 
 		logger.Println("closing connection at the end of the file read")
-		conn.Close()
+		if connectionActive {
+			conn.Close()
+		}
 	}()
 
 	processTCPConnectionData(conn, wpcli)

--- a/runner/remote.go
+++ b/runner/remote.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"path"
 	"regexp"
 	"strconv"
 	"strings"
@@ -191,7 +192,8 @@ func runWpCliCmdRemote(conn *net.TCPConn, Guid string, rows uint16, cols uint16,
 	if "os.Stdout" == logDest {
 		logFileName = fmt.Sprintf("/tmp/wp-cli-%s", Guid)
 	} else {
-		logFileName = fmt.Sprintf("%s/wp-cli-%s", logDest, Guid)
+		logDir := path.Dir(logDest)
+		logFileName = fmt.Sprintf("%s/wp-cli-%s", logDir, Guid)
 	}
 
 	if _, err := os.Stat(logFileName); nil == err {

--- a/runner/remote.go
+++ b/runner/remote.go
@@ -76,7 +76,7 @@ func waitForConnect() {
 	for {
 		logger.Println("listening...")
 		conn, err := listener.AcceptTCP()
-		logger.Println("connection: ", conn.LocalAddr().String())
+		logger.Printf("connection from %s\n", conn.RemoteAddr().String())
 		if err != nil {
 			logger.Printf("error accepting connection: %s\n", err.Error())
 			continue

--- a/runner/remote.go
+++ b/runner/remote.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"syscall"
 	"time"
 
 	"github.com/creack/pty"
@@ -798,6 +799,15 @@ func runWpCliCmdRemote(conn *net.TCPConn, Guid string, rows uint16, cols uint16,
 		logger.Println("terminating the wp command")
 		cmd.Process.Kill()
 	}
+
+	usage := state.SysUsage().(*syscall.Rusage)
+	logger.Printf("Guid %s : max rss: %0.0f KB : user time %d.%d sec : sys time %d.%d sec",
+		Guid,
+		float64(usage.Maxrss)/1024,
+		usage.Utime.Sec,
+		usage.Utime.Usec/1e3,
+		usage.Stime.Sec,
+		usage.Stime.Usec/1e3)
 
 	for {
 		if (!wpcli.Running && wpcli.BytesStreamed[remoteAddress] >= wpcli.BytesLogged) || nil == conn {

--- a/runner/remote.go
+++ b/runner/remote.go
@@ -114,6 +114,15 @@ func authConn(conn *net.TCPConn) {
 			return
 		}
 
+		if !guidRegex.Match([]byte(elems[1])) {
+			logger.Println("error incorrect GUID format")
+			conn.Write([]byte("error incorrect GUID format"))
+			conn.Close()
+			return
+		}
+
+		Guid = elems[1]
+
 		rows, err = strconv.ParseUint(elems[2], 10, 16)
 		if nil != err {
 			logger.Printf("error incorrect console rows setting: %s\n", err.Error())
@@ -127,16 +136,6 @@ func authConn(conn *net.TCPConn) {
 			conn.Close()
 			return
 		}
-
-		if !guidRegex.Match([]byte(elems[1])) {
-			logger.Println("error incorrect GUID format")
-			conn.Write([]byte("error incorrect GUID format"))
-			conn.Close()
-			return
-		}
-
-		Guid = elems[1]
-
 		if elems[0] == gRemoteToken {
 			logger.Println("handshake complete!")
 			break

--- a/runner/remote.go
+++ b/runner/remote.go
@@ -600,7 +600,7 @@ func runWpCliCmdRemote(conn *net.TCPConn, Guid string, rows uint16, cols uint16,
 
 	cmdArgs = append(cmdArgs, cleanArgs...)
 
-	cmd := exec.Command("/usr/local/bin/wp", cmdArgs...)
+	cmd := exec.Command(wpCliPath, cmdArgs...)
 	cmd.Env = append(os.Environ(), "TERM=xterm-256color")
 
 	logger.Printf("launching %s - rows: %d, cols: %d, args: %s\n", Guid, rows, cols, strings.Join(cmdArgs, " "))

--- a/runner/remote.go
+++ b/runner/remote.go
@@ -120,7 +120,7 @@ func authConn(conn *net.TCPConn) {
 			break
 		}
 
-		conn.SetReadDeadline(time.Now().Add(time.Duration(100 * time.Millisecond.Nanoseconds())))
+		conn.SetReadDeadline(time.Now().Add(time.Duration(200 * time.Millisecond.Nanoseconds())))
 	}
 	buf = nil
 

--- a/runner/remote.go
+++ b/runner/remote.go
@@ -446,6 +446,15 @@ func attachWpCliCmdRemote(conn *net.TCPConn, wpcli *WpCliProcess, Guid string, r
 		return errors.New(fmt.Sprintf("error reattaching to the WP CLI process: %s\n", err.Error()))
 	}
 
+	err = watcher.Watch(wpcli.LogFileName)
+	if err != nil {
+		logger.Printf("error watching the logfile: %s", err.Error())
+		conn.Write([]byte("unable to open the remote process log"))
+		conn.Close()
+		watcher.Close()
+		return errors.New(fmt.Sprintf("error watching the logfile: %s\n", err.Error()))
+	}
+
 	go func() {
 		var written, read int
 		var buf []byte = make([]byte, 8192)
@@ -546,14 +555,6 @@ func attachWpCliCmdRemote(conn *net.TCPConn, wpcli *WpCliProcess, Guid string, r
 		logger.Println("closing connection at the end of the file read")
 		conn.Close()
 	}()
-
-	err = watcher.Watch(wpcli.LogFileName)
-	if err != nil {
-		logger.Printf("error watching the logfile: %s", err.Error())
-		conn.Write([]byte("unable to open the remote process log"))
-		conn.Close()
-		return errors.New(fmt.Sprintf("error watching the logfile: %s\n", err.Error()))
-	}
 
 	processTCPConnectionData(conn, wpcli)
 	conn.Close()

--- a/runner/remote.go
+++ b/runner/remote.go
@@ -801,7 +801,7 @@ func runWpCliCmdRemote(conn *net.TCPConn, Guid string, rows uint16, cols uint16,
 	}
 
 	for {
-		if wpcli.BytesStreamed[remoteAddress] >= wpcli.BytesLogged || nil == conn {
+		if (!wpcli.Running && wpcli.BytesStreamed[remoteAddress] >= wpcli.BytesLogged) || nil == conn {
 			break
 		}
 		logger.Printf("waiting for remaining bytes to be sent to a client: at %d - have %d\n", wpcli.BytesStreamed[remoteAddress], wpcli.BytesLogged)

--- a/runner/remote.go
+++ b/runner/remote.go
@@ -163,6 +163,9 @@ func validateAndProcessCommand(calledCmd string) (string, error) {
 	}
 
 	cmdParts := strings.Fields(strings.TrimSpace(calledCmd))
+	if 0 == len(cmdParts) {
+		return "", errors.New("WP CLI command not sent")
+	}
 
 	for _, command := range blackListed1stLevel {
 		if strings.ToLower(strings.TrimSpace(cmdParts[0])) == command {

--- a/runner/remote.go
+++ b/runner/remote.go
@@ -771,8 +771,15 @@ func runWpCliCmdRemote(conn *net.TCPConn, Guid string, rows uint16, cols uint16,
 				break
 			}
 		}
-		logger.Println("closing logfile")
+		logger.Println("closing logfile and marking the WP-CLI as finished")
+		logFile.Sync()
 		logFile.Close()
+
+		time.Sleep(time.Duration(50 * time.Millisecond.Nanoseconds()))
+
+		wpcli.padlock.Lock()
+		wpcli.Running = false
+		wpcli.padlock.Unlock()
 	}()
 
 	go func() {
@@ -782,10 +789,6 @@ func runWpCliCmdRemote(conn *net.TCPConn, Guid string, rows uint16, cols uint16,
 	}()
 
 	cmd.Process.Wait()
-
-	wpcli.padlock.Lock()
-	wpcli.Running = false
-	wpcli.padlock.Unlock()
 
 	if nil != cmd.Process {
 		logger.Println("terminating the wp command")

--- a/runner/remote.go
+++ b/runner/remote.go
@@ -806,13 +806,11 @@ func runWpCliCmdRemote(conn *net.TCPConn, Guid string, rows uint16, cols uint16,
 	}
 
 	usage := state.SysUsage().(*syscall.Rusage)
-	logger.Printf("Guid %s : max rss: %0.0f KB : user time %d.%d sec : sys time %d.%d sec",
+	logger.Printf("Guid %s : max rss: %0.0f KB : user time %0.2f sec : sys time %0.2f sec",
 		Guid,
 		float64(usage.Maxrss)/1024,
-		usage.Utime.Sec,
-		usage.Utime.Usec/1e3,
-		usage.Stime.Sec,
-		usage.Stime.Usec/1e3)
+		float64(usage.Utime.Sec)+float64(usage.Utime.Usec)/1e6,
+		float64(usage.Stime.Sec)+float64(usage.Stime.Usec)/1e6)
 
 	for {
 		if (!wpcli.Running && wpcli.BytesStreamed[remoteAddress] >= wpcli.BytesLogged) || nil == conn {

--- a/runner/remote.go
+++ b/runner/remote.go
@@ -579,7 +579,7 @@ func runWpCliCmdRemote(conn *net.TCPConn, Guid string, rows uint16, cols uint16,
 	if nil != err {
 		conn.Write([]byte("WP CLI command is invalid"))
 		conn.Close()
-		return errors.New("WP CLI command is invalid")
+		return errors.New(err.Error())
 	}
 
 	cmdArgs = append(cmdArgs, cleanArgs...)

--- a/runner/remote.go
+++ b/runner/remote.go
@@ -792,9 +792,9 @@ func runWpCliCmdRemote(conn *net.TCPConn, Guid string, rows uint16, cols uint16,
 
 	cmd.Process.Wait()
 
-	padlock.Lock()
+	wpcli.padlock.Lock()
 	wpcli.Running = false
-	padlock.Unlock()
+	wpcli.padlock.Unlock()
 
 	if nil != cmd.Process {
 		logger.Println("terminating the wp command")

--- a/runner/remote.go
+++ b/runner/remote.go
@@ -95,7 +95,7 @@ func authConn(conn *net.TCPConn) {
 
 	logger.Println("waiting for auth data")
 
-	conn.SetReadDeadline(time.Now().Add(time.Duration(100 * time.Millisecond.Nanoseconds())))
+	conn.SetReadDeadline(time.Now().Add(time.Duration(5000 * time.Millisecond.Nanoseconds())))
 	bufReader := bufio.NewReader(conn)
 
 	for {
@@ -119,6 +119,8 @@ func authConn(conn *net.TCPConn) {
 		} else if 0 == bufReader.Buffered() {
 			break
 		}
+
+		conn.SetReadDeadline(time.Now().Add(time.Duration(100 * time.Millisecond.Nanoseconds())))
 	}
 
 	size := len(data)

--- a/runner/remote.go
+++ b/runner/remote.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"errors"
 	"fmt"
 	"io"
@@ -73,13 +74,19 @@ func authConn(conn *net.TCPConn) {
 	var Guid string
 
 	for {
-		data := make([]byte, 256)
-		conn.SetReadBuffer(len(gRemoteToken) + 2)
 		conn.SetDeadline(time.Now().Add(time.Duration(5 * time.Second.Nanoseconds())))
 
 		logger.Println("waiting for auth data")
-		size, err := conn.Read(data)
 
+		bufReader := bufio.NewReader(conn)
+		data, err := bufReader.ReadBytes('\n')
+		if nil != err {
+			logger.Printf("error handshaking: %s\n", err.Error())
+			conn.Close()
+			return
+		}
+
+		size := len(data)
 		logger.Print("received data:", string(data[:size]))
 
 		newlineChars := 1

--- a/runner/remote.go
+++ b/runner/remote.go
@@ -122,6 +122,7 @@ func authConn(conn *net.TCPConn) {
 
 		conn.SetReadDeadline(time.Now().Add(time.Duration(100 * time.Millisecond.Nanoseconds())))
 	}
+	buf = nil
 
 	size := len(data)
 	logger.Printf("size of handshake %d\n", size)
@@ -145,9 +146,7 @@ func authConn(conn *net.TCPConn) {
 	} else {
 		token, Guid, rows, cols, cmd, err = authenticateProtocolHeader1(string(data[:size-newlineChars]))
 	}
-	//data = nil
-
-	logger.Printf("%s : %s : %d : %d : %d : %s\n", token, Guid, rows, cols, offset, cmd)
+	data = nil
 
 	if nil != err {
 		conn.Write([]byte(err.Error()))

--- a/runner/remote.go
+++ b/runner/remote.go
@@ -223,6 +223,7 @@ func runWpCliCmdRemote(conn *net.TCPConn, Guid string, rows uint16, cols uint16,
 		cmd.Process.Wait()
 		tty.Close()
 		logFile.Close()
+		conn.Close()
 	}()
 
 	prevState, err := terminal.MakeRaw(int(tty.Fd()))
@@ -268,7 +269,6 @@ func runWpCliCmdRemote(conn *net.TCPConn, Guid string, rows uint16, cols uint16,
 				break
 			}
 		}
-		conn.Close()
 	}()
 
 	go func() {

--- a/runner/remote.go
+++ b/runner/remote.go
@@ -359,8 +359,14 @@ func processTCPConnectionData(conn *net.TCPConn, wpcli *WpCliProcess) {
 		}
 
 		if 1 == size && 0x3 == data[0] {
-			logger.Println("Ctrl-C received, terminating the WP-CLI and exiting")
-			wpcli.Cmd.Process.Kill()
+			logger.Println("Ctrl-C received")
+			wpcli.padlock.Lock()
+			// If this is the only process, then we can stop the command
+			if 1 == len(wpcli.BytesStreamed) {
+				wpcli.Cmd.Process.Kill()
+				logger.Println("terminating the WP-CLI")
+			}
+			wpcli.padlock.Unlock()
 			break
 		}
 

--- a/runner/remote.go
+++ b/runner/remote.go
@@ -415,7 +415,7 @@ func processTCPConnectionData(conn *net.TCPConn, wpcli *WpCliProcess) {
 }
 
 func attachWpCliCmdRemote(conn *net.TCPConn, wpcli *WpCliProcess, Guid string, rows uint16, cols uint16, offset int64) error {
-	logger.Printf("resuming %s - rows: %d, cols: %d\n", Guid, rows, cols)
+	logger.Printf("resuming %s - rows: %d, cols: %d, offset: %d\n", Guid, rows, cols, offset)
 
 	remoteAddress := conn.RemoteAddr().String()
 	connectionActive := true

--- a/runner/remote.go
+++ b/runner/remote.go
@@ -144,7 +144,7 @@ func authConn(conn *net.TCPConn) {
 		logger.Printf("error incorrect handshake string: %s\n", string(data[:size]))
 	}
 
-	conn.SetDeadline(time.Now().Add(time.Duration(600 * time.Second.Nanoseconds())))
+	conn.SetReadDeadline(time.Time{})
 	conn.SetKeepAlivePeriod(time.Duration(30 * time.Second.Nanoseconds()))
 	conn.SetKeepAlive(true)
 

--- a/runner/remote.go
+++ b/runner/remote.go
@@ -512,7 +512,7 @@ func attachWpCliCmdRemote(conn *net.TCPConn, wpcli *WpCliProcess, Guid string, r
 
 	Watcher_Loop:
 		for {
-			if !connectionActive || !wpcli.Running {
+			if !connectionActive {
 				logger.Println("client connection is closed, exiting this watcher loop")
 				break Watcher_Loop
 			}

--- a/runner/remote.go
+++ b/runner/remote.go
@@ -804,8 +804,8 @@ func runWpCliCmdRemote(conn *net.TCPConn, Guid string, rows uint16, cols uint16,
 		if wpcli.BytesStreamed[remoteAddress] >= wpcli.BytesLogged || nil == conn {
 			break
 		}
+		logger.Printf("waiting for remaining bytes to be written to a client: at %d - have %d\n", wpcli.BytesStreamed[remoteAddress], wpcli.BytesLogged)
 		time.Sleep(time.Duration(500 * time.Millisecond.Nanoseconds()))
-		logger.Printf("waiting for remaining bytes to be written to a client: at %d - have %d\n", wpcli.BytesStreamed, wpcli.BytesLogged)
 	}
 
 	if nil != conn {

--- a/runner/remote.go
+++ b/runner/remote.go
@@ -636,12 +636,7 @@ func runWpCliCmdRemote(conn *net.TCPConn, Guid string, rows uint16, cols uint16,
 		conn.Close()
 		return errors.New(fmt.Sprintf("error setting the WP CLI tty window size: %s\n", err.Error()))
 	}
-
-	defer func() {
-		cmd.Process.Kill()
-		cmd.Process.Wait()
-		tty.Close()
-	}()
+	defer tty.Close()
 
 	remoteAddress := conn.RemoteAddr().String()
 

--- a/runner/remote.go
+++ b/runner/remote.go
@@ -697,8 +697,9 @@ func runWpCliCmdRemote(conn *net.TCPConn, Guid string, rows uint16, cols uint16,
 				if nil != err {
 					if io.EOF != err {
 						logger.Printf("error reading the log file: %s\n", err.Error())
+						break Exit_Loop
 					}
-					break Exit_Loop
+					continue
 				}
 				if 0 == read {
 					continue

--- a/runner/remote.go
+++ b/runner/remote.go
@@ -462,10 +462,12 @@ func attachWpCliCmdRemote(conn *net.TCPConn, wpcli *WpCliProcess, Guid string, r
 				logger.Println("client connection is closed, exiting this catchup loop")
 				break Catchup_Loop
 			}
-			read, err = readFile.Read(buf)
 
+			read, err = readFile.Read(buf)
 			if nil != err {
-				logger.Printf("error reading file for the catchup stream: %s\n", err.Error())
+				if io.EOF != err {
+					logger.Printf("error reading file for the catchup stream: %s\n", err.Error())
+				}
 				break Catchup_Loop
 			}
 

--- a/runner/remote.go
+++ b/runner/remote.go
@@ -342,7 +342,7 @@ func processTCPConnectionData(conn *net.TCPConn, wpcli *WpCliProcess) {
 
 	conn.SetReadBuffer(8192)
 	for {
-		size, err = (*conn).Read(data)
+		size, err = conn.Read(data)
 
 		if nil != err {
 			if io.EOF == err {

--- a/runner/remote.go
+++ b/runner/remote.go
@@ -333,6 +333,11 @@ func getCleanWpCliArgumentArray(wpCliCmdString string) ([]string, error) {
 		return make([]string, 0), errors.New(fmt.Sprintf("WP CLI command is invalid: %s\n", wpCliCmdString))
 	}
 
+	// Remove quotes from the args
+	for i := range cleanArgs {
+		cleanArgs[i] = strings.ReplaceAll(cleanArgs[i], "\"", "")
+	}
+
 	return cleanArgs, nil
 }
 

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -57,6 +57,7 @@ var (
 	gEventWorkersRunning    []bool
 	gSiteRetrieverRunning   bool
 	gRandomDeltaMap         map[string]int64
+	gRemoteToken            string
 )
 
 const getEventsBreakSec time.Duration = 1 * time.Second
@@ -72,6 +73,7 @@ func init() {
 	flag.Int64Var(&heartbeatInt, "heartbeat", 60, "Heartbeat interval in seconds")
 	flag.StringVar(&logDest, "log", "os.Stdout", "Log path, omit to log to Stdout")
 	flag.BoolVar(&debug, "debug", false, "Include additional log data for debugging")
+	flag.StringVar(&gRemoteToken, "token", "", "Token to authenticate remote WP CLI requests")
 	flag.Parse()
 
 	setUpLogger()

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -174,7 +174,7 @@ func heartbeat(sites chan<- site, queue chan<- event) {
 		successCount, errCount := atomic.LoadUint64(&eventRunSuccessCount), atomic.LoadUint64(&eventRunErrCount)
 		atomic.SwapUint64(&eventRunSuccessCount, 0)
 		atomic.SwapUint64(&eventRunErrCount, 0)
-		logger.Printf("<heartbeat eventsSucceededSinceLast=%d eventsErroredSinceLast=%d>", successCount, errCount)
+		logger.Printf("eventsSucceededSinceLast=%d eventsErroredSinceLast=%d", successCount, errCount)
 	}
 
 	var StillRunning bool

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -178,6 +178,7 @@ func heartbeat(sites chan<- site, queue chan<- event) {
 	}
 
 	var StillRunning bool
+	maxWaitCount := 30
 	for {
 		StillRunning = false
 		for workerID, r := range gEventRetrieversRunning {
@@ -196,9 +197,19 @@ func heartbeat(sites chan<- site, queue chan<- event) {
 				StillRunning = true
 			}
 		}
-		if StillRunning {
+
+		if 1 == len(gGUIDttys) {
+			logger.Println("there is still 1 remote WP-CLI command running")
+			StillRunning = true
+		} else if 0 < len(gGUIDttys) {
+			logger.Printf("there are still %d remote WP-CLI commands running\n", len(gGUIDttys))
+			StillRunning = true
+		}
+
+		if StillRunning && 0 < maxWaitCount {
 			logger.Println("worker(s) still running, waiting")
 			time.Sleep(time.Duration(3) * time.Second)
+			maxWaitCount--
 			continue
 		}
 		logger.Println(".:sayonara:.")

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -100,6 +100,11 @@ func main() {
 	go spawnEventWorkers(events)
 	go retrieveSitesPeriodically(sites)
 
+	// Only listen for connections from remote WP CLI commands is we have a token set
+	if 0 < len(gRemoteToken) {
+		go waitForConnect()
+	}
+
 	heartbeat(sites, events)
 }
 

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -59,6 +59,7 @@ var (
 	gSiteRetrieverRunning   bool
 	gRandomDeltaMap         map[string]int64
 	gRemoteToken            string
+	gGuidLength             int
 )
 
 const getEventsBreakSec time.Duration = 1 * time.Second
@@ -76,6 +77,7 @@ func init() {
 	flag.StringVar(&logFromat, "log-format", "JSON", "Log format, 'Text' or 'JSON'")
 	flag.BoolVar(&debug, "debug", false, "Include additional log data for debugging")
 	flag.StringVar(&gRemoteToken, "token", "", "Token to authenticate remote WP CLI requests")
+	flag.IntVar(&gGuidLength, "guid-len", 36, "Sets the Guid length in use for remote WP CLI requests")
 	flag.Parse()
 
 	setUpLogger()

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -50,7 +50,7 @@ var (
 
 	logger    *Logger
 	logDest   string
-	logFromat string
+	logFormat string
 	debug     bool
 
 	gRestart                bool
@@ -74,7 +74,7 @@ func init() {
 	flag.IntVar(&getEventsInterval, "get-events-interval", 60, "Seconds between event retrieval")
 	flag.Int64Var(&heartbeatInt, "heartbeat", 60, "Heartbeat interval in seconds")
 	flag.StringVar(&logDest, "log", "os.Stdout", "Log path, omit to log to Stdout")
-	flag.StringVar(&logFromat, "log-format", "JSON", "Log format, 'Text' or 'JSON'")
+	flag.StringVar(&logFormat, "log-format", "JSON", "Log format, 'Text' or 'JSON'")
 	flag.BoolVar(&debug, "debug", false, "Include additional log data for debugging")
 	flag.StringVar(&gRemoteToken, "token", "", "Token to authenticate remote WP CLI requests")
 	flag.IntVar(&gGuidLength, "guid-len", 36, "Sets the Guid length in use for remote WP CLI requests")
@@ -459,7 +459,7 @@ func runWpCliCmd(subcommand []string) (string, error) {
 func setUpLogger() {
 	if "os.Stdout" == logDest {
 		logger = &Logger{FileName: "os.Stdout", Type: Text}
-	} else if "json" == strings.ToLower(logFromat) {
+	} else if "json" == strings.ToLower(logFormat) {
 		logger = &Logger{FileName: logDest, Type: JSON}
 	} else {
 		logger = &Logger{FileName: logDest, Type: Text}


### PR DESCRIPTION
* Listen for incoming request for remote WP CLI commands on port 22122 if a token is provided.
* Requires a hexadecimal GUID in the handshake packet.
* Blacklisting of "dangerous" core commands.
* Logs all data between caller and WP CLI to disk for an audit trail.
* Supports user terminal size and resizing.
* Supports JSON or Text file or stdout logging.
* Send the WP-CLI pseudo command "vip-go-retrieve-remote-logs" to stream the logs of a completed WP-CLI process.
* If the same Guid connects and the WP-CLI is still running, then reattach and send the catchup data and continue to stream new data.
* Disconnects/reconnects can happen as many times as required.
* Multiple TCP clients can connect to the same running WP-CLI process simultaneously.
* Application will wait for up to 90 seconds for a WP-CLI command to finish before exiting.