### PR TITLE
Misc cleanup for "cron control next" changeset

### DIFF
--- a/includes/class-main.php
+++ b/includes/class-main.php
@@ -54,11 +54,13 @@ class Main extends Singleton {
 		require __DIR__ . '/class-lock.php';
 
 		// Load remaining functionality.
+		require __DIR__ . '/class-event.php';
 		require __DIR__ . '/class-events.php';
 		require __DIR__ . '/class-internal-events.php';
 		require __DIR__ . '/class-rest-api.php';
 		require __DIR__ . '/functions.php';
 		require __DIR__ . '/wp-cli.php';
+		require __DIR__ . '/wp-adapter.php';
 	}
 
 	/**

--- a/includes/wp-adapter.php
+++ b/includes/wp-adapter.php
@@ -55,7 +55,7 @@ function pre_schedule_event( $pre, $event ) {
 		];
 	}
 
-	$existing = Event::get( $query_args );
+	$existing = Event::find( $query_args );
 	if ( ! is_null( $existing ) ) {
 		return new WP_Error( 'cron-control:wp:duplicate-event' );
 	}
@@ -91,7 +91,7 @@ function pre_reschedule_event( $pre, $event ) {
 		return $pre;
 	}
 
-	$event = Event::get( [
+	$event = Event::find( [
 		'timestamp' => $event->timestamp,
 		'action'    => $event->hook,
 		'args'      => $event->args,
@@ -118,7 +118,7 @@ function pre_unschedule_event( $pre, $timestamp, $hook, $args ) {
 		return $pre;
 	}
 
-	$event = Event::get( [
+	$event = Event::find( [
 		'timestamp' => $timestamp,
 		'action'    => $hook,
 		'args'      => $args,
@@ -201,7 +201,7 @@ function pre_get_scheduled_event( $pre, $hook, $args, $timestamp ) {
 		return $pre;
 	}
 
-	$event = Event::get( [
+	$event = Event::find( [
 		'timestamp' => $timestamp,
 		'action'    => $hook,
 		'args'      => $args,
@@ -279,7 +279,7 @@ function pre_update_cron_option( $new_value, $old_value ) {
 	// Remove first, to prevent scheduling conflicts for the "added events" next.
 	$removed_events = array_diff_key( $current_events, $new_events );
 	foreach ( $removed_events as $event_to_remove ) {
-		$existing_event = Event::get( [
+		$existing_event = Event::find( [
 			'timestamp' => $event_to_remove['timestamp'],
 			'action'    => $event_to_remove['action'],
 			'args'      => $event_to_remove['args'],

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -37,13 +37,18 @@ function _manually_load_plugin() {
 	require dirname( dirname( __FILE__ ) ) . '/cron-control.php';
 
 	// Plugin loads after `wp_install()` is called, so we compensate.
-	// See the `class_init()` method in Events_Store for the logic behind this.
 	\Automattic\WP\Cron_Control\Events_Store::instance()->prepare_table();
-	remove_filter( 'schedule_event', '__return_false' );
-	add_filter( 'pre_option_cron', array( \Automattic\WP\Cron_Control\Events_Store::instance(), 'get_option' ) );
-	add_filter( 'pre_update_option_cron', array( \Automattic\WP\Cron_Control\Events_Store::instance(), 'update_option' ), 10, 2 );
-	add_filter( 'schedule_event', array( \Automattic\WP\Cron_Control\Events_Store::instance(), 'block_creation_if_job_exists' ) );
-	\Automattic\WP\Cron_Control\_resume_event_creation();
+
+	// Need to re-add the filters since they would have been skipped over in wp-adapter.php the first time around.
+	add_filter( 'pre_schedule_event', __NAMESPACE__ . '\Automattic\WP\Cron_Control\pre_schedule_event', 10, 2 );
+	add_filter( 'pre_reschedule_event', __NAMESPACE__ . '\Automattic\WP\Cron_Control\pre_reschedule_event', 10, 2 );
+	add_filter( 'pre_unschedule_event', __NAMESPACE__ . '\Automattic\WP\Cron_Control\pre_unschedule_event', 10, 4 );
+	add_filter( 'pre_clear_scheduled_hook', __NAMESPACE__ . '\Automattic\WP\Cron_Control\pre_clear_scheduled_hook', 10, 3 );
+	add_filter( 'pre_unschedule_hook', __NAMESPACE__ . '\Automattic\WP\Cron_Control\pre_unschedule_hook', 10, 2 );
+	add_filter( 'pre_get_scheduled_event', __NAMESPACE__ . '\Automattic\WP\Cron_Control\pre_get_scheduled_event', 10, 4 );
+	add_filter( 'pre_get_ready_cron_jobs', __NAMESPACE__ . '\Automattic\WP\Cron_Control\pre_get_ready_cron_jobs', 10, 1 );
+	add_filter( 'pre_option_cron', __NAMESPACE__ . '\Automattic\WP\Cron_Control\pre_get_cron_option', 10 );
+	add_filter( 'pre_update_option_cron', __NAMESPACE__ . '\Automattic\WP\Cron_Control\pre_update_cron_option', 10, 2 );
 }
 tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 

--- a/tests/includes/class-utils.php
+++ b/tests/includes/class-utils.php
@@ -97,4 +97,40 @@ class Utils {
 			return $tested_data;
 		}
 	}
+
+	static function apply_event_props( $event, $props ) {
+		$props_to_set = array_keys( $props );
+
+		if ( in_array( 'status', $props_to_set, true ) ) {
+			$event->set_status( $props['status'] );
+		}
+
+		if ( in_array( 'action', $props_to_set, true ) ) {
+			$event->set_action( $props['action'] );
+		}
+
+		if ( in_array( 'args', $props_to_set, true ) ) {
+			$event->set_args( $props['args'] );
+		}
+
+		if ( in_array( 'schedule', $props_to_set, true ) ) {
+			$event->set_schedule( $props['schedule'], $props['interval'] );
+		}
+
+		if ( in_array( 'timestamp', $props_to_set, true ) ) {
+			$event->set_timestamp( $props['timestamp'] );
+		}
+	}
+
+	static function assert_event_raw_data_equals( object $raw_event, array $expected_data, $context ) {
+		$context->assertEquals( $raw_event->ID, $expected_data['id'], 'id matches' );
+		$context->assertEquals( $raw_event->status, $expected_data['status'], 'status matches' );
+		$context->assertEquals( $raw_event->action, $expected_data['action'], 'action matches' );
+		$context->assertEquals( $raw_event->action_hashed, md5( $expected_data['action'] ), 'action_hash matches' );
+		$context->assertEquals( $raw_event->args, serialize( $expected_data['args'] ), 'args match' );
+		$context->assertEquals( $raw_event->instance, md5( serialize( $expected_data['args'] ) ), 'instance matches' );
+		$context->assertEquals( $raw_event->schedule, $expected_data['schedule'], 'schedule matches' );
+		$context->assertEquals( $raw_event->interval, $expected_data['interval'], 'interval matches' );
+		$context->assertEquals( $raw_event->timestamp, $expected_data['timestamp'], 'timestamp matches' );
+	}
 }

--- a/tests/tests/class-wp-adapter-tests.php
+++ b/tests/tests/class-wp-adapter-tests.php
@@ -47,7 +47,7 @@ class WP_Adapter_Tests extends \WP_UnitTestCase {
 		$this->assertTrue( $result, 'scheduling was successful' );
 
 		// Ensure the event made it's way to the DB.
-		$event = Event::get( [ 'action' => $event_args->hook ] );
+		$event = Event::find( [ 'action' => $event_args->hook ] );
 		$this->assertEquals( $event_args->timestamp, $event->get_timestamp() );
 
 		// Try to register again, and we get a duplicate event error.
@@ -72,7 +72,7 @@ class WP_Adapter_Tests extends \WP_UnitTestCase {
 		$this->assertTrue( $result, 'rescheduling was successful' );
 
 		// Ensure the event update made it's way to the DB.
-		$event = Event::get( [ 'action' => $event_args->hook ] );
+		$event = Event::find( [ 'action' => $event_args->hook ] );
 		$this->assertEquals( $event_args->timestamp + HOUR_IN_SECONDS, $event->get_timestamp() );
 
 		// Should fail if it can't find the event.
@@ -97,7 +97,7 @@ class WP_Adapter_Tests extends \WP_UnitTestCase {
 		$this->assertTrue( $result, 'unscheduling was successful' );
 
 		// Ensure the event update made it's way to the DB.
-		$object = Event::get( [ 'action' => $event->hook, 'status' => Events_Store::STATUS_COMPLETED ] );
+		$object = Event::find( [ 'action' => $event->hook, 'status' => Events_Store::STATUS_COMPLETED ] );
 		$this->assertEquals( Events_Store::STATUS_COMPLETED, $object->get_status() );
 
 		// Now that the event is "gone", it should fail to unschedule again.
@@ -128,7 +128,7 @@ class WP_Adapter_Tests extends \WP_UnitTestCase {
 		$this->assertEquals( 2, $result, 'clearing was successful' );
 
 		// Ensure the event update made it's way to the DB.
-		$object = Event::get( [
+		$object = Event::find( [
 			'action' => 'test_pre_clear_scheduled_hook',
 			'timestamp' => $event_two['timestamp'],
 			'status' => Events_Store::STATUS_COMPLETED,
@@ -161,9 +161,8 @@ class WP_Adapter_Tests extends \WP_UnitTestCase {
 		$this->assertEquals( 3, $result, 'clearing was successful' );
 
 		// Ensure the event update made it's way to the DB.
-		$object = Event::get( [
+		$object = Event::find( [
 			'action' => 'test_pre_unschedule_hook',
-			'args' => $event_three['args'],
 			'status' => Events_Store::STATUS_COMPLETED,
 		] );
 		$this->assertEquals( Events_Store::STATUS_COMPLETED, $object->get_status() );
@@ -257,7 +256,7 @@ class WP_Adapter_Tests extends \WP_UnitTestCase {
 		$update_result   = Cron_Control\pre_update_cron_option( $new_option, $existing_option );
 
 		$this->assertEquals( $existing_option, $update_result, 'return value is always the prev value' );
-		$added_event = Event::get( [ 'action' => 'test_pre_update_cron_option_new' ] );
+		$added_event = Event::find( [ 'action' => 'test_pre_update_cron_option_new' ] );
 		$this->assertEquals( $event_to_add->get_action(), $added_event->get_action(), 'event was registered' );
 
 		// Mock the scenario of deleting an event from the mix.
@@ -266,7 +265,7 @@ class WP_Adapter_Tests extends \WP_UnitTestCase {
 		$update_result   = Cron_Control\pre_update_cron_option( $new_option, $existing_option );
 
 		$this->assertEquals( $existing_option, $update_result, 'return value is always the prev value' );
-		$removed_event = Event::get( [ 'action' => 'test_pre_update_cron_option_existing' ] );
+		$removed_event = Event::find( [ 'action' => 'test_pre_update_cron_option_existing' ] );
 		$this->assertEquals( null, $removed_event, 'event was removed' );
 	}
 


### PR DESCRIPTION
Helps tie the previous `next/pull-request-base` PRs together.

- Swap usage to the newer `Event::find()` method.
- Require new files.
- Add new test utils & fix testing bootstrap.