### PR TITLE
Travis: Set distribution and MySQL service

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,8 @@
+dist: xenial
+
+services:
+  - mysql
+
 language: php
 
 notifications:
@@ -8,6 +13,9 @@ notifications:
 php:
   - 5.6
   - 7.0
+  - 7.1
+  - 7.2
+  - 7.3
 
 env:
   - WP_VERSION=latest WP_MULTISITE=0
@@ -15,15 +23,26 @@ env:
   - WP_VERSION=trunk WP_MULTISITE=0
   - WP_VERSION=trunk WP_MULTISITE=1
 
+before_install:
+  - export PHPUNIT_DIR=/tmp/phpunit
+  # Download different versions of PHPUnit depending on PHP version. WP integration tests are only compatible
+  # with PHPUnit 7.x, so we can only test up to PHP 7.3 which is the maximum PHPUnit 7.x supports.
+  - |
+    if [[ ${TRAVIS_PHP_VERSION:0:3} == "5.6" || ${TRAVIS_PHP_VERSION:0:3} == "7.0" ]]; then
+      wget -P $PHPUNIT_DIR https://phar.phpunit.de/phpunit-5.phar && chmod +x $PHPUNIT_DIR/phpunit-5.phar;
+    elif [[ ${TRAVIS_PHP_VERSION:0:3} == "7.1" || ${TRAVIS_PHP_VERSION:0:3} == "7.2" || ${TRAVIS_PHP_VERSION:0:3} == "7.3" ]]; then
+      wget -P $PHPUNIT_DIR https://phar.phpunit.de/phpunit-7.phar && chmod +x $PHPUNIT_DIR/phpunit-7.phar;
+    fi
+
 before_script:
   - phpenv config-rm xdebug.ini
   - export PATH="$HOME/.composer/vendor/bin:$PATH"
-  - |
-    if [[ ${TRAVIS_PHP_VERSION:0:2} == "7." ]]; then
-      composer global require "phpunit/phpunit=5.7.*"
-    elif [[ ${TRAVIS_PHP_VERSION:0:3} != "5.2" ]]; then
-      composer global require "phpunit/phpunit=4.8.*"
-    fi
   - bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
 
-script: phpunit
+script: 
+  - |
+    if [[ ${TRAVIS_PHP_VERSION:0:3} == "5.6" || ${TRAVIS_PHP_VERSION:0:3} == "7.0" ]]; then
+      php $PHPUNIT_DIR/phpunit-5.phar
+    elif [[ ${TRAVIS_PHP_VERSION:0:3} == "7.1" || ${TRAVIS_PHP_VERSION:0:3} == "7.2" || ${TRAVIS_PHP_VERSION:0:3} == "7.3" ]]; then
+      php $PHPUNIT_DIR/phpunit-7.phar
+    fi


### PR DESCRIPTION
This Travis config file was last amended when Trusty was the default Linux distribution for Travis. The default is now Xenial, and both Xenial and Bionic no longer include the MySQL service by default, and as such, the unit tests fail to initialise and all PRs fail.

This PR will work towards getting Travis working again for the `develop` branch, and then existing PRs can be updated to pull these fixes in and so hopefully pass.