### PR TITLE
Provide an output message when a WP-CLI command is terminated

### DIFF
--- a/runner/remote.go
+++ b/runner/remote.go
@@ -832,6 +832,7 @@ func runWpCliCmdRemote(conn net.Conn, Guid string, rows uint16, cols uint16, wpC
 
 	if !state.Exited() {
 		logger.Println("terminating the wp command")
+		conn.Write([]byte("Command has been terminated\n"))
 		cmd.Process.Kill()
 	}
 


### PR DESCRIPTION
## Description
This provided a message to the client when a command is terminated/killed by the runner (due to OOM, etc). Currently the user has no idea that the command has been terminated as the output just stops.

I did look into sending back some sort of error on close, but it doesn't seem possible

## Steps to test
Getting setup to test locally is a bit of a bear:
https://github.com/Automattic/vip-go-api-public#wp-cli-against-cron-control-runner

Note, I wasn't actually able to test this exact code path locally, as I couldn't get the command to be killed in the same fashion that the runer does (I tried SIGINT, SIGKILL, SIGTERM, etc). However, I do know that this is the code path that is reached when a command on the production server isterminated.
