### PR TITLE
Implement WP cron filters

### DIFF
--- a/includes/wp-adapter.php
+++ b/includes/wp-adapter.php
@@ -1,0 +1,314 @@
+<?php
+
+namespace Automattic\WP\Cron_Control;
+
+use Automattic\WP\Cron_Control\Events_Store;
+use WP_Error;
+
+// Integrate w/ WP's cron api once the custom table is installed.
+if ( Events_Store::is_installed() ) {
+	// Core filters added in WP 5.1, allowing us to fully use the custom event's store.
+	add_filter( 'pre_schedule_event', __NAMESPACE__ . '\\pre_schedule_event', 10, 2 );
+	add_filter( 'pre_reschedule_event', __NAMESPACE__ . '\\pre_reschedule_event', 10, 2 );
+	add_filter( 'pre_unschedule_event', __NAMESPACE__ . '\\pre_unschedule_event', 10, 4 );
+	add_filter( 'pre_clear_scheduled_hook', __NAMESPACE__ . '\\pre_clear_scheduled_hook', 10, 3 );
+	add_filter( 'pre_unschedule_hook', __NAMESPACE__ . '\\pre_unschedule_hook', 10, 2 );
+	add_filter( 'pre_get_scheduled_event', __NAMESPACE__ . '\\pre_get_scheduled_event', 10, 4 );
+	add_filter( 'pre_get_ready_cron_jobs', __NAMESPACE__ . '\\pre_get_ready_cron_jobs', 10, 1 );
+
+	// Backwards-compat filters in case anybody tries doing something directly w/ the 'cron' options.
+	add_filter( 'pre_option_cron', __NAMESPACE__ . '\\pre_get_cron_option', 10 );
+	add_filter( 'pre_update_option_cron', __NAMESPACE__ . '\\pre_update_cron_option', 10, 2 );
+}
+
+/**
+ * Intercept event scheduling.
+ *
+ * @param null     $pre Null if the process has not been intercepted yet.
+ * @param stdClass $event Event data object.
+ * @return bool|WP_Error true on success, WP_Error on failure.
+ */
+function pre_schedule_event( $pre, $event ) {
+	if ( null !== $pre ) {
+		return $pre;
+	}
+
+	$query_args = [
+		'action' => $event->hook,
+		'args'   => $event->args,
+	];
+
+	$is_recurring = ! empty( $event->schedule );
+	if ( $is_recurring ) {
+		// Prevent exact duplicate recurring events altogether (ignoring timeframe).
+		// This diverges a bit from core behavior, but preventing such duplicates comes with good benefits.
+		$query_args['schedule'] = $event->schedule;
+	} else {
+		// Prevent one-time event duplicates if there is already another one like it within a 10m time span.
+		// Same logic as that in wp_schedule_single_event().
+		$ten_minutes  = 10 * MINUTE_IN_SECONDS;
+		$current_time = time();
+
+		$query_args['timestamp'] = [
+			'from' => ( $current_time + $ten_minutes ) > $event->timestamp ? 0 : $event->timestamp - $ten_minutes,
+			'to'   => $current_time > $event->timestamp ? $current_time + $ten_minutes : $event->timestamp + $ten_minutes,
+		];
+	}
+
+	$existing = Event::get( $query_args );
+	if ( ! is_null( $existing ) ) {
+		return new WP_Error( 'cron-control:wp:duplicate-event' );
+	}
+
+	// TODO: Maybe re-query the duplicate check with SRTM first before we do the INSERT? (also would need a cache bypass flag)
+
+	/** This filter is documented in wordpress/wp-includes/cron.php */
+	$event = apply_filters( 'schedule_event', $event );
+
+	// Passed duplicate checks, all clear to create an event.
+	$new_event = new Event();
+	$new_event->set_action( $event->hook );
+	$new_event->set_timestamp( $event->timestamp );
+	$new_event->set_args( $event->args );
+
+	if ( ! empty( $event->schedule ) && ! empty( $event->interval ) ) {
+		$new_event->set_schedule( $event->schedule, $event->interval );
+	}
+
+	return $new_event->save();
+}
+
+/**
+ * Intercept event rescheduling.
+ * Should be unused if core cron is disabled (using cron control runner for example).
+ *
+ * @param null     $pre Null if the process has not been intercepted yet.
+ * @param stdClass $event Event object.
+ * @return bool|WP_Error true on success, WP_Error on failure.
+ */
+function pre_reschedule_event( $pre, $event ) {
+	if ( null !== $pre ) {
+		return $pre;
+	}
+
+	$event = Event::get( [
+		'timestamp' => $event->timestamp,
+		'action'    => $event->hook,
+		'args'      => $event->args,
+	] );
+
+	if ( is_null( $event ) ) {
+		return new WP_Error( 'cron-control:wp:event-not-found' );
+	}
+
+	return $event->reschedule();
+}
+
+/**
+ * Intercept event unscheduling.
+ *
+ * @param null   $pre Null if the process has not been intercepted yet.
+ * @param int    $timestamp Event timestamp.
+ * @param string $hook Event action.
+ * @param array  $args Event arguments.
+ * @return bool|WP_Error true on success, WP_Error on failure.
+ */
+function pre_unschedule_event( $pre, $timestamp, $hook, $args ) {
+	if ( null !== $pre ) {
+		return $pre;
+	}
+
+	$event = Event::get( [
+		'timestamp' => $timestamp,
+		'action'    => $hook,
+		'args'      => $args,
+	] );
+
+	if ( is_null( $event ) ) {
+		return new WP_Error( 'cron-control:wp:event-not-found' );
+	}
+
+	return $event->complete();
+}
+
+/**
+ * Clear all actions for a given hook with specific event args.
+ *
+ * @param null       $pre Null if the process has not been intercepted yet.
+ * @param string     $hook Event action.
+ * @param null|array $args Event arguments. Passing null will delete all events w/ the hook.
+ * @return int|WP_Error Number of unscheduled events on success (could be 0), WP_Error on failure.
+ */
+function pre_clear_scheduled_hook( $pre, $hook, $args ) {
+	if ( null !== $pre ) {
+		return $pre;
+	}
+
+	$query_args = [
+		'action' => $hook,
+		'args'   => $args,
+		'limit'  => 100,
+		'page'   => 1,
+	];
+
+	// First grab all the events before making any changes (avoiding pagination complexities).
+	$all_events = [];
+	do {
+		$events     = Events::query( $query_args );
+		$all_events = array_merge( $all_events, $events );
+
+		$query_args['page']++;
+	} while ( ! empty( $events ) );
+
+	$all_successful = true;
+	foreach ( $all_events as $event ) {
+		$result = $event->complete();
+
+		if ( true !== $result ) {
+			$all_successful = false;
+		}
+	}
+
+	return $all_successful ? count( $all_events ) : new WP_Error( 'cron-control:wp:failed-event-deleting' );
+}
+
+/**
+ * Clear all actions for a given hook, regardless of event args.
+ *
+ * @param null   $pre  Null if the process has not been intercepted yet.
+ * @param string $hook Event action.
+ * @return int|WP_Error Number of unscheduled events on success (could be 0), WP_Error on failure.
+ */
+function pre_unschedule_hook( $pre, $hook ) {
+	if ( null !== $pre ) {
+		return $pre;
+	}
+
+	return pre_clear_scheduled_hook( $pre, $hook, null );
+}
+
+/**
+ * Intercept event retrieval.
+ *
+ * @param null     $pre  Null if the process has not been intercepted yet.
+ * @param string   $hook Event action.
+ * @param array    $args Event arguments.
+ * @param int|null $timestamp Event timestamp, null to just retrieve the next event.
+ * @return object|false The event object. False if the event does not exist.
+ */
+function pre_get_scheduled_event( $pre, $hook, $args, $timestamp ) {
+	if ( null !== $pre ) {
+		return $pre;
+	}
+
+	$event = Event::get( [
+		'timestamp' => $timestamp,
+		'action'    => $hook,
+		'args'      => $args,
+	] );
+
+	return is_null( $event ) ? false : $event->get_wp_event_format();
+}
+
+/**
+ * Intercept "ready events" retrieval.
+ * Should be unused if core cron is disabled (using cron control runner for example).
+ *
+ * @param null $pre Null if the process has not been intercepted yet.
+ * @return array Cron events ready to be run.
+ */
+function pre_get_ready_cron_jobs( $pre ) {
+	if ( null !== $pre ) {
+		return $pre;
+	}
+
+	// 100 is more than enough here.
+	// Also, we are unlikely to see this function ever used w/ core cron running disabled.
+	$events = Events::query( [
+		'timestamp' => 'due_now',
+		'limit'     => 100,
+	] );
+
+	return Events::format_events_for_wp( $events );
+}
+
+/**
+ * Intercepts requests for the entire 'cron' option.
+ * Ideally this is never called any more, but we must support this for backwards compatability.
+ *
+ * @param false $pre False if the process has not been intercepted yet.
+ * @return array Cron array, in the format WP expects.
+ */
+function pre_get_cron_option( $pre ) {
+	if ( false !== $pre ) {
+		return $pre;
+	}
+
+	// For maximum BC, we need to truly give all events here.
+	// Still stepping in increments of 100 to allow query caching to do it's job.
+	$query_args = [ 'limit' => 100, 'page' => 1 ];
+	$all_events = [];
+	do {
+		$events     = Events::query( $query_args );
+		$all_events = array_merge( $all_events, $events );
+
+		$query_args['page']++;
+	} while ( ! empty( $events ) );
+
+	$cron_array = Events::format_events_for_wp( $all_events );
+	$cron_array['version'] = 2; // a legacy core thing
+	return $cron_array;
+}
+
+/**
+ * Intercepts 'cron' option update.
+ * Ideally this is never called any more either, but we must support this for backwards compatability.
+ *
+ * @param array $new_value New cron array trying to be saved
+ * @param array $old_value Existing cron array (already intercepted via pre_get_cron_option() above)
+ * @return array Always returns $old_value to prevent update from occurring.
+ */
+function pre_update_cron_option( $new_value, $old_value ) {
+	if ( ! is_array( $new_value ) ) {
+		return $old_value;
+	}
+
+	$current_events = Events::flatten_wp_events_array( $old_value );
+	$new_events     = Events::flatten_wp_events_array( $new_value );
+
+	// Remove first, to prevent scheduling conflicts for the "added events" next.
+	$removed_events = array_diff_key( $current_events, $new_events );
+	foreach ( $removed_events as $event_to_remove ) {
+		$existing_event = Event::get( [
+			'timestamp' => $event_to_remove['timestamp'],
+			'action'    => $event_to_remove['action'],
+			'args'      => $event_to_remove['args'],
+		] );
+
+		if ( ! is_null( $existing_event ) ) {
+			// Mark as completed (perhaps canceled in the future).
+			$existing_event->complete();
+		}
+	}
+
+	// Now add any new events.
+	$added_events = array_diff_key( $new_events, $current_events );
+	foreach ( $added_events as $event_to_add ) {
+		$wp_event = [
+			'timestamp' => $event_to_add['timestamp'],
+			'hook'      => $event_to_add['action'],
+			'args'      => $event_to_add['args'],
+		];
+
+		if ( ! empty( $item['value']['schedule'] ) ) {
+			$wp_event['schedule'] = $event_to_add['schedule'];
+			$wp_event['interval'] = $event_to_add['interval'];
+		}
+
+		// Pass it up through this function so we can take advantage of duplicate prevention.
+		pre_schedule_event( null, (object) $wp_event );
+	}
+
+	// Always just return the old value so we don't trigger a db update.
+	return $old_value;
+}

