### PR TITLE
switch back to gofast

### DIFF
--- a/runner/go.mod
+++ b/runner/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/creack/pty v1.1.11
 	github.com/howeyc/fsnotify v0.9.0
 	github.com/prometheus/client_golang v1.9.0
-	github.com/tomasen/fcgi_client v0.0.0-20180423082037-2bb3d819fd19
+	github.com/yookoala/gofast v0.6.0
 	golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad
-	golang.org/x/net v0.0.0-20200625001655-4c5254603344
+	golang.org/x/net v0.0.0-20200822124328-c89045814202
 )

--- a/runner/go.sum
+++ b/runner/go.sum
@@ -63,6 +63,7 @@ github.com/go-kit/kit v0.10.0/go.mod h1:xUsJbQ/Fp4kEt7AFgCuvyX4a71u8h9jB8tj/ORgO
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
+github.com/go-restit/lzjson v0.0.0-20161206095556-efe3c53acc68/go.mod h1:7vXSKQt83WmbPeyVjCfNT9YDJ5BUFmcwFsEjI9SCvYM=
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/gogo/googleapis v1.1.0/go.mod h1:gf4bu3Q80BeJ6H1S1vYPm8/ELATdvryBaNFGgqEef3s=
@@ -96,6 +97,7 @@ github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
+github.com/gopherjs/gopherjs v0.0.0-20200217142428-fce0ec30dd00/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
@@ -243,6 +245,7 @@ github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPx
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
+github.com/smartystreets/assertions v1.1.1/go.mod h1:tcbTF8ujkAEcZ8TElKY+i30BzYlVhC/LOxJk7iOWnoo=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/sony/gobreaker v0.4.1/go.mod h1:ZKptC7FHNvhBz7dN2LGjPVBz2sZJmc0/PkyDJOjmxWY=
@@ -257,11 +260,12 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
-github.com/tomasen/fcgi_client v0.0.0-20180423082037-2bb3d819fd19 h1:ZCmSnT6CLGhfoQ2lPEhL4nsJstKDCw1F1RfN8/smTCU=
-github.com/tomasen/fcgi_client v0.0.0-20180423082037-2bb3d819fd19/go.mod h1:SXTY+QvI+KTTKXQdg0zZ7nx0u94QWh8ZAwBQYsW9cqk=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
+github.com/yookoala/gofast v0.6.0 h1:E5x2acfUD7GkzCf8bmIMwnV10VxDy5tUCHc5LGhluwc=
+github.com/yookoala/gofast v0.6.0/go.mod h1:OJU201Q6HCaE1cASckaTbMm3KB6e0cZxK0mgqfwOKvQ=
+github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738/go.mod h1:dnLIgRNXwCJa5e+c6mIZCrds/GIG4ncV9HhK5PX7jPg=
 go.opencensus.io v0.20.1/go.mod h1:6WKK9ahsWS3RSO+PY9ZHZUfv2irvY6gN279GOPZjmmk=
@@ -291,6 +295,7 @@ golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHl
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
+golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -309,6 +314,8 @@ golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20190813141303-74dc4d7220e7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200625001655-4c5254603344 h1:vGXIOMxbNfDTk/aXCmfdLgkrSV+Z2tcbze+pEc3v5W4=
 golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
+golang.org/x/net v0.0.0-20200822124328-c89045814202 h1:VvcQYSHwXgi7W+TpUR6A9g6Up98WAHf3f/ulnJ62IyA=
+golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -317,6 +324,7 @@ golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -358,11 +366,16 @@ golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBn
 golang.org/x/tools v0.0.0-20190621195816-6e04913cbbac/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20191029041327-9cc4af7d6b2c/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191029190741-b9c20aec41a5/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200103221440-774c71fcf114/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
