### PR TITLE
Travis: Fix and improve

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,53 +12,55 @@ notifications:
 
 cache:
   directories:
-    - vendor
-    - $HOME/.composer/cache
+    - $HOME/.composer/cache/files
 
-matrix:
-  include:
-    # PHPUnit
-    - php: 7.2
-      env: WP_VERSION=latest
-    - php: 7.2
-      env: WP_VERSION=trunk
-    - php: 7.1
-      env: WP_VERSION=latest
-    - php: 7.1
-      env: WP_VERSION=trunk
-    - php: 7.0
-      env: WP_VERSION=latest
-    - php: 7.0
-      env: WP_VERSION=trunk
-    # PHPCS
-    - php: 7.1
-      env: WP_TRAVISCI=phpcs
+php:
+  - 7.0
+  - 7.1
+  - 7.2
+  - 7.3
 
-before_script:
-  - phpenv config-rm xdebug.ini
+env:
+  - WP_VERSION=latest
+  - WP_VERSION=latest WP_MULTISITE=1
+  - WP_VERSION=trunk
+  - WP_VERSION=trunk WP_MULTISITE=1
+
+stages:
+  - name: test
+  - name: phpcs
+
+jobs:
+  fast_finish: true
+  include: 
+    # Use PHP 7.2 whilst still on Xenial, to save the job having to install a later version of PHP.
+    - stage: phpcs
+      php: 7.2
+
+before_install:
+    # Speed up build time by disabling Xdebug.
+    # https://johnblackbourn.com/reducing-travis-ci-build-times-for-wordpress-projects/
+    # https://twitter.com/kelunik/status/954242454676475904
+    - phpenv config-rm xdebug.ini || echo 'No xdebug config.'
+
+install:
   - export PATH="$HOME/.composer/vendor/bin:$PATH"
   - |
-    if [[ ! -z "$WP_VERSION" ]] ; then
+    if [[ "$TRAVIS_BUILD_STAGE_NAME" == "Test" ]]; then
       bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
-      if [[ ${TRAVIS_PHP_VERSION:0:2} == "5." ]]; then
-        composer global require "phpunit/phpunit=4.8.*"
-      else
-        composer global require "phpunit/phpunit=5.7.*"
-      fi
+      composer global require --dev "phpunit/phpunit=5.7.*"
     fi
   - |
-    if [[ "$WP_TRAVISCI" == "phpcs" ]] ; then
-      composer global require wp-coding-standards/wpcs
-      phpcs --config-set installed_paths $HOME/.composer/vendor/wp-coding-standards/wpcs
+    if [[ "$TRAVIS_BUILD_STAGE_NAME" == "Phpcs" ]]; then
+      composer global require --dev dealerdirect/phpcodesniffer-composer-installer wp-coding-standards/wpcs
     fi
 
 script:
   - |
-    if [[ ! -z "$WP_VERSION" ]] ; then
+    if [[ "$TRAVIS_BUILD_STAGE_NAME" == "Test" ]]; then
       phpunit
-      WP_MULTISITE=1 phpunit
     fi
   - |
-    if [[ "$WP_TRAVISCI" == "phpcs" ]] ; then
+    if [[ "$TRAVIS_BUILD_STAGE_NAME" == "Phpcs" ]]; then
       phpcs
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
-sudo: false
+dist: xenial
+
+services:
+  - mysql
 
 language: php
 

--- a/includes/class-events.php
+++ b/includes/class-events.php
@@ -265,8 +265,8 @@ class Events extends Singleton {
 		// Ensure we don't run jobs ahead of time.
 		if ( ! $force && $timestamp > time() ) {
 			return new \WP_Error(
-				/* translators: 1: Job identifier */
 				'premature',
+				/* translators: 1: Job identifier */
 				sprintf( __( 'Job with identifier `%1$s` is not scheduled to run yet.', 'automattic-cron-control' ), "$timestamp-$action-$instance" ),
 				array(
 					'status' => 403,
@@ -287,8 +287,8 @@ class Events extends Singleton {
 		// Nothing to do...
 		if ( ! is_object( $event ) ) {
 			return new \WP_Error(
-				/* translators: 1: Job identifier */
 				'no-event',
+				/* translators: 1: Job identifier */
 				sprintf( __( 'Job with identifier `%1$s` could not be found.', 'automattic-cron-control' ), "$timestamp-$action-$instance" ),
 				array(
 					'status' => 404,
@@ -305,8 +305,8 @@ class Events extends Singleton {
 
 			if ( ! $this->can_run_event( $event ) ) {
 				return new \WP_Error(
-					/* translators: 1: Event action, 2: Event arguments */
 					'no-free-threads',
+					/* translators: 1: Event action, 2: Event arguments */
 					sprintf( __( 'No resources available to run the job with action `%1$s` and arguments `%2$s`.', 'automattic-cron-control' ), $event->action, maybe_serialize( $event->args ) ),
 					array(
 						'status' => 429,
@@ -464,16 +464,16 @@ class Events extends Singleton {
 
 			// First, we try to get it from the schedule.
 			if ( isset( $schedules[ $event->schedule ] ) ) {
-				$interval = $schedules[ $event->schedule ]['interval'];
+				$interval = (int) $schedules[ $event->schedule ]['interval'];
 			}
 
 			// Now we try to get it from the saved interval, in case the schedule disappears.
-			if ( 0 == $interval ) {
+			if ( 0 === $interval ) {
 				$interval = $event->interval;
 			}
 
 			// If we have an interval, update the existing event entry.
-			if ( 0 != $interval ) {
+			if ( 0 !== $interval ) {
 				// Determine new timestamp, according to how `wp_reschedule_event()` does.
 				$now           = time();
 				$new_timestamp = $event->timestamp;

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -4,7 +4,9 @@
 
 	<config name="ignore_warnings_on_exit" value="1" />
 
-	<rule ref="WordPress-Core" />
+	<rule ref="WordPress-Core">
+		<exclude name="Generic.Arrays.DisallowShortArraySyntax"/>
+	</rule>
 	<rule ref="WordPress-Docs" />
 
 	<!-- Check all PHP files in directory tree by default. -->

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -12,7 +12,7 @@
 	<file>.</file>
 
 	<!-- Show sniff codes in all reports -->
-	<arg value="s"/>
+	<arg value="sp"/>
 
 	<exclude-pattern>*/node_modules/*</exclude-pattern>
 	<exclude-pattern>*/vendor/*</exclude-pattern>


### PR DESCRIPTION
The Travis config file was last amended when Trusty was the default Linux distribution for Travis. The default is now Xenial, and both Xenial and Bionic no longer include the MySQL service by default, and as such, the unit tests fail to initialise and all PRs fail.

In the second commit, I've also made further improvements:

- Simplify environment variables - no need for `WP_MULTISITE=0`
- Use stages to ensure the unit tests pass before running PHPCS.
- Use PHP 7.2 for PHPCS stage, to save having to install a later version of PHP.
- Adjust the existing setup into `before_install` and `install` to better convey the intent of the actions.
- Use built-in environment variable to identify the current stage.
- Ensure Composer dependencies are required with `--dev`.
- Use Composer plugin to register standards with PHPCS - helpful when VIPCS, PHPCompatibilityWP or other standards are added.
- Use correct directory for caching Composer archive files.
- Run unit tests with more recent versions of PHP.
- Make multisite tests their own job, for more visibility and parallelism.

The third commit fixes up some small PHPCS violations that were failing due to always requiring the most recent releases of WPCS.