### PR TITLE
Add command to list sites divided up by host

### DIFF
--- a/includes/wp-cli.php
+++ b/includes/wp-cli.php
@@ -79,4 +79,5 @@ require __DIR__ . '/wp-cli/class-lock.php';
 require __DIR__ . '/wp-cli/class-one-time-fixers.php';
 require __DIR__ . '/wp-cli/class-orchestrate.php';
 require __DIR__ . '/wp-cli/class-orchestrate-runner.php';
+require __DIR__ . '/wp-cli/class-orchestrate-sites.php';
 require __DIR__ . '/wp-cli/class-rest-api.php';

--- a/includes/wp-cli/class-orchestrate-sites.php
+++ b/includes/wp-cli/class-orchestrate-sites.php
@@ -22,33 +22,31 @@ class Orchestrate_Sites extends \WP_CLI_Command {
 		], $assoc_args );
 
 		$this->heartbeat( $assoc_args[ 'heartbeat_interval' ] );
-
 		$hosts = $this->get_hosts();
 
 		// Use 2 hosts per site
 		$num_groups = count( $hosts ) / 2;
 		if ( $num_groups < 2 ) {
-			return $this->display_sites( 1, 0 );
+			// Every host runs every site
+			return $this->display_sites();
 		}
 
 		$id = array_search( gethostname(), $hosts );
-		$group = $id % $num_groups;
-		$this->display_sites( $num_groups, $group );
+		$this->display_sites( $num_groups, $id % $num_groups );
 	}
 
