### PR TITLE
Split the heartbeat from site retrieval

### DIFF
--- a/includes/wp-cli/class-orchestrate-sites.php
+++ b/includes/wp-cli/class-orchestrate-sites.php
@@ -17,17 +17,23 @@ class Orchestrate_Sites extends \WP_CLI_Command {
 	const RUNNER_HOST_HEARTBEAT_KEY = 'a8c_cron_control_host_heartbeats';
 
 	/**
-	 * List sites
+	 * Record a heartbeat
 	 *
-	 * [--get-events-interval=<duration>]
+	 * [--heartbeat-interval=<duration>]
 	 * : The polling interval used by the runner to retrieve events and sites
 	 */
-	public function list( $args, $assoc_args ) {
+	public function heartbeat( $args, $assoc_args ) {
 		$assoc_args = wp_parse_args( $assoc_args, [
-			'get-events-interval' => 60,
+			'heartbeat-interval' => 60,
 		] );
 
-		$this->heartbeat( intval( $assoc_args[ 'get-events-interval' ] ) );
+		$this->do_heartbeat( intval( $assoc_args[ 'heartbeat-interval' ] ) );
+	}
+
+	/**
+	 * List sites
+	 */
+	public function list() {
 		$hosts = $this->get_hosts();
 
 		// Use 2 hosts per site
@@ -64,7 +70,7 @@ class Orchestrate_Sites extends \WP_CLI_Command {
 		$formatter->display_items( $sites );
 	}
 
-	private function heartbeat( $heartbeat_interval = 60 ) {
+	private function do_heartbeat( $heartbeat_interval = 60 ) {
 		if ( defined( 'WPCOM_SANDBOXED' ) && true === WPCOM_SANDBOXED ) {
 			return;
 		}
@@ -75,9 +81,9 @@ class Orchestrate_Sites extends \WP_CLI_Command {
 		}
 
 		// Remove stale hosts
-		// If a host has missed 3 heartbeats, remove it from jobs processing
+		// If a host has missed 2 heartbeats, remove it from jobs processing
 		$heartbeats = array_filter( $heartbeats, function( $timestamp ) {
-			if ( time() - ( $heartbeat_interval * 3 ) > $timestamp ) {
+			if ( time() - ( $heartbeat_interval * 2 ) > $timestamp ) {
 				return false;
 			}
 

--- a/runner/mockcli
+++ b/runner/mockcli
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+COMMAND="$1 $2 $3 $4"
+
+case "$COMMAND" in
+	"cron-control orchestrate sites list")
+		echo '[{"url":"https:\/\/example-com.go-vip.net"},{"url":"https:\/\/example-com.go-vip.net/subsite1"}]'
+		;;
+
+	"cron-control orchestrate runner-only get-info")
+		echo '[{"multisite":1,"siteurl":"https:\/\/example-com.go-vip.net","disabled":0}]'
+		;;
+
+	"cron-control orchestrate runner-only list-due-batch")
+		echo '[{"timestamp":1586382738,"action":"b05eecbc20fcb6b338510de2e15ca4fa","instance":"40cd750bba9870f18aada2478b24840a"},{"timestamp":1586382759,"action":"033bc12724f6f8285fd89ab813c47e4b","instance":"40cd750bba9870f18aada2478b24840a"},{"timestamp":1586382766,"action":"85ede02876b7c1557e7e623428f6cfc7","instance":"40cd750bba9870f18aada2478b24840a"},{"timestamp":1586382566,"action":"7715f1b533e885efdb5e3ef10d2ba3e8","instance":"40cd750bba9870f18aada2478b24840a"},{"timestamp":1586382591,"action":"29ef625a054a0b386093ac9c46a2c616","instance":"40cd750bba9870f18aada2478b24840a"}]'
+		;;
+
+	"cron-control orchestrate runner-only run")
+		sleep 200
+		echo "$@"
+		echo "Success"
+		;;
+esac

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -176,6 +176,12 @@ func heartbeat(sites chan<- site, queue chan<- event) {
 			logger.Println("exiting heartbeat routine")
 			break
 		}
+
+		if smartSiteList {
+			logger.Println("heartbeat")
+			runWpCliCmd([]string{"cron-control", "orchestrate", "sites", "heartbeat", fmt.Sprintf("--heartbeat-interval=%d", getEventsInterval)})
+		}
+
 		successCount, errCount := atomic.LoadUint64(&eventRunSuccessCount), atomic.LoadUint64(&eventRunErrCount)
 		atomic.SwapUint64(&eventRunSuccessCount, 0)
 		atomic.SwapUint64(&eventRunErrCount, 0)
@@ -301,7 +307,7 @@ func getMultisiteSites() ([]site, error) {
 	var raw string
 	var err error
 	if smartSiteList {
-		raw, err = runWpCliCmd([]string{"cron-control", "orchestrate", "sites", "list", fmt.Sprintf("--get-events-interval=%d", getEventsInterval)})
+		raw, err = runWpCliCmd([]string{"cron-control", "orchestrate", "sites", "list"})
 	} else {
 		raw, err = runWpCliCmd([]string{"site", "list", "--fields=url", "--archived=false", "--deleted=false", "--spam=false", "--format=json"})
 	}

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -540,11 +540,18 @@ func waitForEpoch(whom string, epoch_sec int64) {
 }
 
 func setupSignalHandler() {
+	var count int
 	sigChan := make(chan os.Signal)
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
 	for {
 		select {
 		case sig := <-sigChan:
+			count++
+			if count == 2 {
+				logger.Printf("forcing shutdown")
+				os.Exit(1)
+			}
+
 			logger.Printf("caught termination signal %s, scheduling shutdown\n", sig)
 			gRestart = true
 		}

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -179,7 +179,7 @@ func heartbeat(sites chan<- site, queue chan<- event) {
 
 		if smartSiteList {
 			logger.Println("heartbeat")
-			runWpCliCmd([]string{"cron-control", "orchestrate", "sites", "heartbeat", fmt.Sprintf("--heartbeat-interval=%d", getEventsInterval)})
+			runWpCliCmd([]string{"cron-control", "orchestrate", "sites", "heartbeat", fmt.Sprintf("--heartbeat-interval=%d", heartbeatInt)})
 		}
 
 		successCount, errCount := atomic.LoadUint64(&eventRunSuccessCount), atomic.LoadUint64(&eventRunErrCount)

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -257,7 +257,7 @@ func getInstanceInfo() (siteInfo, error) {
 	jsonRes := make([]siteInfo, 0)
 	if err = json.Unmarshal([]byte(raw), &jsonRes); err != nil {
 		if debug {
-			logger.Println(fmt.Sprintf("%+v", err))
+			logger.Println(fmt.Sprintf("%+v - %s", err, raw))
 		}
 
 		return siteInfo{}, err
@@ -313,7 +313,7 @@ func getMultisiteSites() ([]site, error) {
 	jsonRes := make([]site, 0)
 	if err = json.Unmarshal([]byte(raw), &jsonRes); err != nil {
 		if debug {
-			logger.Println(fmt.Sprintf("%+v", err))
+			logger.Println(fmt.Sprintf("%+v - %s", err, raw))
 		}
 
 		return nil, err
@@ -367,7 +367,7 @@ func getSiteEvents(site string) ([]event, error) {
 	siteEvents := make([]event, 0)
 	if err = json.Unmarshal([]byte(raw), &siteEvents); err != nil {
 		if debug {
-			logger.Println(fmt.Sprintf("%+v", err))
+			logger.Println(fmt.Sprintf("%+v - %s", err, raw))
 		}
 
 		return nil, err


### PR DESCRIPTION
Rather than inherently recording a heartbeat when the site list is 
retrieved, we'll do it when the runner records a heartbeat. The heartbeat
process is async whereas site list retrieval is actually blocked by running
events. For example, if events take longer than the event interval to run,
it will take longer than the event interval to get the list of sites. We
were seeing some issues in production where it was taking longer than 3x
the event interval to run events and hosts were being removed from
processing. Recording heartbeats completely async every heartbeat_interval
should resolve this.