### PR TITLE
Add new --queue-size & --queue-window args to the orchestrator's "list-due-batch" CLI

### DIFF
--- a/includes/class-events.php
+++ b/includes/class-events.php
@@ -91,7 +91,7 @@ class Events extends Singleton {
 	/**
 	 * List events pending for the current period
 	 *
-	 * @param array $job_queue_size   Maximum number of events to return.
+	 * @param array $job_queue_size   Maximum number of events to return (excludes internal events).
 	 * @param array $job_queue_window How many seconds into the future events should be fetched.
 	 * @return array
 	 */
@@ -188,7 +188,7 @@ class Events extends Singleton {
 	}
 
 	/**
-	 * Trim events queue down to the limit set by JOB_QUEUE_SIZE
+	 * Trim events queue down to a specific limit.
 	 *
 	 * @param array $events         List of events to be run in the current period.
 	 * @param array $max_queue_size Maximum number of events to return.

--- a/includes/class-events.php
+++ b/includes/class-events.php
@@ -90,8 +90,15 @@ class Events extends Singleton {
 
 	/**
 	 * List events pending for the current period
+	 *
+	 * @param array $job_queue_size   Maximum number of events to return.
+	 * @param array $job_queue_window How many seconds into the future events should be fetched.
+	 * @return array
 	 */
-	public function get_events() {
+	public function get_events( $job_queue_size = null, $job_queue_window = null ) {
+		$job_queue_size   = is_null( $job_queue_size ) ? JOB_QUEUE_SIZE : $job_queue_size;
+		$job_queue_window = is_null( $job_queue_window ) ? JOB_QUEUE_WINDOW_IN_SECONDS : $job_queue_window;
+
 		$events = get_option( 'cron' );
 
 		// That was easy.
@@ -108,7 +115,7 @@ class Events extends Singleton {
 		// Will include missed events as well.
 		$current_events  = array();
 		$internal_events = array();
-		$current_window  = strtotime( sprintf( '+%d seconds', JOB_QUEUE_WINDOW_IN_SECONDS ) );
+		$current_window  = strtotime( sprintf( '+%d seconds', $job_queue_window ) );
 
 		foreach ( $events as $event ) {
 			// Skip events whose time hasn't come.
@@ -139,8 +146,8 @@ class Events extends Singleton {
 		}
 
 		// Limit batch size to avoid resource exhaustion.
-		if ( count( $current_events ) > JOB_QUEUE_SIZE ) {
-			$current_events = $this->reduce_queue( $current_events );
+		if ( count( $current_events ) > $job_queue_size ) {
+			$current_events = $this->reduce_queue( $current_events, $job_queue_size );
 		}
 
 		// Combine with Internal Events.
@@ -183,11 +190,11 @@ class Events extends Singleton {
 	/**
 	 * Trim events queue down to the limit set by JOB_QUEUE_SIZE
 	 *
-	 * @param array $events List of events to be run in the current period.
-	 *
+	 * @param array $events         List of events to be run in the current period.
+	 * @param array $max_queue_size Maximum number of events to return.
 	 * @return array
 	 */
-	private function reduce_queue( $events ) {
+	private function reduce_queue( $events, $max_queue_size ) {
 		// Loop through events, adding one of each action during each iteration.
 		$reduced_queue = array();
 		$action_counts = array();
@@ -221,7 +228,7 @@ class Events extends Singleton {
 
 				continue;
 			}
-		} while ( $i <= 15 && count( $reduced_queue ) < JOB_QUEUE_SIZE && ! empty( $events ) );
+		} while ( $i <= 15 && count( $reduced_queue ) < $max_queue_size && ! empty( $events ) );
 
 		/**
 		 * IMPORTANT: DO NOT re-sort the $reduced_queue array from this point forward.
@@ -230,12 +237,12 @@ class Events extends Singleton {
 		 * While the events are now out of order with respect to timestamp, they're ordered
 		 * such that one of each action is run before another of an already-run action.
 		 * The timestamp mis-ordering is trivial given that we're only dealing with events
-		 * for the current JOB_QUEUE_WINDOW_IN_SECONDS.
+		 * for the current $job_queue_window.
 		 */
 
 		// Finally, ensure that we don't have more than we need.
-		if ( count( $reduced_queue ) > JOB_QUEUE_SIZE ) {
-			$reduced_queue = array_slice( $reduced_queue, 0, JOB_QUEUE_SIZE );
+		if ( count( $reduced_queue ) > $max_queue_size ) {
+			$reduced_queue = array_slice( $reduced_queue, 0, $max_queue_size );
 		}
 
 		return $reduced_queue;

--- a/includes/wp-cli/class-orchestrate-runner.php
+++ b/includes/wp-cli/class-orchestrate-runner.php
@@ -21,6 +21,7 @@ class Orchestrate_Runner extends \WP_CLI_Command {
 	 * Not intended for human use, rather it powers the Go-based Runner. Use the `events list` command instead.
 	 *
 	 * @subcommand list-due-batch
+	 * @synopsis [--queue-size=<numberOfEvents>] [--queue-window=<secondsIntoTheFuture>] [--format=<table|json|csv|etc>]
 	 * @param array $args Array of positional arguments.
 	 * @param array $assoc_args Array of flags.
 	 */
@@ -29,7 +30,19 @@ class Orchestrate_Runner extends \WP_CLI_Command {
 			\WP_CLI::error( __( 'Automatic event execution is disabled', 'automattic-cron-control' ) );
 		}
 
-		$events = \Automattic\WP\Cron_Control\Events::instance()->get_events();
+		// Control how many events are fetched
+		$queue_size = \WP_CLI\Utils\get_flag_value( $assoc_args, 'queue-size', null );
+		if ( ! is_numeric( $queue_size ) ) {
+			$queue_size = null;
+		}
+
+		// Control how far into the future events are fetched.
+		$queue_window = \WP_CLI\Utils\get_flag_value( $assoc_args, 'queue-window', null );
+		if ( ! is_numeric( $queue_window ) ) {
+			$queue_window = null;
+		}
+
+		$events = \Automattic\WP\Cron_Control\Events::instance()->get_events( $queue_size, $queue_window );
 
 		$format = \WP_CLI\Utils\get_flag_value( $assoc_args, 'format', 'table' );
 

--- a/includes/wp-cli/class-orchestrate-runner.php
+++ b/includes/wp-cli/class-orchestrate-runner.php
@@ -30,7 +30,7 @@ class Orchestrate_Runner extends \WP_CLI_Command {
 			\WP_CLI::error( __( 'Automatic event execution is disabled', 'automattic-cron-control' ) );
 		}
 
-		// Control how many events are fetched
+		// Control how many events are fetched. Note that internal events can exceed this cap.
 		$queue_size = \WP_CLI\Utils\get_flag_value( $assoc_args, 'queue-size', null );
 		if ( ! is_numeric( $queue_size ) ) {
 			$queue_size = null;

--- a/tests/tests/class-events.php
+++ b/tests/tests/class-events.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Test the Event's class.
+ *
+ * @package a8c_Cron_Control
+ * @phpcs:disable Squiz.Commenting.ClassComment.Missing
+ * @phpcs:disable Squiz.Commenting.VariableComment.Missing
+ * @phpcs:disable Squiz.Commenting.FunctionComment.Missing
+ * @phpcs:disable WordPress.Arrays.ArrayDeclarationSpacing.AssociativeArrayFound
+ */
+
+namespace Automattic\WP\Cron_Control\Tests;
+use Automattic\WP\Cron_Control\Events;
+
+class Events_Tests extends \WP_UnitTestCase {
+	private $registered_actions = [];
+
+	function setUp() {
+		parent::setUp();
+
+		// make sure the schedule is clear.
+		_set_cron_array( array() );
+	}
+
+	function tearDown() {
+		foreach ( $this->registered_actions as $registered_action ) {
+			remove_action( $registered_action, '__return_true' );
+		}
+
+		_set_cron_array( array() );
+		parent::tearDown();
+	}
+
+	function test_get_events() {
+		$events = Events::instance();
+
+		$test_events = $this->register_test_events();
+
+		// Fetch w/ default args = (10 + internal) max events, +30 seconds window.
+		$results        = $events->get_events();
+		$due_now_events = [ $test_events['test_event_1'], $test_events['test_event_2'], $test_events['test_event_3'] ];
+		$this->check_get_events( $results, $due_now_events );
+
+		// Fetch w/ 1 max queue size.
+		$results     = $events->get_events( 1 );
+		$first_event = [ $test_events['test_event_1'] ];
+		$this->check_get_events( $results, $first_event );
+
+		// Fetch w/ +11mins queue window (should exclude just our last event +30min event).
+		$results       = $events->get_events( null, 60 * 11 );
+		$window_events = [
+			$test_events['test_event_1'],
+			$test_events['test_event_2'],
+			$test_events['test_event_3'],
+			$test_events['test_event_4'],
+			$test_events['test_event_5'],
+		];
+		$this->check_get_events( $results, $window_events );
+	}
+
+	private function check_get_events( $results, $desired_results ) {
+		$this->assertEquals( count( $results['events'] ), count( $desired_results ), 'Incorrect number of events returned' );
+
+		foreach ( $results['events'] as $event ) {
+			$this->assertContains( $event['action'], wp_list_pluck( $desired_results, 'hashed' ), 'Missing registered event' );
+		}
+	}
+
+	private function register_test_events() {
+		$test_events = [
+			[ 'timestamp' => strtotime( '-1 minute' ), 'action' => 'test_event_1' ],
+			[ 'timestamp' => time(), 'action' => 'test_event_2' ],
+			[ 'timestamp' => time(), 'action' => 'test_event_3' ],
+			[ 'timestamp' => strtotime( '+5 minutes' ), 'action' => 'test_event_4' ],
+			[ 'timestamp' => strtotime( '+10 minutes' ), 'action' => 'test_event_5' ],
+			[ 'timestamp' => strtotime( '+30 minutes' ), 'action' => 'test_event_6' ],
+		];
+
+		$scheduled = [];
+		foreach ( $test_events as $test_event ) {
+			$scheduled[ $test_event['action'] ] = $this->register_test_event( $test_event );
+		}
+
+		return $scheduled;
+	}
+
+	private function register_test_event( $args = [] ) {
+		$event = wp_parse_args( $args, [ 'timestamp' => time(), 'action' => 'test_event' ] );
+
+		// Easier testing comparision.
+		$event['hashed'] = md5( $event['action'] );
+
+		// Plugin skips events with no callbacks.
+		$this->registered_actions[] = $event['action'];
+		add_action( $event['action'], '__return_true' );
+
+		wp_schedule_single_event( $event['timestamp'], $event['action'] );
+
+		return $event;
+	}
+}


### PR DESCRIPTION
## Description

To go alongside the new cron runner, we need to be able to customize (or rather disable for now) the functionality that fetches jobs that are not currently "due now". 

Don't want to hardcode a change to `JOB_QUEUE_SIZE` right now, as the new runner is going to be intended for use on k8s and not VIPd - thus PHP changes must remain fully BC.

## Testing

(use `wp cron-control events list` to keep an eye on expected results)

```
// Lists events due up to +60s into the future
wp cron-control orchestrate runner-only list-due-batch

// List only events that are "due now"
wp cron-control orchestrate runner-only list-due-batch --queue-window=0

// List events that are due in the next 5 minutes.
wp cron-control orchestrate runner-only list-due-batch --queue-window=300
```

____

And to allow future tailoring in the runner, I also added a flag to change the queue size.

```
// Fetches only up to (JOB_QUEUE_SIZE + internal) events
wp cron-control orchestrate runner-only list-due-batch --queue-window=900000

// Fetches up to (2 + internal) events
wp cron-control orchestrate runner-only list-due-batch --queue-size=2

// Likely fetches all events
wp cron-control orchestrate runner-only list-due-batch --queue-size=1000 --queue-window=900000 --format=count
```