### PR TITLE
Fix: Events count format

### DIFF
--- a/includes/wp-cli/class-events.php
+++ b/includes/wp-cli/class-events.php
@@ -24,6 +24,13 @@ class Events extends \WP_CLI_Command {
 	public function list_events( $args, $assoc_args ) {
 		$events = $this->get_events( $args, $assoc_args );
 
+		// Show the event count and abort. Works with --status flag.
+		if ( isset( $assoc_args['format'] ) && 'count' === $assoc_args['format'] ) {
+			\WP_CLI::log( $events['total_items'] );
+
+			return;
+		}
+
 		// Prevent one from requesting a page that doesn't exist.
 		// Shouldn't error when first page is requested, though, as that is handled below and is an odd behaviour otherwise.
 		if ( $events['page'] > $events['total_pages'] && $events['page'] > 1 ) {


### PR DESCRIPTION
- `wp cron-control events list --format=count` now shows just the number of pending events.
- `wp cron-control events list --format=count --status=completed` now shows just the number of completed events that have not yet been purged.

<img width="1066" alt="Screenshot 2020-02-13 at 12 41 42" src="https://user-images.githubusercontent.com/88371/74436462-68c73700-4e5e-11ea-9fb5-d3855add68af.png">


Fixes #183.