--- a/tests/tests/class-wp-adapter-tests.php
+++ b/tests/tests/class-wp-adapter-tests.php
@@ -1,0 +1,314 @@
+<?php
+/**
+ * Test the WP adapter, the filters where we implement our custom data store.
+ */
+
+namespace Automattic\WP\Cron_Control\Tests;
+
+use Automattic\WP\Cron_Control\Events_Store;
+use Automattic\WP\Cron_Control\Events;
+use Automattic\WP\Cron_Control\Event;
+use Automattic\WP\Cron_Control;
+
+class WP_Adapter_Tests extends \WP_UnitTestCase {
+	function setUp() {
+		parent::setUp();
+		// delete existing crons before each test
+		_set_cron_array( [] );
+	}
+
+	function tearDown() {
+		_set_cron_array( [] );
+		parent::tearDown();
+	}
+
+	function test_pre_schedule_event() {
+		// Test single/one-time event.
+		$this->run_schedule_test( (object) [
+			'timestamp' => time() + 500,
+			'hook'      => 'test_pre_schedule_event_single',
+			'schedule'  => false,
+			'args'      => [],
+		] );
+
+		// Test recurring events.
+		$this->run_schedule_test( (object) [
+			'timestamp' => time() + 500,
+			'hook'      => 'test_pre_schedule_event_recurring',
+			'args'      => [],
+			'schedule'  => 'hourly',
+			'interval'  => HOUR_IN_SECONDS,
+		] );
+	}
+
+	private function run_schedule_test( $event_args ) {
+		// Make sure the return value is what core expects
+		$result = Cron_Control\pre_schedule_event( null, $event_args );
+		$this->assertTrue( $result, 'scheduling was successful' );
+
+		// Ensure the event made it's way to the DB.
+		$event = Event::get( [ 'action' => $event_args->hook ] );
+		$this->assertEquals( $event_args->timestamp, $event->get_timestamp() );
+
+		// Try to register again, and we get a duplicate event error.
+		$fail_result = Cron_Control\pre_schedule_event( null, $event_args );
+		$this->assertEquals( 'cron-control:wp:duplicate-event', $fail_result->get_error_code() );
+	}
+
+	function test_pre_reschedule_event() {
+		$event_args = (object) [
+			'timestamp' => time() - 500, // Past "due" keeps the calculation simple
+			'hook'      => 'test_pre_reschedule_event',
+			'args'      => [],
+			'schedule'  => 'hourly',
+			'interval'  => HOUR_IN_SECONDS,
+		];
+
+		// Schedule the event for the first time.
+		Cron_Control\pre_schedule_event( null, $event_args );
+
+		// Make sure the successful return value is what core expects
+		$result = Cron_Control\pre_reschedule_event( null, $event_args );
+		$this->assertTrue( $result, 'rescheduling was successful' );
+
+		// Ensure the event update made it's way to the DB.
+		$event = Event::get( [ 'action' => $event_args->hook ] );
+		$this->assertEquals( $event_args->timestamp + HOUR_IN_SECONDS, $event->get_timestamp() );
+
+		// Should fail if it can't find the event.
+		$event_args->action = 'test_pre_reschedule_event_missing';
+		$fail_result = Cron_Control\pre_reschedule_event( null, $event_args );
+		$this->assertEquals( 'cron-control:wp:event-not-found', $fail_result->get_error_code() );
+	}
+
+	function test_pre_unschedule_event() {
+		$event = (object) [
+			'timestamp' => time(),
+			'hook'      => 'test_pre_unschedule_event',
+			'args'      => [],
+			'schedule'  => false,
+		];
+
+		// Schedule the event for the first time.
+		Cron_Control\pre_schedule_event( null, $event );
+
+		// Make sure the successful return value is what core expects
+		$result = Cron_Control\pre_unschedule_event( null, $event->timestamp, $event->hook, $event->args );
+		$this->assertTrue( $result, 'unscheduling was successful' );
+
+		// Ensure the event update made it's way to the DB.
+		$object = Event::get( [ 'action' => $event->hook, 'status' => Events_Store::STATUS_COMPLETED ] );
+		$this->assertEquals( Events_Store::STATUS_COMPLETED, $object->get_status() );
+
+		// Now that the event is "gone", it should fail to unschedule again.
+		$fail_result = Cron_Control\pre_unschedule_event( null, $event->timestamp, $event->hook, $event->args );
+		$this->assertEquals( 'cron-control:wp:event-not-found', $fail_result->get_error_code() );
+	}
+
+	function test_pre_clear_scheduled_hook() {
+		$event_details = [
+			'hook'      => 'test_pre_clear_scheduled_hook',
+			'schedule'  => false,
+			'timestamp' => time(),
+		];
+
+		$event_one = array_merge( $event_details, [ 'args' => [ 'default args' ] ] );
+
+		// Same args (instance), but very different timestamps so they both register.
+		$event_two = array_merge( $event_details, [ 'args' => [ 'other args' ], 'timestamp' => time() + 500 ] );
+		$event_three  = array_merge( $event_details, [ 'args' => [ 'other args' ], 'timestamp' => time() + 1500 ] );
+
+		// Schedule the events for the first time.
+		Cron_Control\pre_schedule_event( null, (object) $event_one );
+		Cron_Control\pre_schedule_event( null, (object) $event_two );
+		Cron_Control\pre_schedule_event( null, (object) $event_three );
+
+		// Unschedule the two similar events.
+		$result = Cron_Control\pre_clear_scheduled_hook( null, 'test_pre_clear_scheduled_hook', [ 'other args' ] );
+		$this->assertEquals( 2, $result, 'clearing was successful' );
+
+		// Ensure the event update made it's way to the DB.
+		$object = Event::get( [
+			'action' => 'test_pre_clear_scheduled_hook',
+			'timestamp' => $event_two['timestamp'],
+			'status' => Events_Store::STATUS_COMPLETED,
+		] );
+		$this->assertEquals( Events_Store::STATUS_COMPLETED, $object->get_status() );
+
+		// Empty args array should clear no events since we have not registered any w/ empty args.
+		$result = Cron_Control\pre_clear_scheduled_hook( null, 'test_pre_clear_scheduled_hook', [] );
+		$this->assertEquals( 0, $result, 'no events were cleared' );
+	}
+
+	function test_pre_unschedule_hook() {
+		$event_details = [
+			'hook'      => 'test_pre_unschedule_hook',
+			'schedule'  => false,
+			'timestamp' => time(),
+		];
+
+		$event_one   = array_merge( $event_details, [ 'args' => [] ] );
+		$event_two   = array_merge( $event_details, [ 'args' => [ 'default args' ] ] );
+		$event_three = array_merge( $event_details, [ 'args' => [ 'unique args' ] ] );
+
+		// Schedule the events.
+		Cron_Control\pre_schedule_event( null, (object) $event_one );
+		Cron_Control\pre_schedule_event( null, (object) $event_two );
+		Cron_Control\pre_schedule_event( null, (object) $event_three );
+
+		// Should clear them all, even though args are different.
+		$result = Cron_Control\pre_unschedule_hook( null, 'test_pre_unschedule_hook' );
+		$this->assertEquals( 3, $result, 'clearing was successful' );
+
+		// Ensure the event update made it's way to the DB.
+		$object = Event::get( [
+			'action' => 'test_pre_unschedule_hook',
+			'args' => $event_three['args'],
+			'status' => Events_Store::STATUS_COMPLETED,
+		] );
+		$this->assertEquals( Events_Store::STATUS_COMPLETED, $object->get_status() );
+
+		// Nothing left to clear, returns 0 as WP expects.
+		$result = Cron_Control\pre_unschedule_hook( null, 'test_pre_unschedule_hook' );
+		$this->assertEquals( 0, $result, 'nothing was cleared' );
+	}
+
+	function test_pre_get_scheduled_event() {
+		$event_details = (object) [
+			'hook'      => 'test_pre_get_scheduled_event',
+			'args'      => [],
+			'timestamp' => time() + 2500,
+		];
+
+		// Event does not exist yet.
+		$result = Cron_Control\pre_get_scheduled_event( null, $event_details->hook, $event_details->args, $event_details->timestamp );
+		$this->assertFalse( $result, 'event does not exist, returns false as WP expected' );
+
+		// Now it exists.
+		Cron_Control\pre_schedule_event( null, $event_details );
+		$result = Cron_Control\pre_get_scheduled_event( null, $event_details->hook, $event_details->args, $event_details->timestamp );
+		$this->assertEquals( $result->hook, $event_details->hook );
+
+		// Make a similar event but w/ an earlier timestamp.
+		$event_details->timestamp = time() + 10;
+		Cron_Control\pre_schedule_event( null, $event_details );
+
+		// If we fetch w/o timestamp, it gets the (new) next occurring event.
+		$result = Cron_Control\pre_get_scheduled_event( null, $event_details->hook, $event_details->args, null );
+		$this->assertEquals( $result->timestamp, $event_details->timestamp, 'fetched the next occurring event' );
+	}
+
+	function test_pre_get_ready_cron_jobs() {
+		$ready_jobs = Cron_Control\pre_get_ready_cron_jobs( null );
+		$this->assertTrue( [] === $ready_jobs, 'returns no ready jobs' );
+
+		// Schedule some events, two are due, two are in the future (one is recurring).
+		$test_events = $this->create_test_events();
+
+		// Should give us the two due jobs.
+		$ready_jobs = Cron_Control\pre_get_ready_cron_jobs( null );
+		$this->assertEquals( 2, count( $ready_jobs ), 'returns two ready jobs' );
+
+		// Make it flat for easier testing (this flattening is tested individually elsewhere)
+		$flat_jobs = array_values( Events::flatten_wp_events_array( $ready_jobs ) );
+		$this->assert_event_matches_expected_args( $flat_jobs[0], $test_events['due_one'] );
+		$this->assert_event_matches_expected_args( $flat_jobs[1], $test_events['due_two'] );
+	}
+
+	public function test_pre_get_cron_option() {
+		$cron_option = Cron_Control\pre_get_cron_option( false );
+		$this->assertEquals( [ 'version' => 2 ], $cron_option, 'cron option is effectively empty' );
+
+		// Schedule some events.
+		$test_events = $this->create_test_events();
+
+		// Make sure we get the right response.
+		$cron_option = Cron_Control\pre_get_cron_option( false );
+		$this->assertEquals( 4 + 1, count( $cron_option ), 'cron option returned 4 events + version arg' );
+
+		// Make it flat for easier testing (this flattening is tested individually elsewhere)
+		$flat_option = array_values( Events::flatten_wp_events_array( $cron_option ) );
+		$this->assert_event_matches_expected_args( $flat_option[0], $test_events['due_one'] );
+		$this->assert_event_matches_expected_args( $flat_option[1], $test_events['due_two'] );
+		$this->assert_event_matches_expected_args( $flat_option[2], $test_events['future'] );
+		$this->assert_event_matches_expected_args( $flat_option[3], $test_events['recurring'] );
+	}
+
+	public function test_pre_update_cron_option() {
+		// Ironically, if the function being tested here is broken,
+		// the below will make it clear because test setup/teardown won't be able to clear things out :)
+		// Though it probably breaks things in much earlier tests.
+		$cron_option = Cron_Control\pre_get_cron_option( false );
+		$this->assertEquals( [ 'version' => 2 ], $cron_option );
+
+		// If given invalid data, just returns the old value it was given.
+		$update_result = Cron_Control\pre_update_cron_option( 'not array', [ 'old array' ] );
+		$this->assertEquals( [ 'old array' ], $update_result );
+
+		// Schedule an event, and leave one unsaved.
+		$default_args   = [ 'timestamp' => time() + 100, 'args' => [ 'some', 'args' ] ];
+		$event_to_add   = $this->create_unsaved_event( array_merge( $default_args, [ 'action' => 'test_pre_update_cron_option_new' ] ) );
+		$existing_event = $this->create_unsaved_event( array_merge( $default_args, [ 'action' => 'test_pre_update_cron_option_existing' ] ) );
+		$existing_event->save();
+
+		// Mock the scenario of sending a fresh event into the mix.
+		$existing_option = Events::format_events_for_wp( [ $existing_event ] );
+		$new_option      = Events::format_events_for_wp( [ $existing_event, $event_to_add ] );
+		$update_result   = Cron_Control\pre_update_cron_option( $new_option, $existing_option );
+
+		$this->assertEquals( $existing_option, $update_result, 'return value is always the prev value' );
+		$added_event = Event::get( [ 'action' => 'test_pre_update_cron_option_new' ] );
+		$this->assertEquals( $event_to_add->get_action(), $added_event->get_action(), 'event was registered' );
+
+		// Mock the scenario of deleting an event from the mix.
+		$existing_option = Events::format_events_for_wp( [ $existing_event, $added_event ] );
+		$new_option      = Events::format_events_for_wp( [ $event_to_add ] );
+		$update_result   = Cron_Control\pre_update_cron_option( $new_option, $existing_option );
+
+		$this->assertEquals( $existing_option, $update_result, 'return value is always the prev value' );
+		$removed_event = Event::get( [ 'action' => 'test_pre_update_cron_option_existing' ] );
+		$this->assertEquals( null, $removed_event, 'event was removed' );
+	}
+
+	private function assert_event_matches_expected_args( $event, $args ) {
+		$this->assertEquals( $event['timestamp'], $args['timestamp'], 'timestamp matches' );
+		$this->assertEquals( $event['action'], $args['hook'], 'action matches' );
+		$this->assertEquals( $event['args'], $args['args'], 'args match' );
+
+		if ( ! empty( $args['schedule'] ) ) {
+			$this->assertEquals( $event['schedule'], $args['schedule'], 'schedule matches' );
+			$this->assertEquals( $event['interval'], $args['interval'], 'interval matches' );
+		}
+	}
+
+	private function create_test_events() {
+		$event_details  = [ 'hook' => 'test_create_test_events', 'schedule' => false ];
+		$recurring_args = [ 'schedule' => 'hourly', 'interval' => HOUR_IN_SECONDS ];
+
+		// Schedule some events.
+		$due_event_one = array_merge( $event_details, [ 'timestamp' => time() - 1000, 'args' => [] ] );
+		$due_event_two = array_merge( $event_details, [ 'timestamp' => time() - 10, 'args' => [ 'default args' ] ] );
+		$future_event  = array_merge( $event_details, [ 'timestamp' => time() + 500, 'args' => [ 'unique args' ] ] );
+		$recurring     = array_merge( $event_details, $recurring_args, [ 'timestamp' => time() + 1500, 'args' => [ 'recurring args' ] ] );
+		Cron_Control\pre_schedule_event( null, (object) $due_event_one );
+		Cron_Control\pre_schedule_event( null, (object) $due_event_two );
+		Cron_Control\pre_schedule_event( null, (object) $future_event );
+		Cron_Control\pre_schedule_event( null, (object) $recurring );
+
+		return [
+			'due_one'   => $due_event_one,
+			'due_two'   => $due_event_two,
+			'future'    => $future_event,
+			'recurring' => $recurring,
+		];
+	}
+
+	private function create_unsaved_event( array $args ) {
+		$event = new Event();
+		$event->set_action( $args['action'] );
+		$event->set_timestamp( $args['timestamp'] );
+		$event->set_args( $args['args'] );
+
+		return $event;
+	}
+}


