### PR TITLE
Stderr from wp-cli should not be included in runWpCliCmd return value

### DIFF
--- a/runner/runner.go
+++ b/runner/runner.go
@@ -471,9 +471,19 @@ func runWpCliCmd(subcommand []string) (string, error) {
 		subcommand = append(subcommand, fmt.Sprintf("--network=%d", wpNetwork))
 	}
 
+	var stdout, stderr strings.Builder
 	wpCli := exec.Command(wpCliPath, subcommand...)
-	wpOut, err := wpCli.CombinedOutput()
-	wpOutStr := string(wpOut)
+	wpCli.Stdout = &stdout
+	wpCli.Stderr = &stderr
+	err := wpCli.Run()
+	wpOutStr := stdout.String()
+	if stderr.Len() > 0 {
+		stderrStr := strings.TrimSpace(stderr.String())
+		if len(stderrStr) > 0 {
+			logger.Printf("STDERR for command[%s]: %s", strings.Join(subcommand, " "), stderrStr)
+		}
+	}
+
 
 	// always log stats, even in case of an error:
 	if stats, ok := wpCli.ProcessState.SysUsage().(*syscall.Rusage); ok && stats != nil {


### PR DESCRIPTION
When we containerize PHP, we do the plumbing to send php error_log output to PHP's stderr stream, so it can get slurped into docker logs. The cron runner is including the stderr output in the result, which tries to parse it as json.

Stderr should not be used for parseable output, so we should just log it and continue.