### PR TITLE
Don't schedule internal events in REST context

### DIFF
--- a/includes/class-internal-events.php
+++ b/includes/class-internal-events.php
@@ -44,7 +44,6 @@ class Internal_Events extends Singleton {
 			add_action( 'wp_loaded', array( $this, 'schedule_internal_events' ) );
 		} else {
 			add_action( 'admin_init', array( $this, 'schedule_internal_events' ) );
-			add_action( 'rest_api_init', array( $this, 'schedule_internal_events' ) );
 		}
 
 		add_filter( 'cron_schedules', array( $this, 'register_internal_events_schedules' ) );


### PR DESCRIPTION
Every call to wp_next_scheduled is a request to the object cache for the full cron option. We have 4 internal events, so that's 4 additional object cache requests on every REST API request. Limiting cron scheduled, as much as possible, to wp-admin will reduce load on our object cache.