### PR TITLE
New event's store methods

### DIFF
--- a/includes/class-events-store.php
+++ b/includes/class-events-store.php
@@ -961,7 +961,7 @@ class Events_Store extends Singleton {
 
 	/**
 	 * Get raw events data based on various available query args.
-	 * For internal use only, please use Event::get( $args ) or Events::query( $args ).
+	 * For internal use only, please use Event::find( $args ) or Events::query( $args ).
 	 *
 	 * @param array $args Argument list for the query.
 	 * @return array Array of raw event objects.
@@ -1012,18 +1012,7 @@ class Events_Store extends Singleton {
 			],
 		];
 
-		$parsed_args = wp_parse_args( $args, [
-			'action'        => $valid_args['action']['default'],
-			'action_hashed' => $valid_args['action_hashed']['default'],
-			'args'          => $valid_args['args']['default'],
-			'instance'      => $valid_args['instance']['default'],
-			'timestamp'     => $valid_args['timestamp']['default'],
-			'schedule'      => $valid_args['schedule']['default'],
-			'status'        => $valid_args['status']['default'],
-			'limit'         => $valid_args['limit']['default'],
-			'page'          => $valid_args['page']['default'],
-			'order'          => $valid_args['order']['default'],
-		] );
+		$parsed_args = wp_parse_args( $args, array_map( fn( $arg ) => $arg['default'], $valid_args ) );
 
 		foreach ( $valid_args as $arg_name => $arg_checks ) {
 			if ( $parsed_args[ $arg_name ] !== $arg_checks['default'] ) {
@@ -1067,7 +1056,7 @@ class Events_Store extends Singleton {
 		}
 
 		if ( ! is_null( $parsed_args['action_hashed'] ) ) {
-			// TODO: Deprecate this query arg later once all is converted to the new API.
+			// TODO: Deprecate this query arg later once all is converted.
 			$sql .= ' AND action_hashed = %s';
 			$placeholders[] = $parsed_args['action_hashed'];
 		}
@@ -1078,7 +1067,7 @@ class Events_Store extends Singleton {
 			$sql .= ' AND instance = %s';
 			$placeholders[] = $instance;
 		} elseif ( ! is_null( $parsed_args['instance'] ) ) {
-			// TODO: Deprecate this query arg later once all is converted to the new API.
+			// TODO: Deprecate this query arg later once all is converted.
 			$sql .= ' AND instance = %s';
 			$placeholders[] = $parsed_args['instance'];
 		}


### PR DESCRIPTION
## Description

Here are the aforementioned four main new methods on the data store:

```
_create_event( array $row_data ): int
_update_event( int $event_id, array $row_data ): bool
_get_event_raw( int $id ): ?object
_query_events_raw( array $args = [] ): array
```

These do pretty much all the heavy lifting needed for querying. In fact, the "working branch" already has additional cleanup in this class that I'll be PRing afterwards that replaces other store methods to internally use these new ones. That PR will look a lot more pleasant, sitting at `+110, -521` :), and has full backwards compatibility w/ all currently public methods and existing unit tests.

Some notes about the PR:

- Cache invalidation is handled by the `last_changed` cache group key. Whenever an update occurs, this is incremented to the current timestamp, signaling the query class that it needs to get fresh data. This works essentially the same way the old way of caching the entire cron option array in multiple buckets, except now they are individual entries w/o concerns for race conditions occurring while the cache is built up.
- A future enhancement I'm eyeing is caching individual events on a `action/instance/timestamp` key w/ their own group. Since the main action that happens on the FE is checking if an event is already registered (w/ these 3 args), this will help keep invalidations to a minimum for those queries as we can invalidate them specifically only when that event is changed. I've already planned out how this will work and we can do it w/ full BC later if we find it's needed.
- I'm not a huge fan of the "fake private" static methods, but it will take a few rotations of deprecations before we can make Events_Store a non-singleton and better enclose it within the plugin. So for now this seemed best.
_____

## Testing

You'll actually want to checkout the `next/complete-changeset` branch to test the full picture together currently. I recommend doing that locally while reviewing this new file rather than just via GH.

**Expect tests to fail in the individual PRs.** The final PR will be the passing one :)

## PR Process Notes
This is one of a few parts of changes that I have currently to ship together. To help keep things "small" and reviewable, I've created a branch called `next/pull-request-base` that these PRs will be opened against. As they are reviewed and approved, I'll merge into this branch. Everything going into `next/pull-request-base` will be approved via PR, I've set up a temporary branch protection on it.

Once all the pieces are in, `next/pull-request-base` will be rebased against master and can become the new "cron control next" branch for pre-prod testing, eventually to be merged into master for the production release.