+golang.org/x/tools v0.0.0-20200908211811-12e1bf57a112 h1:DmrRJy1qn9VDMf4+GSpRlwfZ51muIF7r96MFBFP4bPM=
+golang.org/x/tools v0.0.0-20200908211811-12e1bf57a112/go.mod h1:Cj7w3i3Rnn0Xh82ur9kSqwfTHTeVxaDqrfMjpcNT6bE=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
+golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.3.1/go.mod h1:6wY9I6uQWHQ8EM57III9mq/AjF+i8G65rmVagqKMtkk=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.2.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
@@ -396,6 +409,7 @@ gopkg.in/cheggaaa/pb.v1 v1.0.25/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qS
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/gcfg.v1 v1.2.3/go.mod h1:yesOnuUOFQAhST5vPY4nbZsb/huCgGGXlipJsBn0b3o=
+gopkg.in/ini.v1 v1.38.2/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -122,7 +122,7 @@ func init() {
 }
 
 func main() {
-	logger.Printf("Starting with %d event-retreival worker(s) and %d event worker(s)", numGetWorkers, numRunWorkers)
+	logger.Printf("Starting with %d event-retrieval worker(s) and %d event worker(s)", numGetWorkers, numRunWorkers)
 	logger.Printf("Retrieving events every %d seconds", getEventsInterval)
 	go setupSignalHandler()
 
@@ -196,7 +196,7 @@ func heartbeat(sites chan<- site, queue chan<- event) {
 	}
 
 	for {
-		waitForEpoch("heartbeat", "heartbeat", heartbeatInt)
+		waitForEpoch("heartbeater", "heartbeat", heartbeatInt)
 		if gRestart {
 			logger.Println("heartbeater: exiting heartbeat routine")
 			break
@@ -519,6 +519,7 @@ func runWpFpmCmdSafe(subcommand []string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	defer (func(){ _ = fpmClient.Close() })()
 
 	args, err := buildFpmQuery(subcommand)
 	if err != nil {

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"io"
 	"math/rand"
 	"net/http"
 	"net/url"
@@ -17,7 +18,7 @@ import (
 	"syscall"
 	"time"
 
-	fcgiclient "github.com/tomasen/fcgi_client"
+	"github.com/yookoala/gofast"
 )
 
 type siteInfo struct {
@@ -63,7 +64,7 @@ var (
 	logFormat string
 	debug     bool
 
-	fpmUrl *url.URL
+	fpm gofast.ClientFactory
 
 	smartSiteList bool
 	useWebsockets bool
@@ -108,12 +109,13 @@ func init() {
 
 	if fpmUrlStr != "" {
 		var err error
-		fpmUrl, err = url.Parse(fpmUrlStr)
-		if err != nil || fpmUrl == nil {
+		fpmUrl, err := url.Parse(fpmUrlStr)
+		if err != nil || fpmUrl == nil || fpmUrl.Scheme != "unix" || fpmUrl.Path == "" {
 			logger.Printf("error parsing FPM url %q: %v", fpmUrlStr, err)
 			panic(err)
 		}
 		logger.Printf("Using FPM runtime at %q", fpmUrlStr)
+		fpm = gofast.SimpleClientFactory(gofast.SimpleConnFactory(fpmUrl.Scheme, fpmUrl.Path))
 	}
 
 	gRandomDeltaMap = make(map[string]int64)
@@ -466,20 +468,19 @@ func runWpCmd(subcommand []string) (string, error) {
 	if wpNetwork > 0 {
 		subcommand = append(subcommand, fmt.Sprintf("--network=%d", wpNetwork))
 	}
-	if fpmUrl != nil {
+	if fpm != nil {
 		return runWpFpmCmdWithMetrics(subcommand)
 	} else {
 		return runWpCliCmd(subcommand)
 	}
 }
 
-func fpmEnv() map[string]string {
+func fpmEnv(args url.Values) map[string]string {
 	return map[string]string{
-		"WP_CLI_ROOT":       "/usr/local/wp-cli",
+		"REQUEST_METHOD":    "GET",
 		"SCRIPT_FILENAME":   "/var/wpvip/fpm-cron-runner.php",
 		"GATEWAY_INTERFACE": "FastCGI/1.0",
-		"REQUEST_METHOD":    "POST",
-		"CONTENT_TYPE":      "application/x-www-form-urlencoded",
+		"QUERY_STRING":      args.Encode(),
 	}
 }
 
@@ -491,55 +492,76 @@ func runWpFpmCmdWithMetrics(subcommand []string) (string, error) {
 	return res, err
 }
 
+type fakeHttpResponseWriter struct {
+	Dest       io.Writer
+	LastStatus int
+	Headers    http.Header
+}
+
+func (f *fakeHttpResponseWriter) Header() http.Header {
+	if f.Headers == nil {
+		f.Headers = http.Header{}
+	}
+	return f.Headers
+}
+
+func (f *fakeHttpResponseWriter) Write(bytes []byte) (int, error) {
+	return f.Dest.Write(bytes)
+}
+
+func (f *fakeHttpResponseWriter) WriteHeader(statusCode int) {
+	f.LastStatus = statusCode
+}
+
 func runWpFpmCmdSafe(subcommand []string) (string, error) {
 
-	path := fpmUrl.Path
-	host := fpmUrl.Host
-
-	if path == "" || fpmUrl.Scheme == "unix" {
-		path = fpmUrl.Fragment
-	}
-
-	if fpmUrl.Scheme == "unix" {
-		host = fpmUrl.Path
-	}
-
-	fcgi, err := fcgiclient.Dial(fpmUrl.Scheme, host)
+	fpmClient, err := fpm()
 	if err != nil {
-		logger.Printf("fastcgi Dial failed: %v", err)
 		return "", err
 	}
-
-	defer fcgi.Close()
 
 	args, err := buildFpmQuery(subcommand)
 	if err != nil {
 		return "", err
 	}
 
-	resp, err := fcgi.PostForm(fpmEnv(), args)
+	fcgiReq := gofast.NewRequest(nil)
+	fcgiReq.Params = fpmEnv(args)
+
+	fcgiResp, err := fpmClient.Do(fcgiReq)
 	if err != nil {
-		logger.Printf("Failed to POST to FPM: %v", err)
 		return "", err
 	}
-	defer (func() { _ = resp.Body.Close() })()
+	defer fcgiResp.Close()
+
+	stdErr := &strings.Builder{}
+	stdOut := &strings.Builder{}
+	hrw := &fakeHttpResponseWriter{Dest: stdOut}
+
+	if err = fcgiResp.WriteTo(hrw, stdErr); err != nil {
+		return "", err
+	}
+
+	if hrw.LastStatus != http.StatusOK {
+		return "", fmt.Errorf("fpm error: lastStatus=%d, headers=%v, stdout=%q, stderr=%q", hrw.LastStatus, hrw.Headers, stdOut.String(), stdErr.String())
+	}
 
 	var res struct {
 		Buf    string `json:"buf"`
 		Stdout string `json:"stdout"`
 		Stderr string `json:"stderr"`
 	}
-	err = json.NewDecoder(resp.Body).Decode(&res)
+
+	err = json.Unmarshal([]byte(stdOut.String()), &res)
+
 	if debug {
-		logger.Printf("FPM http response: %d [%s] headers=%v: %+v err=%v", resp.StatusCode, resp.Status, resp.Header, res, err)
+		logger.Printf("fpm result: lastStatus=%d, headers=%v, stdout=%q, stderr=%q, res=%+v, err=%v", hrw.LastStatus, hrw.Headers, stdOut.String(), stdErr.String(), res, err)
 	}
+
 	if err != nil {
-		logger.Printf("Could not decode FPM response: %v", err)
-		return "", err
+		return "", fmt.Errorf("fpm error: could not decode json response from %q: err=%v", stdOut.String(), err)
 	}
-	if resp.StatusCode != 200 {
-		err = fmt.Errorf("error from fcgi: http %s", resp.Status)
-	}
+
 	return res.Buf, err
 }
 
@@ -653,7 +675,7 @@ func waitForEpoch(waiter, whom string, epoch_sec int64) {
 
 	tNextEpoch := time.Now().UnixNano() + tEpochDelta + gRandomDeltaMap[whom]
 
-	if totalWait := time.Unix(0, tNextEpoch).Sub(time.Now()); totalWait > 1 * time.Second {
+	if totalWait := time.Unix(0, tNextEpoch).Sub(time.Now()); totalWait > 1*time.Second {
 		logger.Printf("%s: LONG wait (%v) for epoch %q", waiter, totalWait, whom)
 	}
 


### PR DESCRIPTION
Unfortunately, `tomasen/fcgi_client` does not support splitting out the fcgi stderr stream from the stdout. On a well-behaved site that does not spew notices, thats fine. On most real sites, it's not fine.
