### PR TITLE
try to recover url list in output

### DIFF
--- a/runner/runner.go
+++ b/runner/runner.go
@@ -513,6 +513,10 @@ func (f *fakeHttpResponseWriter) WriteHeader(statusCode int) {
 	f.LastStatus = statusCode
 }
 
+type SiteUrl struct {
+	Url string `json:"url"`
+}
+
 func runWpFpmCmdSafe(subcommand []string) (string, error) {
 
 	fpmClient, err := fpm()
@@ -553,10 +557,24 @@ func runWpFpmCmdSafe(subcommand []string) (string, error) {
 		Stderr string `json:"stderr"`
 	}
 
-	err = json.Unmarshal([]byte(stdOut.String()), &res)
+	stdOutStr := stdOut.String()
+	err = json.Unmarshal([]byte(stdOutStr), &res)
 
 	if debug {
-		logger.Printf("fpm result: lastStatus=%d, headers=%v, stdout=%q, stderr=%q, res=%+v, err=%v", hrw.LastStatus, hrw.Headers, stdOut.String(), stdErr.String(), res, err)
+		logger.Printf("fpm result: lastStatus=%d, headers=%v, stdout=%q, stderr=%q, res=%+v, err=%v", hrw.LastStatus, hrw.Headers, stdOutStr, stdErr.String(), res, err)
+	}
+
+	if err != nil {
+		if idx := strings.Index(stdOutStr, `[{"url":`); idx >= 0 {
+			var urls []SiteUrl
+			// if a site manages to escape the output buffering, this will try to find the output anyways...
+			err = json.NewDecoder(strings.NewReader(stdOutStr[idx:])).Decode(&urls)
+			if err == nil {
+				var buf []byte
+				buf, err = json.Marshal(&urls)
+				res.Buf = string(buf)
+			}
+		}
 	}
 
 	if err != nil {

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -547,8 +547,9 @@ func runWpFpmCmdSafe(subcommand []string) (string, error) {
 		return "", err
 	}
 
+	stdOutStr := stdOut.String()
 	if hrw.LastStatus != http.StatusOK {
-		return "", fmt.Errorf("fpm error: lastStatus=%d, headers=%v, stdout=%q, stderr=%q", hrw.LastStatus, hrw.Headers, stdOut.String(), stdErr.String())
+		return "", fmt.Errorf("fpm error: lastStatus=%d, headers=%v, stdout=%q, stderr=%q", hrw.LastStatus, hrw.Headers, stdOutStr, stdErr.String())
 	}
 
 	var res struct {
@@ -557,7 +558,6 @@ func runWpFpmCmdSafe(subcommand []string) (string, error) {
 		Stderr string `json:"stderr"`
 	}
 
-	stdOutStr := stdOut.String()
 	err = json.Unmarshal([]byte(stdOutStr), &res)
 
 	if debug {
@@ -578,7 +578,7 @@ func runWpFpmCmdSafe(subcommand []string) (string, error) {
 	}
 
 	if err != nil {
-		return "", fmt.Errorf("fpm error: could not decode json response from %q: err=%v", stdOut.String(), err)
+		return "", fmt.Errorf("fpm error: could not decode json response from %q: err=%v", stdOutStr, err)
 	}
 
 	return res.Buf, err


### PR DESCRIPTION
if a site manages to escape the ob_start in the fpm env, and outputs the site list unbuffered, we will try to find it.