### PR TITLE
Introduce new Event object

### DIFF
--- a/includes/class-event.php
+++ b/includes/class-event.php
@@ -1,0 +1,399 @@
+<?php
+
+namespace Automattic\WP\Cron_Control;
+
+use WP_Error;
+
+class Event {
+	private ?int $id;
+	private string $status;
+
+	// TODO: Maybe we don't need action_hashed going forward?
+	private string $action;
+	private string $action_hashed;
+
+	private array $args = [];
+	private string $instance;
+
+	// These are left empty for one-time events.
+	private ?string $schedule;
+	private ?int $interval;
+
+	// When the event will run next.
+	private int $timestamp;
+
+	// Keeps track of what properties are changed.
+	private array $changed = [];
+
+	/**
+	 * Get an existing event if an ID or row data is passed, otherwise the event is new and empty.
+	 * Note: Use Event::get() when possible instead of initializing an existing event here.
+	 *
+	 * @param int|object $event Event to initialize.
+	 */
+	public function __construct( $event = null ) {
+		if ( is_int( $event ) && $event > 0 ) {
+			$event_stub = new \stdClass();
+			$event_stub->ID = $event;
+			self::populate_data( $event_stub );
+		} elseif ( ! empty( $event->ID ) ) {
+			self::populate_data( $event );
+		}
+	}
+
+	/*
+	|--------------------------------------------------------------------------
+	| Getters
+	|--------------------------------------------------------------------------
+	*/
+
+	public function get_id(): ?int {
+		return isset( $this->id ) ? $this->id : null;
+	}
+
+	public function get_status(): ?string {
+		return isset( $this->status ) ? $this->status : null;
+	}
+
+	public function get_action(): ?string {
+		return isset( $this->action ) ? $this->action : null;
+	}
+
+	public function get_args(): array {
+		return $this->args;
+	}
+
+	public function get_instance(): string {
+		// Defaults to a hash of the empty args array.
+		return isset( $this->instance ) ? $this->instance : self::create_instance_hash( $this->args );
+	}
+
+	public function get_schedule(): ?string {
+		return isset( $this->schedule ) ? $this->schedule : null;
+	}
+
+	public function get_interval(): ?int {
+		return isset( $this->interval ) ? $this->interval : null;
+	}
+
+	public function get_timestamp(): ?int {
+		return isset( $this->timestamp ) ? $this->timestamp : null;
+	}
+
+	/*
+	|--------------------------------------------------------------------------
+	| Setters
+	|--------------------------------------------------------------------------
+	*/
+
+	public function set_status( string $status ): void {
+		$status = strtolower( $status );
+
+		if ( in_array( $status, Events_Store::ALLOWED_STATUSES, true ) ) {
+			$this->status = $status;
+		} else {
+			$this->status = Events_Store::STATUS_PENDING;
+		}
+
+		// Always mark status as changed, as we want to ensure it always sends this data in the SQL if needed.
+		$this->mark_changed( 'status' );
+	}
+
+	public function set_action( string $action ): void {
+		if ( ! empty( $action ) ) {
+			$this->action = $action;
+			$this->mark_changed( 'action' );
+
+			$this->action_hashed = md5( $action );
+			$this->mark_changed( 'action_hashed' );
+		}
+	}
+
+	public function set_args( array $args ): void {
+		$this->args = $args;
+		$this->mark_changed( 'args' );
+
+		$this->instance = self::create_instance_hash( $this->args );
+		$this->mark_changed( 'instance' );
+	}
+
+	public function set_schedule( string $schedule, int $interval ): void {
+		if ( ! empty( $schedule ) && $interval > 0 ) {
+			// Ensure either both or none are set.
+			$this->schedule = $schedule;
+			$this->mark_changed( 'schedule' );
+
+			$this->interval = $interval;
+			$this->mark_changed( 'interval' );
+		}
+	}
+
+	public function set_timestamp( int $timestamp ): void {
+		if ( $timestamp >= 1 ) {
+			$this->timestamp = $timestamp;
+			$this->mark_changed( 'timestamp' );
+		}
+	}
+
+	/*
+	|--------------------------------------------------------------------------
+	| Methods for interacting with the object.
+	|--------------------------------------------------------------------------
+	*/
+
+	/**
+	 * Save the event based on locally-changed props.
+	 *
+	 * @return true|WP_Error true on success, WP_Error on failure.
+	 */
+	public function save() {
+		$changed_data = $this->get_changed_data();
+
+		if ( empty( $changed_data ) ) {
+			// Nothing to save.
+			return new WP_Error( 'cron-control:event:no-save-needed' );
+		}
+
+		if ( ! isset( $this->action, $this->timestamp ) ) {
+			// These are required properties, must be set in order to save.
+			return new WP_Error( 'cron-control:event:missing-props' );
+		}
+
+		$all_row_data = [
+			'status'        => isset( $this->status ) ? $this->status : null,
+			'action'        => $this->action,
+			'action_hashed' => md5( $this->action ),
+			'args'          => serialize( $this->args ),
+			'instance'      => self::create_instance_hash( $this->args ),
+			'timestamp'     => $this->timestamp,
+		];
+
+		if ( isset( $this->schedule ) && isset( $this->interval ) ) {
+			$all_row_data['schedule'] = $this->schedule;
+			$all_row_data['interval'] = $this->interval;
+		}
+
+		// Pick out just the data that has changed.
+		$row_data = [];
+		foreach ( $changed_data as $changed_prop ) {
+			$row_data[ $changed_prop ] = $all_row_data[ $changed_prop ];
+		}
+
+		if ( $this->exists() ) {
+			$success = Events_Store::_update_event( $this->id, $row_data );
+			if ( ! $success ) {
+				return new WP_Error( 'cron-control:event:failed-update' );
+			}
+
+			$this->clear_changed_data();
+			return true;
+		}
+
+		// Gotta create the event for the first time. Let's make sure we send all the necessary data and defaults.
+		$status_set = false;
+		if ( ! isset( $row_data['status'] ) ) {
+			$row_data['status'] = Events_Store::STATUS_PENDING;
+			$status_set = true;
+		}
+
+		if ( ! isset( $row_data['args'], $row_data['instance'] ) ) {
+			$row_data['args']     = $all_row_data['args'];
+			$row_data['instance'] = $all_row_data['instance'];
+		}
+
+		if ( ! isset( $row_data['schedule'], $row_data['interval'] ) ) {
+			// Data store expects these, however we'll leave both as null internally here.
+			$row_data['schedule'] = null;
+			$row_data['interval'] = 0;
+		}
+
+		$event_id = Events_Store::_create_event( $row_data );
+		if ( $event_id < 1 ) {
+			return new WP_Error( 'cron-control:event:failed-create' );
+		}
+
+		// Hydrate the object with the defaults that were set.
+		$this->id       = $event_id;
+		$this->status   = $status_set ? Events_Store::STATUS_PENDING : $this->status;
+
+		$this->clear_changed_data();
+		return true;
+	}
+
+	public function run(): void {
+		do_action_ref_array( $this->action, $this->args );
+	}
+
+	/**
+	 * Mark the event as completed.
+	 * TODO: Probably introduce cancel() method and status as well for more specific situations.
+	 *
+	 * @return true|WP_Error true on success, WP_Error on failure.
+	 */
+	public function complete() {
+		if ( ! $this->exists() ) {
+			return new WP_Error( 'cron-control:event:cannot-complete' );
+		}
+
+		// Prevent conflicts with the unique constraints in the table.
+		$this->instance = (string) mt_rand( 1000000, 9999999999999 );
+		$this->mark_changed( 'instance' );
+
+		$this->set_status( Events_Store::STATUS_COMPLETED );
+		return $this->save();
+	}
+
+	/**
+	 * Reschedule the event w/ an updated timestamp.
+	 *
+	 * @return true|WP_Error true on success, WP_Error on failure.
+	 */
+	public function reschedule() {
+		if ( ! $this->exists() ) {
+			return new WP_Error( 'cron-control:event:cannot-reschedule' );
+		}
+
+		if ( ! isset( $this->schedule, $this->interval ) ) {
+			// The event doesn't recur (or data was corrupted somehow), mark it as cancelled instead.
+			$this->complete();
+			return new WP_Error( 'cron-control:event:cannot-reschedule' );
+		}
+
+		$fresh_interval = $this->get_refreshed_schedule_interval();
+		$next_timestamp = $this->calculate_next_timestamp( $fresh_interval );
+
+		if ( $this->interval !== $fresh_interval ) {
+			$this->set_schedule( $this->schedule, $this->interval );
+		}
+
+		$this->set_timestamp( $next_timestamp );
+		return $this->save();
+	}
+
+	/*
+	|--------------------------------------------------------------------------
+	| Utilities
+	|--------------------------------------------------------------------------
+	*/
+
+	/**
+	 * Helper method for getting an event.
+	 *
+	 * @param int|array $event Event ID, or args to search for an event.
+	 * @return Event|null Returns an Event if successful, else null if the event could not be found.
+	 */
+	public static function get( $event ): ?Event {
+		if ( is_int( $event ) ) {
+			$id = $event;
+			$event = new Event( $id );
+			return $event->exists() ? $event : null;
+		}
+
+		if ( is_array( $event ) ) {
+			$args = $event;
+			$query = Events_Store::_query_events_raw( array_merge( $args, [ 'limit' => 1 ] ) );
+			if ( empty( $query ) ) {
+				return null;
+			}
+
+			$event = new Event( $query[0] );
+			return $event->exists() ? $event : null;
+		}
+
+		return null;
+	}
+
+	public function exists(): bool {
+		return isset( $this->id );
+	}
+
+	public function is_internal(): bool {
+		return Internal_Events::instance()->is_internal_event( $this->action );
+	}
+
+	// The format WP expects an event to come in.
+	public function get_wp_event_format(): object {
+		$wp_event = [
+			'hook'      => $this->get_action(),
+			'timestamp' => $this->get_timestamp(),
+			'schedule'  => empty( $this->get_schedule() ) ? false : $this->get_schedule(),
+			'args'      => $this->get_args(),
+		];
+
+		if ( isset( $this->interval ) ) {
+			$wp_event['interval'] = $this->interval;
+		}
+
+		return (object) $wp_event;
+	}
+
+	public static function create_instance_hash( array $args ): string {
+		return md5( serialize( $args ) );
+	}
+
+	private function get_changed_data(): array {
+		return array_keys( $this->changed );
+	}
+
+	private function clear_changed_data(): void {
+		$this->changed = [];
+	}
+
+	private function mark_changed( string $property ): void {
+		$this->changed[ $property ] = true;
+	}
+
+	// Similar functionality to wp_reschedule_event().
+	private function calculate_next_timestamp( int $interval ): ?int {
+		$now = time();
+
+		if ( $this->timestamp >= $now ) {
+			// Event was ran ahead (or right on) it's due time, schedule it to run again after it's full interval.
+			return $now + $interval;
+		}
+
+		// Event ran a bit delayed, adjust accordingly (example: a 12h interval event running 6h late will be scheduled for +6h from now).
+		// TODO: Maybe we can simplify here later and just always return `$now + $interval`?
+		$elapsed_time_since_due = $now - $this->timestamp;
+		$remaining_seconds_into_the_future = ( $interval - ( $elapsed_time_since_due % $interval ) );
+		return $now + $remaining_seconds_into_the_future;
+	}
+
+	private function get_refreshed_schedule_interval() {
+		// Try to get the interval from the schedule in case it's been updated.
+		$schedules = wp_get_schedules();
+		if ( isset( $schedules[ $this->schedule ] ) ) {
+			return (int) $schedules[ $this->schedule ]['interval'];
+		}
+
+		// If we couldn't get from schedule (was removed), use whatever was saved already.
+		return $this->interval;
+	}
+
+	private function populate_data( object $data ): void {
+		if ( ! isset( $data->status, $data->action, $data->args, $data->timestamp ) ) {
+			if ( isset( $data->ID ) ) {
+				// Given just an ID, grab the rest of the data.
+				$data = Events_Store::_get_event_raw( $data->ID );
+			}
+
+			if ( ! isset( $data->ID, $data->status, $data->action, $data->args, $data->timestamp ) ) {
+				// Still no valid data, avoid setting up the object. Will be treated as a new event now.
+				return;
+			}
+		}
+
+		$this->id = $data->ID;
+		$this->set_status( (string) $data->status );
+		$this->set_action( (string) $data->action );
+		$this->set_timestamp( (int) $data->timestamp );
+		$this->set_args( (array) maybe_unserialize( $data->args ) );
+
+		if ( ! empty( $data->schedule ) && ! empty( $data->interval ) ) {
+			$this->set_schedule( (string) $data->schedule, (int) $data->interval );
+		}
+
+		// Didn't actually change anything yet.
+		$this->clear_changed_data();
+	}
+}

