### PR TITLE
Fix errors for `wp orchestrate site list`

### DIFF
--- a/includes/wp-cli/class-orchestrate-sites.php
+++ b/includes/wp-cli/class-orchestrate-sites.php
@@ -57,7 +57,23 @@ class Orchestrate_Sites extends \WP_CLI_Command {
 
 		// Add the site URL to each site object
 		$sites = array_map( function( $site ) {
-			$site->url = get_home_url( $site->blog_id );
+			// Don't use home or siteurl since those don't always match up with the `wp_blogs` entry.
+			// That can result in a "site not found" when passed via the `--url` WP-CLI param.
+			// Instead, construct the URL from data in the `wp_blogs` table.
+
+			// Have to grab scheme from the home URL; not exposed in `$site`.
+			$home_url = get_home_url( $site->blog_id );
+			$scheme = parse_url( $home_url, PHP_URL_SCHEME );
+
+			$domain = $site->domain;
+
+			$path = '';
+			if ( $site->path && '/' !== $site->path ) {
+				$path= $site->path;
+			}
+
+			$site->url = sprintf( '%s://%s%s', $scheme, $domain, $path );
+
 			return $site;
 		}, $sites );
 


### PR DESCRIPTION
When building the site list for the orchestrate command, don't use home or siteurl since those don't always match up with the `wp_blogs` entry. That can result in a "site not found" when passed via the `--url` WP-CLI param and break cron.

Instead, construct the URL from data in the `wp_blogs` table.