### PR TITLE
Allow passing a timestamp to internal events

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,12 +37,15 @@ In `wp-config.php` or a similarly-early and appropriate place, define `CRON_CONT
 ```
 define( 'CRON_CONTROL_ADDITIONAL_INTERNAL_EVENTS', array(
 array(
-	'schedule' => 'hourly',
-	'action'   => 'do_a_thing',
-	'callback' => '__return_true',
+	'schedule'  => 'hourly',
+	'action'    => 'do_a_thing',
+	'callback'  => '__return_true',
+	'timestamp' => strtotime( '+60 seconds' ),
 ),
 ) );
 ```
+
+The `timestamp` parameter is optional, and will default to +60 seconds if left off. Useful in cases where you would like to stagger the intial run of a new internal event across sites.
 
 Due to the early loading (to limit additions), the `action` and `callback` generally can't directly reference any Core, plugin, or theme code. Since WordPress uses actions to trigger cron, class methods can be referenced, so long as the class name is not dynamically referenced. For example:
 

--- a/includes/class-internal-events.php
+++ b/includes/class-internal-events.php
@@ -148,13 +148,12 @@ class Internal_Events extends Singleton {
 	 * Schedule internal events
 	 */
 	public function schedule_internal_events() {
-		$when = strtotime( sprintf( '+%d seconds', JOB_QUEUE_WINDOW_IN_SECONDS ) );
-
 		$schedules = wp_get_schedules();
 
 		foreach ( $this->internal_events as $event_args ) {
 			if ( ! wp_next_scheduled( $event_args['action'] ) ) {
-				$interval = array_key_exists( $event_args['schedule'], $schedules ) ? $schedules[ $event_args['schedule'] ]['interval'] : 0;
+				$interval  = array_key_exists( $event_args['schedule'], $schedules ) ? $schedules[ $event_args['schedule'] ]['interval'] : 0;
+				$timestamp = isset( $event_args['timestamp'] ) ? (int) $event_args['timestamp'] : strtotime( sprintf( '+%d seconds', JOB_QUEUE_WINDOW_IN_SECONDS ) );
 
 				$args = array(
 					'schedule' => $event_args['schedule'],
@@ -162,7 +161,7 @@ class Internal_Events extends Singleton {
 					'interval' => $interval,
 				);
 
-				schedule_event( $when, $event_args['action'], $args );
+				schedule_event( $timestamp, $event_args['action'], $args );
 			}
 		}
 	}


### PR DESCRIPTION
The documentation update explains this pretty well. The main use case is needing to setup a new internal event across a lot of sites, and wanting to stagger them a bit as to avoid both heavy load on multi-sites and on other servers for cases where we make external requests in the job.

Example:

```
define( 'CRON_CONTROL_ADDITIONAL_INTERNAL_EVENTS', array(
	array(
		'schedule'  => 'hourly',
		'action'    => 'wpcom_vip_test_cron_control_job',
		'callback'  => 'wpcom_vip_test_cron_control_job',
		'timestamp' => strtotime( sprintf( '+%d minutes', mt_rand( 1, 60 ) ) ),
	)
) );
```

This only affects the first time the job is registered.