### PR TITLE
Fix scheduling future jobs

### DIFF
--- a/includes/constants.php
+++ b/includes/constants.php
@@ -29,7 +29,7 @@ unset( $job_concurrency_limit );
 /**
  * Job runtime constraints
  */
-const JOB_QUEUE_WINDOW_IN_SECONDS = 60;
+const JOB_QUEUE_WINDOW_IN_SECONDS = 0;
 const JOB_TIMEOUT_IN_MINUTES      = 10;
 const JOB_LOCK_EXPIRY_IN_MINUTES  = 30;
 


### PR DESCRIPTION
We see a lot of future jobs trying to and failing to run. In PHP, we were listing jobs that are due in the next 60 seconds, but in the Go runner we refuse to run events that are scheduled in the future.

https://github.com/Automattic/Cron-Control/blob/9928da3a5f9a78e6616cb82663c03f32ceef5845/runner/runner.go#L417

This is consuming a lot of workers with running jobs that are due in the next 60 seconds in some cases.

This PR synchronizes that offset to +0 seconds in the future.