### PR DESCRIPTION
Refreshed work that continues w/ what started in #178. Thanks immensely to @ethitter & @joshbetz for the prior art on this.

## Description

This implements the filters that were added in WP 5.1 that allow us to intercept every core cron event scheduling operation. As a result, we no longer have to rely on one massive `cron` option that contains everything (race-conditions begone!). So the first section of filters you see here allow us to properly use the custom events storage directly when WP cron-related functions are called.

The second section of filters are re-implementations of existing logic, just in case a plugin for example is reading from the `cron` option, and maybe even deleting/adding events directly. So for full BC we still support doing that.

## Notable changes

(Some of this will be more visible in the other PRs)

1. Clean interaction layer for events. `Event::get()`, `$event->complete()`, etc. The logic is enclosed in that object.
2. One other deviation from the prior `#178` PR is that caching for events is handled individually rather than sharing the same `cron_control_jobs` cache key. This will help prevent race conditions.
3. Returns WP_Error's on failure. Core will automatically translate this to `false` pending on if the requester asked for a WP_Error or not.
4. In `pre_schedule_event`, I deviated from core slightly. It will reject scheduling a duplicate recurring event (one already exists that is active and has the same schedule), as this has caused many problems in the past. Interestingly, [core docblocks](https://developer.wordpress.org/reference/functions/wp_schedule_event/) say that there is some duplication prevention for recurring events, but there is in fact none.
5. The `pre_get_cron_option` avoids the cache bucketing issues we previously had, as it uses the new query layer that automatically caches things based on SQL args. W/o going into too much details on that (will cover in a separate PR), suffice to note that this will help immensely if anybody is still out there asking for the full cron array.
6. I leaned into the "complete" status, and opted for using it rather than directly deleting. Reasoning here is that I'd like to do more w/ statuses in the future and follow a path similar to Action Scheduler. Where we cleanup (truly delete) events that are older than X days, but leave them at say a completed/cancelled/failed status for a few days along with potentially have plugin-level logging with the events so failures can be better seen.

## Testing

You'll actually want to checkout the `next/complete-changeset` branch to test the full picture together currently. Once checked out, can run unit tests and various WP flows where events are added/ran. I recommend reviewing the new file locally w/ the complete changeset branch so you can refer to other methods.

**Expect tests to fail in the individual PRs.** The final PR will be the passing one :)

## PR Process Notes
This is one of a few parts of changes that I have currently to ship together. To help keep things "small" and reviewable, I've created a branch called `next/pull-request-base` that these PRs will be opened against. As they are reviewed and approved, I'll merge into this branch. Everything going into `next/pull-request-base` will be approved via PR, I've set up a temporary branch protection on it.

Once all the pieces are in, `next/pull-request-base` will be rebased against master and can become the new "cron control next" branch for pre-prod testing, eventually to be merged into master for the production release.