### PR TITLE
Site List: Remove unnecessary switch_to_blog

### DIFF
--- a/includes/wp-cli/class-orchestrate-sites.php
+++ b/includes/wp-cli/class-orchestrate-sites.php
@@ -60,11 +60,6 @@ class Orchestrate_Sites extends \WP_CLI_Command {
 			// Don't use home or siteurl since those don't always match up with the `wp_blogs` entry.
 			// That can result in a "site not found" when passed via the `--url` WP-CLI param.
 			// Instead, construct the URL from data in the `wp_blogs` table.
-
-			// Have to grab scheme from the home URL; not exposed in `$site`.
-			$home_url = get_home_url( $site->blog_id );
-			$scheme = parse_url( $home_url, PHP_URL_SCHEME );
-
 			$domain = $site->domain;
 
 			$path = '';
@@ -72,7 +67,7 @@ class Orchestrate_Sites extends \WP_CLI_Command {
 				$path= $site->path;
 			}
 
-			$site->url = sprintf( '%s://%s%s', $scheme, $domain, $path );
+			$site->url = sprintf( '%s%s', $domain, $path );
 
 			return $site;
 		}, $sites );


### PR DESCRIPTION
The `get_home_url()` function calls `switch_to_blog()` and `restore_current_blog()` internally.

First, `restore_current_blog()` is basically `switch_to_blog()` in reverse. In this context, we don't actually care about switching back. We only want this one option for every site, so switching back is a waste of time. After we get the option, we're just outputting it.

More importantly though, `switch_to_blog()` is expensive and not necessary. We're only using the home URL for the scheme, which is unnecessary for a "URL" that gets passed to WP-CLI. The domain + path is enough (i.e. `wp --url=example.com/subsite`). It also seems a little silly, in this context at least, to do a full `switch_to_blog()` to query this one database option. It seems like we just need to know the table name and from there could query the options table directly. The expensive part of `switch_to_blog()` is where we re-initialize the object cache, thus wiping out all auto-loaded options.