### PR TITLE
Fix incorrect invocation of `is_callable()`

### DIFF
--- a/includes/wp-cli.php
+++ b/includes/wp-cli.php
@@ -64,7 +64,7 @@ function stop_the_insanity() {
 	$wp_object_cache->memcache_debug = array();
 	$wp_object_cache->cache          = array();
 
-	if ( is_callable( $wp_object_cache, '__remoteset' ) ) {
+	if ( method_exists( $wp_object_cache, '__remoteset' ) ) {
 		$wp_object_cache->__remoteset();
 	}
 }


### PR DESCRIPTION
This PR fixes the incorrect invocation of `is_callable()` in `stop_the_insanity()`.

Since `WP_Object_Cache` does not have the `__invoke()` method, `is_callable( $wp_object_cache, true )` (`'__remoteset'` is coerced into `true`) always returns `false`.

Related: Automattic/vip-go-mu-plugins#2489
