### PR TITLE
Fix PHPCS Errors

### DIFF
--- a/includes/class-events-store.php
+++ b/includes/class-events-store.php
@@ -598,7 +598,9 @@ class Events_Store extends Singleton {
 		// Create the post, or update an existing entry to run again in the future.
 		if ( is_int( $update_id ) && $update_id > 0 ) {
 			$wpdb->update(
-				$this->get_table_name(), $job_post, array(
+				$this->get_table_name(),
+				$job_post,
+				array(
 					'ID' => $update_id,
 				)
 			);
@@ -660,7 +662,9 @@ class Events_Store extends Singleton {
 		);
 
 		$success = $wpdb->update(
-			$this->get_table_name(), $updates, array(
+			$this->get_table_name(),
+			$updates,
+			array(
 				'ID' => $job_id,
 			)
 		);
@@ -855,7 +859,8 @@ class Events_Store extends Singleton {
 
 		if ( $count > 0 ) {
 			$wpdb->delete(
-				$this->get_table_name(), array(
+				$this->get_table_name(),
+				array(
 					'status' => self::STATUS_COMPLETED,
 				)
 			);

--- a/includes/class-events.php
+++ b/includes/class-events.php
@@ -254,7 +254,9 @@ class Events extends Singleton {
 		// Validate input data.
 		if ( empty( $timestamp ) || empty( $action ) || empty( $instance ) ) {
 			return new \WP_Error(
-				'missing-data', __( 'Invalid or incomplete request data.', 'automattic-cron-control' ), array(
+				'missing-data',
+				__( 'Invalid or incomplete request data.', 'automattic-cron-control' ),
+				array(
 					'status' => 400,
 				)
 			);
@@ -264,7 +266,9 @@ class Events extends Singleton {
 		if ( ! $force && $timestamp > time() ) {
 			return new \WP_Error(
 				/* translators: 1: Job identifier */
-				'premature', sprintf( __( 'Job with identifier `%1$s` is not scheduled to run yet.', 'automattic-cron-control' ), "$timestamp-$action-$instance" ), array(
+				'premature',
+				sprintf( __( 'Job with identifier `%1$s` is not scheduled to run yet.', 'automattic-cron-control' ), "$timestamp-$action-$instance" ),
+				array(
 					'status' => 403,
 				)
 			);
@@ -284,7 +288,9 @@ class Events extends Singleton {
 		if ( ! is_object( $event ) ) {
 			return new \WP_Error(
 				/* translators: 1: Job identifier */
-				'no-event', sprintf( __( 'Job with identifier `%1$s` could not be found.', 'automattic-cron-control' ), "$timestamp-$action-$instance" ), array(
+				'no-event',
+				sprintf( __( 'Job with identifier `%1$s` could not be found.', 'automattic-cron-control' ), "$timestamp-$action-$instance" ),
+				array(
 					'status' => 404,
 				)
 			);
@@ -300,7 +306,9 @@ class Events extends Singleton {
 			if ( ! $this->can_run_event( $event ) ) {
 				return new \WP_Error(
 					/* translators: 1: Event action, 2: Event arguments */
-					'no-free-threads', sprintf( __( 'No resources available to run the job with action `%1$s` and arguments `%2$s`.', 'automattic-cron-control' ), $event->action, maybe_serialize( $event->args ) ), array(
+					'no-free-threads',
+					sprintf( __( 'No resources available to run the job with action `%1$s` and arguments `%2$s`.', 'automattic-cron-control' ), $event->action, maybe_serialize( $event->args ) ),
+					array(
 						'status' => 429,
 					)
 				);

--- a/includes/class-main.php
+++ b/includes/class-main.php
@@ -92,7 +92,8 @@ class Main extends Singleton {
 			status_header( 403 );
 			wp_send_json_error(
 				/* translators: 1: Plugin name */
-				new \WP_Error( 'forbidden', sprintf( __( 'Normal cron execution is blocked when the %s plugin is active.', 'automattic-cron-control' ), 'Cron Control' ) ), array(
+				new \WP_Error( 'forbidden', sprintf( __( 'Normal cron execution is blocked when the %s plugin is active.', 'automattic-cron-control' ), 'Cron Control' ) ),
+				array(
 					'status' => 400,
 				)
 			);

--- a/includes/class-rest-api.php
+++ b/includes/class-rest-api.php
@@ -38,7 +38,9 @@ class REST_API extends Singleton {
 	 */
 	public function rest_api_init() {
 		register_rest_route(
-			self::API_NAMESPACE, '/' . self::ENDPOINT_LIST, array(
+			self::API_NAMESPACE,
+			'/' . self::ENDPOINT_LIST,
+			array(
 				'methods'             => 'POST',
 				'callback'            => array( $this, 'get_events' ),
 				'permission_callback' => array( $this, 'check_secret' ),
@@ -47,7 +49,9 @@ class REST_API extends Singleton {
 		);
 
 		register_rest_route(
-			self::API_NAMESPACE, '/' . self::ENDPOINT_RUN, array(
+			self::API_NAMESPACE,
+			'/' . self::ENDPOINT_RUN,
+			array(
 				'methods'             => 'PUT',
 				'callback'            => array( $this, 'run_event' ),
 				'permission_callback' => array( $this, 'check_secret' ),
@@ -99,7 +103,9 @@ class REST_API extends Singleton {
 
 			return rest_ensure_response(
 				new \WP_Error(
-					'automatic-execution-disabled', $message, array(
+					'automatic-execution-disabled',
+					$message,
+					array(
 						'status' => 403,
 					)
 				)
@@ -130,7 +136,9 @@ class REST_API extends Singleton {
 		// For now, mimic original plugin's "authentication" method. This needs to be better.
 		if ( ! isset( $body['secret'] ) || ! hash_equals( \WP_CRON_CONTROL_SECRET, $body['secret'] ) ) {
 			return new \WP_Error(
-				'no-secret', __( 'Secret must be specified with all requests', 'automattic-cron-control' ), array(
+				'no-secret',
+				__( 'Secret must be specified with all requests', 'automattic-cron-control' ),
+				array(
 					'status' => 400,
 				)
 			);

--- a/includes/wp-cli/class-events.php
+++ b/includes/wp-cli/class-events.php
@@ -64,7 +64,9 @@ class Events extends \WP_CLI_Command {
 			}
 
 			\WP_CLI\Utils\format_items(
-				$format, $events_for_display, array(
+				$format,
+				$events_for_display,
+				array(
 					'ID',
 					'action',
 					'instance',
@@ -514,7 +516,9 @@ class Events extends \WP_CLI_Command {
 			}
 
 			\WP_CLI\Utils\format_items(
-				'table', $events_to_delete, array(
+				'table',
+				$events_to_delete,
+				array(
 					'ID',
 					'created',
 					'last_modified',
@@ -585,7 +589,8 @@ class Events extends \WP_CLI_Command {
 			// Limit just to failed deletes when many events are removed.
 			if ( count( $events_deleted ) > $assoc_args['limit'] ) {
 				$events_deleted = array_filter(
-					$events_deleted, function( $event ) {
+					$events_deleted,
+					function( $event ) {
 						if ( 'no' === $event['deleted'] ) {
 							return $event;
 						} else {
@@ -604,7 +609,9 @@ class Events extends \WP_CLI_Command {
 			// Don't display a table if there's nothing to display.
 			if ( count( $events_deleted ) > 0 ) {
 				\WP_CLI\Utils\format_items(
-					'table', $events_deleted, array(
+					'table',
+					$events_deleted,
+					array(
 						'ID',
 						'deleted',
 					)

--- a/includes/wp-cli/class-orchestrate-runner.php
+++ b/includes/wp-cli/class-orchestrate-runner.php
@@ -34,7 +34,9 @@ class Orchestrate_Runner extends \WP_CLI_Command {
 		$format = \WP_CLI\Utils\get_flag_value( $assoc_args, 'format', 'table' );
 
 		\WP_CLI\Utils\format_items(
-			$format, $events['events'], array(
+			$format,
+			$events['events'],
+			array(
 				'timestamp',
 				'action',
 				'instance',

--- a/includes/wp-cli/class-rest-api.php
+++ b/includes/wp-cli/class-rest-api.php
@@ -63,7 +63,9 @@ class REST_API extends \WP_CLI_Command {
 		}
 
 		\WP_CLI\Utils\format_items(
-			$format, $events_for_display, array(
+			$format,
+			$events_for_display,
+			array(
 				'timestamp',
 				'action',
 				'instance',

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -2,6 +2,8 @@
 <ruleset name="WordPress Coding Standards for Plugins">
 	<description>Generally-applicable sniffs for WordPress plugins</description>
 
+	<config name="ignore_warnings_on_exit" value="1" />
+
 	<rule ref="WordPress-Core" />
 	<rule ref="WordPress-Docs" />
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -20,7 +20,8 @@ function _manually_load_plugin() {
 	define( 'WP_CRON_CONTROL_SECRET', 'testtesttest' );
 
 	define(
-		'CRON_CONTROL_ADDITIONAL_INTERNAL_EVENTS', array(
+		'CRON_CONTROL_ADDITIONAL_INTERNAL_EVENTS',
+		array(
 			array(
 				'schedule' => 'hourly',
 				'action'   => 'cron_control_additional_internal_event',

--- a/tests/tests/class-events-store-tests.php
+++ b/tests/tests/class-events-store-tests.php
@@ -178,11 +178,13 @@ class Events_Store_Tests extends \WP_UnitTestCase {
 	function test_get_job_by_attributes() {
 		$event = Utils::create_test_event();
 
-		$event_from_store = \Automattic\WP\Cron_Control\get_event_by_attributes( [
-			'timestamp' => $event['timestamp'],
-			'action'    => $event['action'],
-			'instance'  => md5( maybe_serialize( $event['args'] ) ),
-		] );
+		$event_from_store = \Automattic\WP\Cron_Control\get_event_by_attributes(
+			[
+				'timestamp' => $event['timestamp'],
+				'action'    => $event['action'],
+				'instance'  => md5( maybe_serialize( $event['args'] ) ),
+			]
+		);
 
 		$this->assertInternalType( 'object', $event_from_store );
 	}
@@ -193,12 +195,14 @@ class Events_Store_Tests extends \WP_UnitTestCase {
 	function test_get_job_by_attributes_with_any_status() {
 		$event = Utils::create_test_event();
 
-		$event_from_store = \Automattic\WP\Cron_Control\get_event_by_attributes( [
-			'timestamp' => $event['timestamp'],
-			'action'    => $event['action'],
-			'instance'  => md5( maybe_serialize( $event['args'] ) ),
-			'status'    => 'any',
-		] );
+		$event_from_store = \Automattic\WP\Cron_Control\get_event_by_attributes(
+			[
+				'timestamp' => $event['timestamp'],
+				'action'    => $event['action'],
+				'instance'  => md5( maybe_serialize( $event['args'] ) ),
+				'status'    => 'any',
+			]
+		);
 
 		$this->assertInternalType( 'object', $event_from_store );
 	}
@@ -209,10 +213,12 @@ class Events_Store_Tests extends \WP_UnitTestCase {
 	function test_get_job_by_attributes_with_insufficient_args() {
 		$event = Utils::create_test_event();
 
-		$event_from_store = \Automattic\WP\Cron_Control\get_event_by_attributes( [
-			'timestamp' => $event['timestamp'],
-			'action'    => $event['action'],
-		] );
+		$event_from_store = \Automattic\WP\Cron_Control\get_event_by_attributes(
+			[
+				'timestamp' => $event['timestamp'],
+				'action'    => $event['action'],
+			]
+		);
 
 		$this->assertFalse( $event_from_store );
 	}

--- a/tests/tests/class-rest-api-tests.php
+++ b/tests/tests/class-rest-api-tests.php
@@ -94,7 +94,8 @@ class REST_API_Tests extends \WP_UnitTestCase {
 				),
 				'endpoint'             => get_rest_url( null, \Automattic\WP\Cron_Control\REST_API::API_NAMESPACE . '/' . \Automattic\WP\Cron_Control\REST_API::ENDPOINT_RUN ),
 				'total_events_pending' => 1,
-			), $response
+			),
+			$response
 		);
 	}
 


### PR DESCRIPTION
Latest version of PHPCS rules throw errors (mostly around 1 argument per line in multiline function calls). 

Just ran `phpcbf` and that autofixed them all.