### PR TITLE
Fix: Undefined variable: status

### DIFF
--- a/includes/wp-cli/class-events.php
+++ b/includes/wp-cli/class-events.php
@@ -229,7 +229,7 @@ class Events extends \WP_CLI_Command {
 		$total_items = \Automattic\WP\Cron_Control\count_events_by_status( $event_status );
 		$total_pages = ceil( $total_items / $limit );
 
-		return compact( 'status', 'limit', 'page', 'offset', 'items', 'total_items', 'total_pages' );
+		return compact( 'limit', 'page', 'offset', 'items', 'total_items', 'total_pages' );
 	}
 
 	/**


### PR DESCRIPTION
Fixes a PHP Notice:

> Notice: compact(): Undefined variable: status in /path/to/cron-control/includes/wp-cli/class-events.php on line 230

The `$status` variable is unset on line 198.

No usage of this method was found that relies on the `status` key being set.