### PR TITLE
Lower force publish missed scheduled posts to 2 minutes

### DIFF
--- a/includes/class-internal-events.php
+++ b/includes/class-internal-events.php
@@ -60,7 +60,7 @@ class Internal_Events extends Singleton {
 	private function prepare_internal_events() {
 		$internal_events = array(
 			array(
-				'schedule' => 'a8c_cron_control_five_minute',
+				'schedule' => 'a8c_cron_control_minute',
 				'action'   => 'a8c_cron_control_force_publish_missed_schedules',
 				'callback' => array( $this, 'force_publish_missed_schedules' ),
 			),
@@ -106,9 +106,9 @@ class Internal_Events extends Singleton {
 	 */
 	private function prepare_internal_events_schedules() {
 		$internal_events_schedules = array(
-			'a8c_cron_control_five_minute'      => array(
-				'interval' => 5 * MINUTE_IN_SECONDS,
-				'display'  => __( 'Cron Control internal job - every 5 minutes', 'automattic-cron-control' ),
+			'a8c_cron_control_minute'      => array(
+				'interval' => 2 * MINUTE_IN_SECONDS,
+				'display'  => __( 'Cron Control internal job - every 2 minutes (used to be 1 minute)', 'automattic-cron-control' ),
 			),
 			'a8c_cron_control_ten_minutes' => array(
 				'interval' => 10 * MINUTE_IN_SECONDS,

--- a/includes/class-internal-events.php
+++ b/includes/class-internal-events.php
@@ -60,7 +60,7 @@ class Internal_Events extends Singleton {
 	private function prepare_internal_events() {
 		$internal_events = array(
 			array(
-				'schedule' => 'a8c_cron_control_minute',
+				'schedule' => 'a8c_cron_control_five_minute',
 				'action'   => 'a8c_cron_control_force_publish_missed_schedules',
 				'callback' => array( $this, 'force_publish_missed_schedules' ),
 			),
@@ -106,9 +106,9 @@ class Internal_Events extends Singleton {
 	 */
 	private function prepare_internal_events_schedules() {
 		$internal_events_schedules = array(
-			'a8c_cron_control_minute'      => array(
-				'interval' => 1 * MINUTE_IN_SECONDS,
-				'display'  => __( 'Cron Control internal job - every minute', 'automattic-cron-control' ),
+			'a8c_cron_control_five_minute'      => array(
+				'interval' => 5 * MINUTE_IN_SECONDS,
+				'display'  => __( 'Cron Control internal job - every 5 minutes', 'automattic-cron-control' ),
 			),
 			'a8c_cron_control_ten_minutes' => array(
 				'interval' => 10 * MINUTE_IN_SECONDS,


### PR DESCRIPTION
This job is a significant % of all jobs across VIP Go and likely causing more problems than it currently solves by delaying other jobs. Since this is just a backup method, 2 minutes should be plenty.

This is just a first step. We should look at how useful this job really is in practice. Does it still make sense to have this job scheduled on all sites? Should we have a lower default (5 minutes? 10 minutes?) that individual sites can override? Should the force schedule job be a separate plugin altogether?