### PR TITLE
Don't alter JSON parameters on WP-CLI commands

### DIFF
--- a/runner/remote.go
+++ b/runner/remote.go
@@ -332,7 +332,7 @@ func validateAndProcessCommand(calledCmd string) (string, error) {
 }
 
 func getCleanWpCliArgumentArray(wpCliCmdString string) ([]string, error) {
-	rawArgs := strings.Fields(wpCliCmdString)
+	rawArgs := tokenizeString(wpCliCmdString)
 	cleanArgs := make([]string, 0)
 	openQuote := false
 	arg := ""
@@ -917,6 +917,23 @@ func streamLogs(conn net.Conn, Guid string) {
 	logFile.Close()
 	logger.Printf("log file for Guid %s sent\n", Guid)
 }
+/*
+Splits a string into an array based on whitespace except when that whitepace is inside double qoutes or escaped quotes
+*/
+func tokenizeString( rawString string) [] string {
+	quoted := false
+	var prevRune rune
+	tokenized := strings.FieldsFunc(rawString, func(r rune) bool {
+		if r == '"' && prevRune != '\\' {
+			quoted = !quoted
+		}
+		prevRune = r;
+		return !quoted && r == ' '
+	})
+	out := strings.Join(tokenized, ", ")
+	return tokenized;
+}
+
 
 func isJSON(str string) bool {
     var js json.RawMessage

--- a/runner/remote.go
+++ b/runner/remote.go
@@ -924,6 +924,7 @@ func tokenizeString( rawString string) [] string {
 	quoted := false
 	var prevRune rune
 	tokenized := strings.FieldsFunc(rawString, func(r rune) bool {
+		//Tokenizing on double quotes EXCEPT when presceded by the escape char
 		if r == '"' && prevRune != '\\' {
 			quoted = !quoted
 		}

--- a/runner/remote.go
+++ b/runner/remote.go
@@ -19,6 +19,7 @@ import (
 	"sync/atomic"
 	"syscall"
 	"time"
+	"encoding/json"
 
 	"github.com/creack/pty"
 	"github.com/howeyc/fsnotify"
@@ -364,7 +365,9 @@ func getCleanWpCliArgumentArray(wpCliCmdString string) ([]string, error) {
 
 	// Remove quotes from the args
 	for i := range cleanArgs {
-		cleanArgs[i] = strings.ReplaceAll(cleanArgs[i], "\"", "")
+		if( ! isJSON( cleanArgs[i])) { //don't alter JSON arguments
+			cleanArgs[i] = strings.ReplaceAll(cleanArgs[i], "\"", "")
+		}
 	}
 
 	return cleanArgs, nil
@@ -913,4 +916,9 @@ func streamLogs(conn net.Conn, Guid string) {
 	conn.Close()
 	logFile.Close()
 	logger.Printf("log file for Guid %s sent\n", Guid)
+}
+
+func isJSON(str string) bool {
+    var js json.RawMessage
+    return json.Unmarshal([]byte(str), &js) == nil
 }


### PR DESCRIPTION
## Description 
This change fixes a bug that would strip double quotes from the property name and values inside a JSON payload. While not a "failure" bug, this would cause unexpected consequences for some clients when the values weren't stored with the quotes.
`vip @site.env --yes -- post meta update 1 custom_option '{\"name\":\"Text\",\"version\":0}'`

It also fixes a bug where if there was a space in a JSON value, the command would fail. THis command should now work:
`vip @site.env --yes -- post meta update 1 custom_option '{\"name\":\"Some text with spaces\",\"version\":0}'`