--- a/includes/class-event.php
+++ b/includes/class-event.php
@@ -201,34 +201,16 @@ class Event {
 	|--------------------------------------------------------------------------
 	*/
 
-	/**
-	 * Helper method for getting an event.
-	 *
-	 * @param int|array $event Event ID, or args to search for an event.
-	 * @return Event|null Returns an Event if successful, else null if the event could not be found.
-	 */
-	public static function get( $event ): ?Event {
-		// Given an event ID.
-		if ( is_int( $event ) ) {
-			$db_row = Events_Store::_get_event_raw( $event );
-			return is_null( $db_row ) ? null : self::get_from_db_row( $db_row );
-		}
-
-		// Given event args.
-		if ( is_array( $event ) ) {
-			$query = Events_Store::_query_events_raw( array_merge( $event, [ 'limit' => 1 ] ) );
-			return empty( $query ) ? null : self::get_from_db_row( $query[0] );
-		}
-
-		return null;
+	public static function get( int $event_id ): ?Event {
+		$db_row = Events_Store::_get_event_raw( $event_id );
+		return is_null( $db_row ) ? null : self::get_from_db_row( $db_row );
 	}
 
-	/**
-	 * Hydrate the event object given a row from the DB.
-	 *
-	 * @param object $data Event database row.
-	 * @return Event|null Returns an Event if successful, else null if given invalid data.
-	 */
+	public static function find( array $query_args ): ?Event {
+		$results = Events_Store::_query_events_raw( array_merge( $query_args, [ 'limit' => 1 ] ) );
+		return empty( $results ) ? null : self::get_from_db_row( $results[0] );
+	}
+
 	public static function get_from_db_row( object $data ): ?Event {
 		if ( ! isset( $data->ID, $data->status, $data->action, $data->timestamp ) ) {
 			// Missing expected/required data, cannot setup the object.

--- a/tests/tests/class-event-tests.php
+++ b/tests/tests/class-event-tests.php
@@ -135,13 +135,20 @@ class Event_Tests extends \WP_UnitTestCase {
 		// Failed get by ID.
 		$event = Event::get( PHP_INT_MAX );
 		$this->assertNull( $event, 'could not find event by ID' );
+	}
 
-		// Successful get by args.
-		$event = Event::get( [ 'action' => 'test_get_action', 'timestamp' => 1637447875 ] );
-		$this->assertEquals( 'test_get_action', $event->get_action(), 'found event by args' );
+	function test_find() {
+		$test_event = new Event();
+		$test_event->set_action( 'test_find_action' );
+		$test_event->set_timestamp( 1637447876 );
+		$test_event->save();
 
-		// Failed get by args.
-		$event = Event::get( [ 'action' => 'non_existant_action', 'timestamp' => 1637447875 ] );
+		// Successful find by args.
+		$event = Event::find( [ 'action' => 'test_find_action', 'timestamp' => 1637447876 ] );
+		$this->assertEquals( 'test_find_action', $event->get_action(), 'found event by args' );
+
+		// Failed find by args.
+		$event = Event::find( [ 'action' => 'non_existant_action', 'timestamp' => 1637447876 ] );
 		$this->assertNull( $event, 'could not find event by args' );
 	}
 

--- a/tests/tests/class-event-tests.php
+++ b/tests/tests/class-event-tests.php
@@ -1,0 +1,389 @@
+<?php
+/**
+ * Test the Event class.
+ */
+
+namespace Automattic\WP\Cron_Control\Tests;
+
+use Automattic\WP\Cron_Control\Events_Store;
+use Automattic\WP\Cron_Control\Event;
+
+class Event_Tests extends \WP_UnitTestCase {
+	function setUp() {
+		parent::setUp();
+
+		// delete existing crons
+		_set_cron_array( [] );
+	}
+
+	function tearDown() {
+		_set_cron_array( [] );
+		parent::tearDown();
+	}
+
+	function test_set_status() {
+		$event = new Event();
+
+		$event->set_status( 1 );
+		$this->assertEquals( Events_Store::STATUS_PENDING, $event->get_status(), 'invalid status is set to the default' );
+		$event->set_status( 'COMPLETE' );
+		$this->assertEquals( Events_Store::STATUS_COMPLETED, $event->get_status(), 'status is matched w/ lowercase versions' );
+	}
+
+	function test_set_action() {
+		$event = new Event();
+
+		$event->set_action( '' );
+		$this->assertEquals( null, $event->get_action(), 'action is not set if invalid' );
+	}
+
+	function test_set_schedule() {
+		$event = new Event();
+
+		$event->set_schedule( '', HOUR_IN_SECONDS );
+		$this->assertEquals( null, $event->get_schedule(), 'schedule is not set if name is invalid' );
+		$event->set_schedule( 'hourly', 0 );
+		$this->assertEquals( null, $event->get_schedule(), 'schedule is not set if interval is invalid' );
+	}
+
+	function test_set_timestamp() {
+		$event = new Event();
+
+		$event->set_timestamp( -1 );
+		$this->assertEquals( null, $event->get_timestamp(), 'timestamp is not set if invalid' );
+	}
+
+	function test_run() {
+		$called = 0;
+		add_action( 'test_run_event_action', function () use ( &$called ) {
+			$called++;
+		} );
+
+		$event = new Event();
+		$event->set_action( 'test_run_event_action' );
+		$event->run();
+
+		$this->assertEquals( 1, $called, 'event callback was triggered once' );
+	}
+
+	function test_complete() {
+		// Mock up an event, but try to complete it before saving.
+		$event = new Event();
+		$event->set_action( 'test_action' );
+		$event->set_timestamp( time() );
+		$result = $event->complete();
+		$this->assertEquals( 'cron-control:event:cannot-complete', $result->get_error_code() );
+
+		// Now save the event and make sure props were updated correctly.
+		$event->save();
+		$result = $event->complete();
+		$this->assertTrue( $result, 'event was successfully completed' );
+		$this->assertEquals( Events_Store::STATUS_COMPLETED, $event->get_status() );
+	}
+
+	function test_reschedule() {
+		// Try to reschedule a non-recurring event.
+		$event = new Event();
+		$event->set_action( 'test_action' );
+		$event->set_timestamp( time() + 10 );
+		$event->save();
+		$result = $event->reschedule();
+		$this->assertEquals( 'cron-control:event:cannot-reschedule', $result->get_error_code() );
+		$this->assertEquals( Events_Store::STATUS_COMPLETED, $event->get_status() );
+
+		// Mock up recurring event, but try to reschedule before saving.
+		$event = new Event();
+		$event->set_action( 'test_action' );
+		$event->set_timestamp( time() + 10 );
+		$event->set_schedule( 'hourly', HOUR_IN_SECONDS );
+		$result = $event->reschedule();
+		$this->assertEquals( 'cron-control:event:cannot-reschedule', $result->get_error_code() );
+
+		// Now save the event and make sure props were updated correctly.
+		$event->save();
+		$result = $event->reschedule();
+		$this->assertTrue( $result, 'event was successfully rescheduled' );
+		$this->assertEquals( Events_Store::STATUS_PENDING, $event->get_status() );
+		$this->assertEquals( time() + HOUR_IN_SECONDS, $event->get_timestamp() );
+	}
+
+	function test_exists() {
+		$event = new Event();
+		$event->set_action( 'test_action' );
+		$event->set_timestamp( time() );
+		$this->assertFalse( $event->exists() );
+
+		$event->save();
+		$this->assertTrue( $event->exists() );
+
+		$missing_event = new Event( PHP_INT_MAX );
+		$this->assertFalse( $missing_event->exists() );
+	}
+
+	function test_create_instance_hash() {
+		$empty_args = Event::create_instance_hash( [] );
+		$this->assertEquals( md5( serialize( [] ) ), $empty_args );
+
+		$has_args = Event::create_instance_hash( [ 'some', 'data' ] );
+		$this->assertEquals( md5( serialize( [ 'some', 'data' ] ) ), $has_args );
+	}
+
+	function test_get_wp_event_format() {
+		$event = new Event();
+		$event->set_action( 'test_action' );
+		$event->set_timestamp( 123 );
+		$event->save();
+
+		$this->assertEquals( (object) [
+			'hook'      => 'test_action',
+			'timestamp' => 123,
+			'schedule'  => false,
+			'args'      => [],
+		], $event->get_wp_event_format() );
+
+		$event->set_schedule( 'hourly', HOUR_IN_SECONDS );
+		$event->set_args( [ 'args' ] );
+		$event->save();
+
+		$this->assertEquals( (object) [
+			'hook'      => 'test_action',
+			'timestamp' => 123,
+			'schedule'  => 'hourly',
+			'interval'  => HOUR_IN_SECONDS,
+			'args'      => [ 'args' ],
+		], $event->get_wp_event_format() );
+	}
+
+	function test_get() {
+		$test_event = new Event();
+		$test_event->set_action( 'test_get_action' );
+		$test_event->set_timestamp( 1637447875 );
+		$test_event->save();
+
+		// Successful get by ID.
+		$event = Event::get( $test_event->get_id() );
+		$this->assertEquals( 'test_get_action', $event->get_action(), 'found event by id' );
+
+		// Failed get by ID.
+		$event = Event::get( PHP_INT_MAX );
+		$this->assertNull( $event, 'could not find event by ID' );
+
+		// Successful get by args.
+		$event = Event::get( [ 'action' => 'test_get_action', 'timestamp' => 1637447875 ] );
+		$this->assertEquals( 'test_get_action', $event->get_action(), 'found event by args' );
+
+		// Failed get by args.
+		$event = Event::get( [ 'action' => 'non_existant_action', 'timestamp' => 1637447875 ] );
+		$this->assertNull( $event, 'could not find event by args' );
+	}
+
+	// Run through various flows of event creation.
+	function test_event_creations() {
+		// Create event w/ bare information to test the defaults.
+		$this->run_event_creation_test( [
+			'creation_args' => [
+				'action'    => 'test_event',
+				'timestamp' => 1637447872,
+			],
+			'expected_args' => [
+				'status'    => 'pending',
+				'action'    => 'test_event',
+				'args'      => [],
+				'schedule'  => null,
+				'interval'  => 0,
+				'timestamp' => 1637447872,
+			],
+		] );
+
+		// Create event w/ all non-default data.
+		$this->run_event_creation_test( [
+			'creation_args' => [
+				'status'    => 'complete',
+				'action'    => 'test_event',
+				'args'      => [ 'some' => 'data' ],
+				'schedule'  => 'hourly',
+				'interval'  => HOUR_IN_SECONDS,
+				'timestamp' => 1637447873,
+			],
+			'expected_args' => [
+				'status'    => 'complete',
+				'action'    => 'test_event',
+				'args'      => [ 'some' => 'data' ],
+				'schedule'  => 'hourly',
+				'interval'  => HOUR_IN_SECONDS,
+				'timestamp' => 1637447873,
+			],
+		] );
+
+		// Try to create event w/ missing action.
+		$this->run_event_creation_test( [
+			'creation_args' => [
+				'timestamp' => 1637447873,
+			],
+			'expected_args' => false,
+		] );
+
+		// Try to create event w/ missing timestamp.
+		$this->run_event_creation_test( [
+			'creation_args' => [
+				'action'    => 'test_event',
+			],
+			'expected_args' => false,
+		] );
+	}
+
+	private function run_event_creation_test( array $event_data ) {
+		$should_fail = false === $event_data['expected_args'];
+
+		$test_event = new Event();
+		Utils::apply_event_props( $test_event, $event_data['creation_args'] );
+		$save_result = $test_event->save();
+
+		// Check save results.
+		if ( $should_fail ) {
+			$this->assertEquals( 'cron-control:event:missing-props', $save_result->get_error_code(), 'save should fail due to missing props' );
+		} else {
+			$this->assertTrue( $save_result, 'event was saved' );
+
+			// Changes should be reset, nothing should be attempted to be saved right away again.
+			$second_save_result = $test_event->save();
+			$this->assertEquals( 'cron-control:event:no-save-needed', $second_save_result->get_error_code() );
+		}
+
+		// 1) Grab straight from the DB so we can make sure the enclosed properties worked correctly.
+		if ( ! $should_fail ) {
+			$raw_event = Events_Store::_get_event_raw( $test_event->get_id() );
+			$event_data['expected_args']['id'] = $test_event->get_id();
+			Utils::assert_event_raw_data_equals( $raw_event, $event_data['expected_args'], $this );
+		}
+
+		// 2) Initiate the event again, testing the getters and ensuring data is hydrated correctly.
+		if ( ! $should_fail ) {
+			$check_event = new Event( $test_event->get_id() );
+			$event_data['expected_args']['id'] = $test_event->get_id();
+			$this->assert_props_are_correct( $check_event, $event_data['expected_args'] );
+		}
+	}
+
+	// Run through various flows for event updates.
+	function test_event_updates() {
+		// All defaults, w/ a timestamp increase.
+		$this->run_event_update_test( [
+			'creation_args' => [
+				'action'    => 'test_update_event',
+				'timestamp' => 1637447872,
+			],
+			'update_args' => [
+				'action'    => 'test_update_event',
+				'timestamp' => 1637447872 + 500,
+			],
+			'expected_args' => [
+				'status'    => 'pending',
+				'action'    => 'test_update_event',
+				'args'      => [],
+				'schedule'  => null,
+				'interval'  => 0,
+				'timestamp' => 1637447872 + 500,
+			],
+		] );
+
+		// Ensure invalid data does not trigger update.
+		$this->run_event_update_test( [
+			'creation_args' => [
+				'action'    => 'test_update_event',
+				'timestamp' => 1637447872,
+			],
+			'update_args' => [
+				'action'    => '',
+				'timestamp' => -1,
+			],
+			'expected_args' => [
+				'status'    => 'pending',
+				'action'    => 'test_update_event',
+				'args'      => [],
+				'schedule'  => null,
+				'interval'  => 0,
+				'timestamp' => 1637447872,
+			],
+		], true );
+	}
+
+	private function run_event_update_test( array $event_data, bool $update_should_fail = false ) {
+		// Make the  intial test event.
+		$test_event = new Event();
+		Utils::apply_event_props( $test_event, $event_data['creation_args'] );
+		$save_result = $test_event->save();
+		$this->assertTrue( $save_result, 'event was saved' );
+
+		// Apply updates
+		Utils::apply_event_props( $test_event, $event_data['update_args'] );
+		$update_result = $test_event->save();
+
+		// 1) Check the update results
+		if ( $update_should_fail ) {
+			$this->assertTrue( is_wp_error( $update_result ), 'event was not updated' );
+		} else {
+			$this->assertTrue( $update_result, 'event was updated' );
+
+			// Nothing left to update.
+			$second_save_result = $test_event->save();
+			$this->assertEquals( 'cron-control:event:no-save-needed', $second_save_result->get_error_code() );
+		}
+
+		// 2) Check updates in the DB.
+		$raw_event = Events_Store::_get_event_raw( $test_event->get_id() );
+		$event_data['expected_args']['id'] = $test_event->get_id();
+		Utils::assert_event_raw_data_equals( $raw_event, $event_data['expected_args'], $this );
+
+		// 3) Initiate the event again, and test it's props.
+		$check_event = new Event( $test_event->get_id() );
+		$this->assert_props_are_correct( $check_event, $event_data['expected_args'] );
+
+		return $test_event;
+	}
+
+	public function test_populate_data() {
+		$test_event = new Event();
+		$test_event->set_action( 'test_populate_data' );
+		$test_event->set_timestamp( 1637447875 );
+		$test_event->save();
+
+		$expected_result = [
+			'id'        => $test_event->get_id(),
+			'status'    => Events_Store::STATUS_PENDING,
+			'action'    => 'test_populate_data',
+			'args'      => [],
+			'schedule'  => null,
+			'timestamp' => 1637447875,
+		];
+
+		// Can populate event from valid ID.
+		$by_id = new Event( $test_event->get_id() );
+		$this->assert_props_are_correct( $by_id, $expected_result );
+		$save_result = $by_id->save();
+		$this->assertEquals( 'cron-control:event:no-save-needed', $save_result->get_error_code(), 'nothing to save yet' );
+
+		$raw_event = Events_Store::_get_event_raw( $test_event->get_id() );
+
+		// Can populate the event w/ full data from database.
+		$by_data = new Event( $raw_event );
+		$this->assert_props_are_correct( $by_id, $expected_result );
+		$save_result = $by_id->save();
+		$this->assertEquals( 'cron-control:event:no-save-needed', $save_result->get_error_code(), 'nothing to save yet' );
+
+		// Cannot populate event w/ partial data from database.
+		unset( $raw_event->ID );
+		$by_missing_data = new Event( $raw_event );
+		$this->assertFalse( $by_missing_data->exists(), 'event should not exist yet' );
+		$this->assertEquals( $by_missing_data->get_action(), null, 'event should not have had any props set' );
+	}
+
+	private function assert_props_are_correct( Event $event, array $expected_data ) {
+		$this->assertEquals( $event->get_id(), $expected_data['id'] );
+		$this->assertEquals( $event->get_status(), $expected_data['status'] );
+		$this->assertEquals( $event->get_action(), $expected_data['action'] );
+		$this->assertEquals( $event->get_args(), $expected_data['args'] );
+		$this->assertEquals( $event->get_schedule(), $expected_data['schedule'] );
+		$this->assertEquals( $event->get_timestamp(), $expected_data['timestamp'] );
+	}
+}

--- a/tests/tests/class-event-tests.php
+++ b/tests/tests/class-event-tests.php
@@ -7,6 +7,7 @@ namespace Automattic\WP\Cron_Control\Tests;
 
 use Automattic\WP\Cron_Control\Events_Store;
 use Automattic\WP\Cron_Control\Event;
+use WP_Error;
 
 class Event_Tests extends \WP_UnitTestCase {
 	function setUp() {
@@ -19,38 +20,6 @@ class Event_Tests extends \WP_UnitTestCase {
 	function tearDown() {
 		_set_cron_array( [] );
 		parent::tearDown();
-	}
-
-	function test_set_status() {
-		$event = new Event();
-
-		$event->set_status( 1 );
-		$this->assertEquals( Events_Store::STATUS_PENDING, $event->get_status(), 'invalid status is set to the default' );
-		$event->set_status( 'COMPLETE' );
-		$this->assertEquals( Events_Store::STATUS_COMPLETED, $event->get_status(), 'status is matched w/ lowercase versions' );
-	}
-
-	function test_set_action() {
-		$event = new Event();
-
-		$event->set_action( '' );
-		$this->assertEquals( null, $event->get_action(), 'action is not set if invalid' );
-	}
-
-	function test_set_schedule() {
-		$event = new Event();
-
-		$event->set_schedule( '', HOUR_IN_SECONDS );
-		$this->assertEquals( null, $event->get_schedule(), 'schedule is not set if name is invalid' );
-		$event->set_schedule( 'hourly', 0 );
-		$this->assertEquals( null, $event->get_schedule(), 'schedule is not set if interval is invalid' );
-	}
-
-	function test_set_timestamp() {
-		$event = new Event();
-
-		$event->set_timestamp( -1 );
-		$this->assertEquals( null, $event->get_timestamp(), 'timestamp is not set if invalid' );
 	}
 
 	function test_run() {
@@ -69,8 +38,9 @@ class Event_Tests extends \WP_UnitTestCase {
 	function test_complete() {
 		// Mock up an event, but try to complete it before saving.
 		$event = new Event();
-		$event->set_action( 'test_action' );
+		$event->set_action( 'test_complete' );
 		$event->set_timestamp( time() );
+		$event->set_args( [ 'test', 'args' ] );
 		$result = $event->complete();
 		$this->assertEquals( 'cron-control:event:cannot-complete', $result->get_error_code() );
 
@@ -78,13 +48,14 @@ class Event_Tests extends \WP_UnitTestCase {
 		$event->save();
 		$result = $event->complete();
 		$this->assertTrue( $result, 'event was successfully completed' );
-		$this->assertEquals( Events_Store::STATUS_COMPLETED, $event->get_status() );
+		$this->assertEquals( Events_Store::STATUS_COMPLETED, $event->get_status(), 'the status was updated' );
+		$this->assertNotEquals( Event::create_instance_hash( [ 'test', 'args' ] ), $event->get_instance(), 'the instance was updated' );
 	}
 
 	function test_reschedule() {
 		// Try to reschedule a non-recurring event.
 		$event = new Event();
-		$event->set_action( 'test_action' );
+		$event->set_action( 'test_reschedule' );
 		$event->set_timestamp( time() + 10 );
 		$event->save();
 		$result = $event->reschedule();
@@ -93,7 +64,7 @@ class Event_Tests extends \WP_UnitTestCase {
 
 		// Mock up recurring event, but try to reschedule before saving.
 		$event = new Event();
-		$event->set_action( 'test_action' );
+		$event->set_action( 'test_reschedule' );
 		$event->set_timestamp( time() + 10 );
 		$event->set_schedule( 'hourly', HOUR_IN_SECONDS );
 		$result = $event->reschedule();
@@ -109,15 +80,12 @@ class Event_Tests extends \WP_UnitTestCase {
 
 	function test_exists() {
 		$event = new Event();
-		$event->set_action( 'test_action' );
+		$event->set_action( 'test_exists' );
 		$event->set_timestamp( time() );
 		$this->assertFalse( $event->exists() );
 
 		$event->save();
 		$this->assertTrue( $event->exists() );
-
-		$missing_event = new Event( PHP_INT_MAX );
-		$this->assertFalse( $missing_event->exists() );
 	}
 
 	function test_create_instance_hash() {
@@ -130,12 +98,12 @@ class Event_Tests extends \WP_UnitTestCase {
 
 	function test_get_wp_event_format() {
 		$event = new Event();
-		$event->set_action( 'test_action' );
+		$event->set_action( 'test_get_wp_event_format' );
 		$event->set_timestamp( 123 );
 		$event->save();
 
 		$this->assertEquals( (object) [
-			'hook'      => 'test_action',
+			'hook'      => 'test_get_wp_event_format',
 			'timestamp' => 123,
 			'schedule'  => false,
 			'args'      => [],
@@ -146,7 +114,7 @@ class Event_Tests extends \WP_UnitTestCase {
 		$event->save();
 
 		$this->assertEquals( (object) [
-			'hook'      => 'test_action',
+			'hook'      => 'test_get_wp_event_format',
 			'timestamp' => 123,
 			'schedule'  => 'hourly',
 			'interval'  => HOUR_IN_SECONDS,
@@ -177,213 +145,219 @@ class Event_Tests extends \WP_UnitTestCase {
 		$this->assertNull( $event, 'could not find event by args' );
 	}
 
-	// Run through various flows of event creation.
-	function test_event_creations() {
-		// Create event w/ bare information to test the defaults.
-		$this->run_event_creation_test( [
-			'creation_args' => [
-				'action'    => 'test_event',
-				'timestamp' => 1637447872,
+	function test_validate_props() {
+		// Invalid status.
+		$this->run_event_save_test( [
+			'creation' => [
+				'args' => [
+					'timestamp' => 1637447873,
+					'action'    => 'test_event',
+					'status'    => 'invalid_status',
+				],
+				'result' => new WP_Error( 'cron-control:event:prop-validation:invalid-status' ),
 			],
-			'expected_args' => [
-				'status'    => 'pending',
-				'action'    => 'test_event',
-				'args'      => [],
-				'schedule'  => null,
-				'interval'  => 0,
-				'timestamp' => 1637447872,
+		] );
+
+		// Invalid/missing action.
+		$this->run_event_save_test( [
+			'creation' => [
+				'args' => [
+					'timestamp' => 1637447873,
+					'action'    => '',
+				],
+				'result' => new WP_Error( 'cron-control:event:prop-validation:invalid-action' ),
+			],
+		] );
+
+		// Missing timestamp.
+		$this->run_event_save_test( [
+			'creation' => [
+				'args' => [ 'action' => 'test_event' ],
+				'result' => new WP_Error( 'cron-control:event:prop-validation:invalid-timestamp' ),
+			],
+		] );
+
+		// Invalid timestamp.
+		$this->run_event_save_test( [
+			'creation' => [
+				'args' => [
+					'timestamp' => -100,
+					'action'    => 'test_event',
+				],
+				'result' => new WP_Error( 'cron-control:event:prop-validation:invalid-timestamp' ),
+			],
+		] );
+
+		// Invalid schedule.
+		$this->run_event_save_test( [
+			'creation' => [
+				'args' => [
+					'timestamp' => 1637447873,
+					'action'    => 'test_event',
+					'schedule'  => '',
+					'interval'  => HOUR_IN_SECONDS,
+				],
+				'result' => new WP_Error( 'cron-control:event:prop-validation:invalid-schedule' ),
+			],
+		] );
+
+		// Invalid interval.
+		$this->run_event_save_test( [
+			'creation' => [
+				'args' => [
+					'timestamp' => 1637447873,
+					'action'    => 'test_event',
+					'schedule'  => 'hourly',
+					'interval'  => 0,
+				],
+				'result' => new WP_Error( 'cron-control:event:prop-validation:invalid-schedule' ),
+			],
+		] );
+	}
+
+	// Run through various flows of event saving.
+	function test_event_save() {
+		// Create event w/ bare information to test the defaults.
+		// Then update the timestamp.
+		$this->run_event_save_test( [
+			'creation' => [
+				'args' => [
+					'action'    => 'test_event_creations_1',
+					'timestamp' => 1637447872,
+				],
+				'result' => [
+					'status'    => 'pending',
+					'action'    => 'test_event_creations_1',
+					'args'      => [],
+					'schedule'  => null,
+					'interval'  => 0,
+					'timestamp' => 1637447872,
+				],
+			],
+			'update' => [
+				'args' => [ 'timestamp' => 1637447872 + 500 ],
+				'result' => [
+					'status'    => 'pending',
+					'action'    => 'test_event_creations_1',
+					'args'      => [],
+					'schedule'  => null,
+					'interval'  => 0,
+					'timestamp' => 1637447872 + 500,
+				],
 			],
 		] );
 
 		// Create event w/ all non-default data.
-		$this->run_event_creation_test( [
-			'creation_args' => [
-				'status'    => 'complete',
-				'action'    => 'test_event',
-				'args'      => [ 'some' => 'data' ],
-				'schedule'  => 'hourly',
-				'interval'  => HOUR_IN_SECONDS,
-				'timestamp' => 1637447873,
+		// Then try to update with invalid timestamp
+		$this->run_event_save_test( [
+			'creation' => [
+				'args' => [
+					'status'    => 'complete',
+					'action'    => 'test_event_creations_2',
+					'args'      => [ 'some' => 'data' ],
+					'schedule'  => 'hourly',
+					'interval'  => HOUR_IN_SECONDS,
+					'timestamp' => 1637447873,
+				],
+				'result' => [
+					'status'    => 'complete',
+					'action'    => 'test_event_creations_2',
+					'args'      => [ 'some' => 'data' ],
+					'schedule'  => 'hourly',
+					'interval'  => HOUR_IN_SECONDS,
+					'timestamp' => 1637447873,
+				],
 			],
-			'expected_args' => [
-				'status'    => 'complete',
-				'action'    => 'test_event',
-				'args'      => [ 'some' => 'data' ],
-				'schedule'  => 'hourly',
-				'interval'  => HOUR_IN_SECONDS,
-				'timestamp' => 1637447873,
+			'update' => [
+				'args' => [ 'timestamp' => -1 ],
+				'result' => new WP_Error( 'cron-control:event:prop-validation:invalid-timestamp' ),
 			],
-		] );
-
-		// Try to create event w/ missing action.
-		$this->run_event_creation_test( [
-			'creation_args' => [
-				'timestamp' => 1637447873,
-			],
-			'expected_args' => false,
-		] );
-
-		// Try to create event w/ missing timestamp.
-		$this->run_event_creation_test( [
-			'creation_args' => [
-				'action'    => 'test_event',
-			],
-			'expected_args' => false,
 		] );
 	}
 
-	private function run_event_creation_test( array $event_data ) {
-		$should_fail = false === $event_data['expected_args'];
-
+	private function run_event_save_test( array $event_data ) {
+		// 1) Create event.
 		$test_event = new Event();
-		Utils::apply_event_props( $test_event, $event_data['creation_args'] );
+		Utils::apply_event_props( $test_event, $event_data['creation']['args'] );
 		$save_result = $test_event->save();
 
-		// Check save results.
-		if ( $should_fail ) {
-			$this->assertEquals( 'cron-control:event:missing-props', $save_result->get_error_code(), 'save should fail due to missing props' );
-		} else {
-			$this->assertTrue( $save_result, 'event was saved' );
+		// 2) Verify event creation save results.
+		$expected_result = $event_data['creation']['result'];
+		$this->verify_save_result( $expected_result, $save_result, $test_event );
 
-			// Changes should be reset, nothing should be attempted to be saved right away again.
-			$second_save_result = $test_event->save();
-			$this->assertEquals( 'cron-control:event:no-save-needed', $second_save_result->get_error_code() );
+		if ( ! isset( $event_data['update'] ) ) {
+			// No update tests to perform.
+			return;
 		}
 
-		// 1) Grab straight from the DB so we can make sure the enclosed properties worked correctly.
-		if ( ! $should_fail ) {
-			$raw_event = Events_Store::_get_event_raw( $test_event->get_id() );
-			$event_data['expected_args']['id'] = $test_event->get_id();
-			Utils::assert_event_raw_data_equals( $raw_event, $event_data['expected_args'], $this );
-		}
-
-		// 2) Initiate the event again, testing the getters and ensuring data is hydrated correctly.
-		if ( ! $should_fail ) {
-			$check_event = new Event( $test_event->get_id() );
-			$event_data['expected_args']['id'] = $test_event->get_id();
-			$this->assert_props_are_correct( $check_event, $event_data['expected_args'] );
-		}
-	}
-
-	// Run through various flows for event updates.
-	function test_event_updates() {
-		// All defaults, w/ a timestamp increase.
-		$this->run_event_update_test( [
-			'creation_args' => [
-				'action'    => 'test_update_event',
-				'timestamp' => 1637447872,
-			],
-			'update_args' => [
-				'action'    => 'test_update_event',
-				'timestamp' => 1637447872 + 500,
-			],
-			'expected_args' => [
-				'status'    => 'pending',
-				'action'    => 'test_update_event',
-				'args'      => [],
-				'schedule'  => null,
-				'interval'  => 0,
-				'timestamp' => 1637447872 + 500,
-			],
-		] );
-
-		// Ensure invalid data does not trigger update.
-		$this->run_event_update_test( [
-			'creation_args' => [
-				'action'    => 'test_update_event',
-				'timestamp' => 1637447872,
-			],
-			'update_args' => [
-				'action'    => '',
-				'timestamp' => -1,
-			],
-			'expected_args' => [
-				'status'    => 'pending',
-				'action'    => 'test_update_event',
-				'args'      => [],
-				'schedule'  => null,
-				'interval'  => 0,
-				'timestamp' => 1637447872,
-			],
-		], true );
-	}
-
-	private function run_event_update_test( array $event_data, bool $update_should_fail = false ) {
-		// Make the  intial test event.
-		$test_event = new Event();
-		Utils::apply_event_props( $test_event, $event_data['creation_args'] );
-		$save_result = $test_event->save();
-		$this->assertTrue( $save_result, 'event was saved' );
-
-		// Apply updates
-		Utils::apply_event_props( $test_event, $event_data['update_args'] );
+		// 3) Apply event updates.
+		Utils::apply_event_props( $test_event, $event_data['update']['args'] );
 		$update_result = $test_event->save();
 
-		// 1) Check the update results
-		if ( $update_should_fail ) {
-			$this->assertTrue( is_wp_error( $update_result ), 'event was not updated' );
-		} else {
-			$this->assertTrue( $update_result, 'event was updated' );
-
-			// Nothing left to update.
-			$second_save_result = $test_event->save();
-			$this->assertEquals( 'cron-control:event:no-save-needed', $second_save_result->get_error_code() );
-		}
-
-		// 2) Check updates in the DB.
-		$raw_event = Events_Store::_get_event_raw( $test_event->get_id() );
-		$event_data['expected_args']['id'] = $test_event->get_id();
-		Utils::assert_event_raw_data_equals( $raw_event, $event_data['expected_args'], $this );
-
-		// 3) Initiate the event again, and test it's props.
-		$check_event = new Event( $test_event->get_id() );
-		$this->assert_props_are_correct( $check_event, $event_data['expected_args'] );
-
-		return $test_event;
+		// 4) Verify the update result.
+		$expected_update_result = $event_data['update']['result'];
+		$this->verify_save_result( $expected_update_result, $update_result, $test_event );
 	}
 
-	public function test_populate_data() {
+	private function verify_save_result( $expected_result, $actual_result, $test_event ) {
+		if ( is_wp_error( $expected_result ) ) {
+			$this->assertEquals( $expected_result->get_error_code(), $actual_result->get_error_code(), 'save should fail w/ WP Error' );
+			// Nothing more to test.
+			return;
+		}
+
+		$this->assertTrue( $actual_result, 'event was saved' );
+		$expected_result['id'] = $test_event->get_id();
+
+		// Grab straight from the DB so we can make sure the enclosed properties worked correctly.
+		$raw_event = Events_Store::_get_event_raw( $test_event->get_id() );
+		Utils::assert_event_raw_data_equals( $raw_event, $expected_result, $this );
+
+		// Initiate the event again, testing the getters and ensuring data is hydrated correctly.
+		$check_event = Event::get_from_db_row( $raw_event );
+		$this->assert_props_are_correct( $check_event, $expected_result );
+	}
+
+	public function test_get_from_db_row() {
+		// Create bare test event.
 		$test_event = new Event();
-		$test_event->set_action( 'test_populate_data' );
+		$test_event->set_action( 'test_get_from_db_row' );
 		$test_event->set_timestamp( 1637447875 );
 		$test_event->save();
 
 		$expected_result = [
 			'id'        => $test_event->get_id(),
 			'status'    => Events_Store::STATUS_PENDING,
-			'action'    => 'test_populate_data',
+			'action'    => 'test_get_from_db_row',
 			'args'      => [],
 			'schedule'  => null,
+			'interval'  => 0,
 			'timestamp' => 1637447875,
 		];
 
-		// Can populate event from valid ID.
-		$by_id = new Event( $test_event->get_id() );
-		$this->assert_props_are_correct( $by_id, $expected_result );
-		$save_result = $by_id->save();
-		$this->assertEquals( 'cron-control:event:no-save-needed', $save_result->get_error_code(), 'nothing to save yet' );
-
 		$raw_event = Events_Store::_get_event_raw( $test_event->get_id() );
 
-		// Can populate the event w/ full data from database.
-		$by_data = new Event( $raw_event );
-		$this->assert_props_are_correct( $by_id, $expected_result );
-		$save_result = $by_id->save();
-		$this->assertEquals( 'cron-control:event:no-save-needed', $save_result->get_error_code(), 'nothing to save yet' );
+		// Will populate the event w/ full data from database.
+		$event = Event::get_from_db_row( $raw_event );
+		$this->assert_props_are_correct( $event, $expected_result );
 
-		// Cannot populate event w/ partial data from database.
+		// Will not populate event w/ partial data from database.
 		unset( $raw_event->ID );
-		$by_missing_data = new Event( $raw_event );
-		$this->assertFalse( $by_missing_data->exists(), 'event should not exist yet' );
-		$this->assertEquals( $by_missing_data->get_action(), null, 'event should not have had any props set' );
+		$by_missing_data = Event::get_from_db_row( $raw_event );
+		$this->assertNull( $by_missing_data, 'event could not be populated' );
 	}
 
 	private function assert_props_are_correct( Event $event, array $expected_data ) {
-		$this->assertEquals( $event->get_id(), $expected_data['id'] );
-		$this->assertEquals( $event->get_status(), $expected_data['status'] );
-		$this->assertEquals( $event->get_action(), $expected_data['action'] );
-		$this->assertEquals( $event->get_args(), $expected_data['args'] );
-		$this->assertEquals( $event->get_schedule(), $expected_data['schedule'] );
-		$this->assertEquals( $event->get_timestamp(), $expected_data['timestamp'] );
+		$this->assertEquals( $event->get_id(), $expected_data['id'], 'id matches' );
+		$this->assertEquals( $event->get_status(), $expected_data['status'], 'status matches' );
+		$this->assertEquals( $event->get_action(), $expected_data['action'], 'action matches' );
+		$this->assertEquals( $event->get_args(), $expected_data['args'], 'args match' );
+		$this->assertEquals( $event->get_instance(), Event::create_instance_hash( $expected_data['args'] ), 'instance matches' );
+		$this->assertEquals( $event->get_schedule(), $expected_data['schedule'], 'schedule matches' );
+		$this->assertEquals( $event->get_timestamp(), $expected_data['timestamp'], 'timestamp matches' );
+
+		// Special case: In the db it's "0", but in our class we keep as null.
+		$expected_interval = 0 === $expected_data['interval'] ? null : $expected_data['interval'];
+		$this->assertEquals( $event->get_interval(), $expected_interval, 'interval matches' );
 	}
 }


### PR DESCRIPTION
## Description

### The Event object

Introduces a new `Event` object that helps standardize and simplify how we interact w/ events across the plugin, in a repeatable and testable way. Some examples:

```
// Making new event
$event = new Event();
$event->set_action( 'example_action' );
$event->set_timestamp( time() );
$event->save();

// Updating the event
$event = new Event( $id );
$event->set_timestamp( time() + 500 );
$event->save();

// Getting a specific event:
Event::get( [
  'timestamp' => time(),
  'action'    => 'example_action',
  'args'      => ['some args'],
] );
```

I usually wouldn't opt for the full getter/setter structure, but the object will help keep a strict contract w/ event interaction. Anything that happens at the single event-level is contained here, `$event->reschedule()` for example helps encapsulate the related logic.

Also of note is the general plan for the plugin to pass around these Event objects or an ID rather than random bits of args. So the orchestrator for example will just get the event ID and run via CLI w/ that. Helping side-step a range of problems we've run into w/ the current setup. So this may be a bit chonky of a PR initially, but a lot of existing code will be able to be removed as a result.

### The Events (plural) object
If something is happens to multiple events, then those will be going into the `Events` class (in a separate PR) where the interactions between multiple Event objects take place. Examples of the API that's going there to help give a full picture for the vision started in this PR:

```
// Query for multiple events.
Events::query( array $args ): array

// Format an array of Event objects the way WP expects the data
Events::format_events_for_wp( $events ): array
```


### The data store

Also going in a separate PR are the methods this object uses to interact with the actual database, but it may help to quickly see them here. The API exposed there is very simple, and notably intended to be private so all consumers go through Event() or Events().

```
_create_event( array $row_data ): int
_update_event( int $event_id, array $row_data ): bool
_get_event_raw( int $id ): ?object
_query_events_raw( array $args = [] ): array
```
_____

By itself, this PR does nothing. But in the other PRs, you will see the object being used for the new functionality. In the future existing plugin logic can be safely converted over in piece-mail.

## Testing

You'll actually want to checkout the `next/complete-changeset` PR to test the full picture together currently. Once checked out, can play with the new object. I recommend doing that locally while reviewing this new file rather than just via GH.

**Expect tests to fail in the individual PRs.** The final PR will be the passing one :)

## PR Process Notes
This is one of a few parts of changes that I have currently to ship together. To help keep things "small" and reviewable, I've created a branch called `next/pull-request-base` that these PRs will be opened against. As they are reviewed and approved, I'll merge into this branch. Everything going into `next/pull-request-base` will be approved via PR, I've set up a temporary branch protection on it.

Once all the pieces are in, `next/pull-request-base` will be rebased against master and can become the new "cron control next" branch for pre-prod testing, eventually to be merged into master for the production release.