-	private function display_sites( $num_groups, $group ) {
+	private function display_sites( $num_groups = 1, $group = 0 ) {
 		$sites = get_sites( [ 'number' => 10000 ] );
-		if ( $num_groups > 1 ) {
-			$sites = array_filter( $sites, function( $id ) use ( $num_groups, $group ) {
-				return $id % $num_groups === $group;
-			}, ARRAY_FILTER_USE_KEY );
-		}
+
+		// Only return sites in our group
+		$sites = array_filter( $sites, function( $id ) use ( $num_groups, $group ) {
+			return $id % $num_groups === $group;
+		}, ARRAY_FILTER_USE_KEY );
 
 		$sites = array_map( function( $site ) {
 			$site->url = get_home_url( $site->blog_id );
 			return $site;
 		}, $sites );
-
 
 		$assoc_args = [
 			'fields' => 'url',

--- a/includes/wp-cli/class-orchestrate-sites.php
+++ b/includes/wp-cli/class-orchestrate-sites.php
@@ -16,12 +16,18 @@ namespace Automattic\WP\Cron_Control\CLI;
 class Orchestrate_Sites extends \WP_CLI_Command {
 	const RUNNER_HOST_HEARTBEAT_KEY = 'a8c_cron_control_host_heartbeats';
 
-	public function list( $assoc_args ) {
-		$assoc_args = wp_parse_args( [
-			'heartbeat_interval' => 60,
-		], $assoc_args );
+	/**
+	 * List sites
+	 *
+	 * [--get-events-interval=<duration>]
+	 * : The polling interval used by the runner to retrieve events and sites
+	 */
+	public function list( $args, $assoc_args ) {
+		$assoc_args = wp_parse_args( $assoc_args, [
+			'get-events-interval' => 60,
+		] );
 
-		$this->heartbeat( $assoc_args[ 'heartbeat_interval' ] );
+		$this->heartbeat( intval( $assoc_args[ 'get-events-interval' ] ) );
 		$hosts = $this->get_hosts();
 
 		// Use 2 hosts per site

--- a/includes/wp-cli/class-orchestrate-sites.php
+++ b/includes/wp-cli/class-orchestrate-sites.php
@@ -43,6 +43,7 @@ class Orchestrate_Sites extends \WP_CLI_Command {
 			return $id % $num_groups === $group;
 		}, ARRAY_FILTER_USE_KEY );
 
+		// Add the site URL to each site object
 		$sites = array_map( function( $site ) {
 			$site->url = get_home_url( $site->blog_id );
 			return $site;

--- a/includes/wp-cli/class-orchestrate-sites.php
+++ b/includes/wp-cli/class-orchestrate-sites.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * Execute cron via WP-CLI
+ *
+ * Not intended for human use, rather it powers the Go-based Runner. Use the `events` command instead.
+ *
+ * @package a8c_Cron_Control
+ */
+
+namespace Automattic\WP\Cron_Control\CLI;
+
+
+/**
+ * Commands used by the Go-based runner to list sites
+ */
+class Orchestrate_Sites extends \WP_CLI_Command {
+	const RUNNER_HOST_HEARTBEAT_KEY = 'a8c_cron_control_host_heartbeats';
+
+	public function list( $assoc_args ) {
+		$assoc_args = wp_parse_args( [
+			'heartbeat_interval' => 60,
+		], $assoc_args );
+
+		$this->heartbeat( $assoc_args[ 'heartbeat_interval' ] );
+
+		$hosts = $this->get_hosts();
+
+		// Use 2 hosts per site
+		$num_groups = count( $hosts ) / 2;
+		if ( $num_groups < 2 ) {
+			return $this->display_sites( 1, 0 );
+		}
+
+		$id = array_search( gethostname(), $hosts );
+		$group = $id % $num_groups;
+		$this->display_sites( $num_groups, $group );
+	}
+
+	private function display_sites( $num_groups, $group ) {
+		$sites = get_sites( [ 'number' => 10000 ] );
+		if ( $num_groups > 1 ) {
+			$sites = array_filter( $sites, function( $id ) use ( $num_groups, $group ) {
+				return $id % $num_groups === $group;
+			}, ARRAY_FILTER_USE_KEY );
+		}
+
+		$sites = array_map( function( $site ) {
+			$site->url = get_home_url( $site->blog_id );
+			return $site;
+		}, $sites );
+
+
+		$assoc_args = [
+			'fields' => 'url',
+			'format' => 'json',
+		];
+
+		$formatter = new \WP_CLI\Formatter( $assoc_args, null, 'site' );
+		$formatter->display_items( $sites );
+	}
+
+	private function heartbeat( $heartbeat_interval = 60 ) {
+		if ( defined( 'WPCOM_SANDBOXED' ) && true === WPCOM_SANDBOXED ) {
+			return;
+		}
+
+		$heartbeats = wp_cache_get( self::RUNNER_HOST_HEARTBEAT_KEY );
+		if ( ! $heartbeats ) {
+			$heartbeats = [];
+		}
+
+		// Remove stale hosts
+		// If a host has missed 3 heartbeats, remove it from jobs processing
+		$heartbeats = array_filter( $heartbeats, function( $timestamp ) {
+			if ( time() - ( $heartbeat_interval * 3 ) > $timestamp ) {
+				return false;
+			}
+
+			return true;
+		} );
+
+		$heartbeats[ gethostname() ] = time();
+		wp_cache_set( self::RUNNER_HOST_HEARTBEAT_KEY, $heartbeats );
+	}
+
+	private function get_hosts() {
+		$heartbeats = wp_cache_get( self::RUNNER_HOST_HEARTBEAT_KEY );
+		if ( ! $heartbeats ) {
+			return [];
+		}
+
+		return array_keys( $heartbeats );
+	}
+}
+
+\WP_CLI::add_command( 'cron-control orchestrate sites', 'Automattic\WP\Cron_Control\CLI\Orchestrate_Sites' );

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -273,7 +273,7 @@ func shouldGetSites(disabled int) bool {
 }
 
 func getMultisiteSites() ([]site, error) {
-	raw, err := runWpCliCmd([]string{"site", "list", "--fields=url", "--archived=false", "--deleted=false", "--spam=false", "--format=json"})
+	raw, err := runWpCliCmd([]string{"cron-control", "orchestrate", "sites", "list"})
 	if err != nil {
 		return nil, err
 	}

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -301,7 +301,7 @@ func getMultisiteSites() ([]site, error) {
 	var raw string
 	var err error
 	if smartSiteList {
-		raw, err = runWpCliCmd([]string{"cron-control", "orchestrate", "sites", "list"})
+		raw, err = runWpCliCmd([]string{"cron-control", "orchestrate", "sites", "list", fmt.Sprintf("--get-events-interval=%d", getEventsInterval)})
 	} else {
 		raw, err = runWpCliCmd([]string{"site", "list", "--fields=url", "--archived=false", "--deleted=false", "--spam=false", "--format=json"})
 	}


### PR DESCRIPTION
Previously the runner would use `wp site list` to get a list of sites to
check. The problem is that if you have many runners (i.e. many cron hosts
per site) we waste a lot of time trying to run the same jobs on every host.

The idea here is to dedicate certain sites to certain hosts.

The runner will run `wp cron-control orchestrate sites list` to get a list
of sites. The act of running that command triggers a "heartbeat", which
stores a list of all hosts in the object cache along with the last
heartbeat time.

We use the list of hosts to divide sites into groups. Right now the idea is
that each site will have 2 hosts dedicated to running cron for it so that
if a host goes away, we have a bit of time to recover.

If a host is not seen for 3 heartbeats, it is removed from the list.