### PR TITLE
Add a websocket listener as an alternative protocol to raw tcp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ node_modules/
 *.sql
 *.tar.gz
 *.zip
+/bin/cron-control-runner

--- a/runner/go.mod
+++ b/runner/go.mod
@@ -7,4 +7,5 @@ require (
 	github.com/howeyc/fsnotify v0.9.0
 	github.com/prometheus/client_golang v1.9.0
 	golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad
+	golang.org/x/net v0.0.0-20200625001655-4c5254603344
 )

--- a/runner/go.sum
+++ b/runner/go.sum
@@ -305,6 +305,7 @@ golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR
 golang.org/x/net v0.0.0-20190613194153-d28f0bde5980/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190813141303-74dc4d7220e7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20200625001655-4c5254603344 h1:vGXIOMxbNfDTk/aXCmfdLgkrSV+Z2tcbze+pEc3v5W4=
 golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -57,6 +57,7 @@ var (
 	debug     bool
 
 	smartSiteList bool
+	useWebsockets bool
 
 	gRestart                bool
 	gEventRetrieversRunning []bool
@@ -83,6 +84,7 @@ func init() {
 	flag.StringVar(&logFormat, "log-format", "JSON", "Log format, 'Text' or 'JSON'")
 	flag.BoolVar(&debug, "debug", false, "Include additional log data for debugging")
 	flag.BoolVar(&smartSiteList, "smart-site-list", false, "Use the `wp cron-control orchestrate` command instead of `wp site list`")
+	flag.BoolVar(&useWebsockets, "use-websockets", false, "Use the websocket listener instead of raw tcp")
 	flag.StringVar(&gRemoteToken, "token", "", "Token to authenticate remote WP CLI requests")
 	flag.IntVar(&gGuidLength, "guid-len", 36, "Sets the Guid length in use for remote WP CLI requests")
 	flag.StringVar(&gMetricsListenAddr, "metrics-listen-addr", "", "Listen address for prometheus metrics (e.g. :4444); if set, can scrape http://:4444/metrics.")


### PR DESCRIPTION
This PR adds an alternative listener that uses Websockets instead of raw TCP.

When enabled, by providing arg `-use-websockets=true`, the protocol used on the remote runner (port 22122) is HTTP websockets instead of bare TCP.

Ultimately, this will make it easier to route requests to this service across network paths where HTTP is already supported, e.g. using kubernetes ingress. And it makes this service "vhost-able" where HTTP requests can already be reverse-proxied, etc.


