### PR TITLE
Bump JOB_QUEUE_WINDOW_IN_SECONDS back to 30 second

### DIFF
--- a/includes/constants.php
+++ b/includes/constants.php
@@ -29,7 +29,7 @@ unset( $job_concurrency_limit );
 /**
  * Job runtime constraints
  */
-const JOB_QUEUE_WINDOW_IN_SECONDS = 0;
+const JOB_QUEUE_WINDOW_IN_SECONDS = 30;
 const JOB_TIMEOUT_IN_MINUTES      = 10;
 const JOB_LOCK_EXPIRY_IN_MINUTES  = 30;
 


### PR DESCRIPTION
I initially thought this 60 second offset was an oversight, but @WPprodigy pointed out that it's probably because there's a delay between when events are retrieved and when they are actually run. It's unlikely that the delay is a full 60 seconds though. Rather than schedule every job which could possibly run in the next 60 seconds, we will try listing jobs that are due in the next 30 seconds. This should cut down on the amount of overhead we see from running jobs that can't possible run yet.

Follow up to https://github.com/Automattic/Cron-Control/pull/205