### PR TITLE
Events store cleanup

### DIFF
--- a/includes/class-events-store.php
+++ b/includes/class-events-store.php
@@ -8,21 +8,13 @@
 namespace Automattic\WP\Cron_Control;
 
 /**
- * Events Store class
+ * Event's Store class
  */
 class Events_Store extends Singleton {
-	/**
-	 * PLUGIN SETUP
-	 */
-
-	/**
-	 * Class constants
-	 */
 	const TABLE_SUFFIX = 'a8c_cron_control_jobs';
 
 	const DB_VERSION        = 1;
 	const DB_VERSION_OPTION = 'a8c_cron_control_db_version';
-	const TABLE_CREATE_LOCK = 'a8c_cron_control_creating_table';
 
 	const STATUS_PENDING   = 'pending';
 	const STATUS_RUNNING   = 'running';
@@ -30,57 +22,32 @@ class Events_Store extends Singleton {
 	const ACTIVE_STATUSES  = [ self::STATUS_PENDING, self::STATUS_RUNNING ];
 	const ALLOWED_STATUSES = [ self::STATUS_PENDING, self::STATUS_RUNNING, self::STATUS_COMPLETED ];
 
-	const CACHE_KEY = 'a8c_cron_ctrl_option';
-
-	/**
-	 * Whether the static option cache is invalid
-	 *
-	 * @var bool
-	 */
-	private $is_option_cache_valid = false;
-
-	/**
-	 * Whether or not event creation is temporarily blocked
-	 *
-	 * @var bool
-	 */
-	private $job_creation_suspended = false;
-
-	/**
-	 * Register hooks
-	 */
 	protected function class_init() {
 		// Create tables during installation.
 		add_action( 'wp_install', array( $this, 'create_table_during_install' ) );
+		// TODO: This is deprecated hook, switch to wp_insert_site.
 		add_action( 'wpmu_new_blog', array( $this, 'create_tables_during_multisite_install' ) );
 
 		// Remove table when a multisite subsite is deleted.
 		add_filter( 'wpmu_drop_tables', array( $this, 'remove_multisite_table' ) );
 
-		// Enable plugin when conditions support it, otherwise limit errors as much as possible.
-		if ( self::is_installed() ) {
-			// Option interception.
-			add_filter( 'pre_option_cron', array( $this, 'get_option' ) );
-			add_filter( 'pre_update_option_cron', array( $this, 'update_option' ), 10, 2 );
-
-			// Disallow duplicates.
-			add_filter( 'schedule_event', array( $this, 'block_creation_if_job_exists' ) );
-		} else {
-			// Can't create events since there's no table to hold them.
-			$this->suspend_event_creation();
-
-			// Prime plugin's options when the options table exists.
+		// Try to get the table installed.
+		if ( ! self::is_installed() ) {
 			if ( ! defined( 'WP_INSTALLING' ) || ! WP_INSTALLING ) {
-				$this->prime_options();
+				// Prime plugin's option before the options table exists.
+				add_option( self::DB_VERSION_OPTION, 0, null, false );
 			}
-
-			// Don't schedule events that won't be run.
-			add_filter( 'schedule_event', '__return_false' );
 
 			// In limited circumstances, try creating the table.
 			add_action( 'shutdown', array( $this, 'maybe_create_table_on_shutdown' ) );
 		}
 	}
+
+	/*
+	|--------------------------------------------------------------------------
+	| Custom table related methods.
+	|--------------------------------------------------------------------------
+	*/
 
 	/**
 	 * Check if events store is ready
@@ -91,7 +58,6 @@ class Events_Store extends Singleton {
 	 */
 	public static function is_installed() {
 		$db_version = (int) get_option( self::DB_VERSION_OPTION );
-
 		return version_compare( $db_version, 0, '>' );
 	}
 
@@ -99,17 +65,7 @@ class Events_Store extends Singleton {
 	 * Build appropriate table name for this install
 	 */
 	public function get_table_name() {
-		global $wpdb;
-
-		return $wpdb->prefix . self::TABLE_SUFFIX;
-	}
-
-	/**
-	 * Set initial options that control plugin's behaviour
-	 */
-	protected function prime_options() {
-		// Prime DB option.
-		add_option( self::DB_VERSION_OPTION, 0, null, false );
+		return self::table_name();
 	}
 
 	/**
@@ -143,6 +99,7 @@ class Events_Store extends Singleton {
 	 * Does not include front-end requests
 	 */
 	public function maybe_create_table_on_shutdown() {
+		// TODO: Also let it try to create in CLI automatically, not just is_admin().
 		if ( ! is_admin() && ! is_rest_endpoint_request( REST_API::ENDPOINT_LIST ) ) {
 			return;
 		}
@@ -166,7 +123,7 @@ class Events_Store extends Singleton {
 		}
 
 		// Limit chance of race conditions when creating table.
-		$create_lock_set = wp_cache_add( self::TABLE_CREATE_LOCK, 1, null, 1 * \MINUTE_IN_SECONDS );
+		$create_lock_set = wp_cache_add( 'a8c_cron_control_creating_table', 1, null, 1 * \MINUTE_IN_SECONDS );
 		if ( false === $create_lock_set ) {
 			return;
 		}
@@ -218,8 +175,8 @@ class Events_Store extends Singleton {
 			update_option( self::DB_VERSION_OPTION, self::DB_VERSION );
 		}
 
-		// Clear caches now that table exists.
-		$this->flush_internal_caches();
+		// Clear caches now that the table exists.
+		self::flush_event_cache();
 	}
 
 	/**
@@ -243,224 +200,94 @@ class Events_Store extends Singleton {
 	 */
 	public function remove_multisite_table( $tables_to_drop ) {
 		$tables_to_drop[] = $this->get_table_name();
-
 		return $tables_to_drop;
 	}
 
-	/**
-	 * PLUGIN FUNCTIONALITY
-	 */
+	/*
+	|--------------------------------------------------------------------------
+	| Deprecated (or soon to be) methods for interactions w/ the data store.
+	|--------------------------------------------------------------------------
+	*/
 
 	/**
-	 * Override cron option requests with data from custom table
+	 * Deprecated, unused by the plugin.
+	 * Giving time to catch warnings before removing the public method.
+	 * @deprecated
 	 */
 	public function get_option() {
-
-		// If this thread has already generated the cron array,
-		// use the copy from local memory. Don't fetch this list
-		// remotely multiple times per request (even from the
-		// object cache).
-		static $cron_array;
-		if ( $cron_array && true === $this->is_option_cache_valid ) {
-			return $cron_array;
-		}
-
-		$this->is_option_cache_valid = true;
-
-		// Use cached value when available.
-		$cached_option = $this->get_cached_option();
-
-		if ( false !== $cached_option ) {
-			return $cached_option;
-		}
-
-		// Start building a new cron option.
-		$cron_array = array(
-			'version' => 2, // Core versions the cron array; without this, events will continually requeue.
-		);
-
-		// Get events to re-render as the cron option.
-		$page     = 1;
-		$quantity = 5000;
-
-		do {
-			$jobs = $this->get_jobs(
-				array(
-					'status'   => self::STATUS_PENDING,
-					'quantity' => $quantity,
-					'page'     => $page++,
-				)
-			);
-
-			// Nothing more to add.
-			if ( empty( $jobs ) ) {
-				break;
-			}
-
-			// Loop through results and built output Core expects.
-			foreach ( $jobs as $job ) {
-				// Alias event timestamp.
-				$timestamp = $job->timestamp;
-
-				// If timestamp is invalid, event is removed to let its source fix it.
-				if ( $timestamp <= 0 ) {
-					$this->mark_job_record_completed( $job->ID );
-					continue;
-				}
-
-				// Basic arguments to add a job to the array format Core expects.
-				$action   = $job->action;
-				$instance = $job->instance;
-
-				// Populate remaining job data.
-				$cron_array[ $timestamp ][ $action ][ $instance ] = array(
-					'schedule' => $job->schedule,
-					'args'     => $job->args,
-					'interval' => 0,
-				);
-
-				if ( isset( $job->interval ) ) {
-					$cron_array[ $timestamp ][ $action ][ $instance ]['interval'] = $job->interval;
-				}
-			}
-		} while ( count( $jobs ) >= $quantity );
-
-		// Re-sort the array just as Core does when events are scheduled.
-		// Ensures events are sorted chronologically.
-		uksort( $cron_array, 'strnatcasecmp' );
-
-		// Cache the results.
-		$this->cache_option( $cron_array );
-
-		return $cron_array;
+		_deprecated_function( 'get_option', 'pre_get_cron_option' );
+		return pre_get_cron_option( false );
 	}
 
 	/**
-	 * Handle requests to update the cron option
-	 *
-	 * By returning $old_value, `cron` option won't be updated
-	 *
-	 * @param array $new_value New option value.
-	 * @param array $old_value Old option value.
-	 * @return array
+	 * Deprecated, unused by the plugin.
+	 * Giving time to catch warnings before removing the public method.
+	 * @deprecated
 	 */
 	public function update_option( $new_value, $old_value ) {
-		// Find changes to record.
-		$new_events     = $this->find_cron_array_differences( $new_value, $old_value );
-		$deleted_events = $this->find_cron_array_differences( $old_value, $new_value );
-
-		// Add/update new events.
-		foreach ( $new_events as $new_event ) {
-			$job_id = $this->get_job_id( $new_event['timestamp'], $new_event['action'], $new_event['instance'] );
-
-			if ( 0 === $job_id ) {
-				$job_id = null;
-			}
-
-			$this->create_or_update_job( $new_event['timestamp'], $new_event['action'], $new_event['args'], $job_id, false );
-		}
-
-		// Mark deleted entries for removal.
-		foreach ( $deleted_events as $deleted_event ) {
-			$this->mark_job_completed( $deleted_event['timestamp'], $deleted_event['action'], $deleted_event['instance'], false );
-		}
-
-		$this->flush_internal_caches();
-
-		return $old_value;
+		_deprecated_function( 'update_option', 'pre_update_cron_option' );
+		return pre_update_cron_option( $new_value, $old_value );
 	}
 
 	/**
-	 * When an entry exists, don't try to create it again
-	 *
-	 * @param object $job Job object.
-	 * @return bool|object
+	 * Deprecated, unused by the plugin.
+	 * Giving time to catch warnings before removing the public method.
+	 * @deprecated
 	 */
 	public function block_creation_if_job_exists( $job ) {
-		// Job already disallowed, carry on.
-		if ( ! is_object( $job ) ) {
-			return $job;
-		}
-
-		$instance = md5( maybe_serialize( $job->args ) );
-		if ( 0 !== $this->get_job_id( $job->timestamp, $job->hook, $instance ) ) {
-			return false;
-		}
-
+		_deprecated_function( 'block_creation_if_job_exists' );
 		return $job;
 	}
 
 	/**
-	 * PLUGIN UTILITY METHODS
-	 */
-
-	/**
 	 * Retrieve jobs given a set of parameters
+	 * Deprecation coming soon.
 	 *
 	 * @param array $args Job arguments to search by.
 	 * @return array
 	 */
 	public function get_jobs( $args ) {
-		global $wpdb;
+		// Adjust this method's previous defaults for what our new method expects.
+		$adjusted_args = [
+			'limit'  => isset( $args['quantity'] ) && is_numeric( $args['quantity'] ) ? $args['quantity'] : 100,
+			'page'   => isset( $args['page'] ) && $args['page'] >= 1 ? $args['page'] : 1,
+			'status' => $args['status'],
+		];
 
-		if ( ! isset( $args['quantity'] ) || ! is_numeric( $args['quantity'] ) ) {
-			$args['quantity'] = 100;
-		}
-
-		if ( isset( $args['page'] ) ) {
-			$page   = max( 0, $args['page'] - 1 );
-			$offset = $page * $args['quantity'];
-		} else {
-			$offset = 0;
-		}
-
-		// Avoid sorting whenever possible, otherwise filesort is used.
-		// Generally only necessary in CLI commands for pagination, as full list of events is usually required.
-		if ( isset( $args['force_sort'] ) && true === $args['force_sort'] ) {
-			$query = $wpdb->prepare( "SELECT * FROM {$this->get_table_name()} WHERE status = %s ORDER BY timestamp ASC LIMIT %d,%d;", $args['status'], $offset, $args['quantity'] ); // Cannot prepare table name. @codingStandardsIgnoreLine
-		} else {
-			$query = $wpdb->prepare( "SELECT * FROM {$this->get_table_name()} WHERE status = %s LIMIT %d,%d;", $args['status'], $offset, $args['quantity'] ); // Cannot prepare table name. @codingStandardsIgnoreLine
-		}
-
-		$jobs = $wpdb->get_results( $query, 'OBJECT' ); // Already prepared. @codingStandardsIgnoreLine
-
-		if ( is_array( $jobs ) ) {
-			$jobs = array_map( array( $this, 'format_job' ), $jobs );
-		} else {
-			$jobs = array();
-		}
-
-		return $jobs;
+		$jobs = self::_query_events_raw( $adjusted_args );
+		return array_map( array( $this, 'format_job' ), $jobs );
 	}
 
 	/**
 	 * Retrieve a single event by its ID
+	 * Deprecation coming soon.
 	 *
 	 * @param int $jid Job ID.
 	 * @return object|false
 	 */
 	public function get_job_by_id( $jid ) {
-		global $wpdb;
-
 		// Validate ID.
 		$jid = absint( $jid );
 		if ( ! $jid ) {
 			return false;
 		}
 
-		$job = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$this->get_table_name()} WHERE ID = %d AND status = %s LIMIT 1", $jid, self::STATUS_PENDING ) ); // Cannot prepare table name. @codingStandardsIgnoreLine
+		$job = self::_get_event_raw( $jid );
+		if ( ! is_object( $job ) ) {
+			return false;
+		}
 
-		if ( is_object( $job ) && ! is_wp_error( $job ) ) {
-			$job = $this->format_job( $job );
-		} else {
-			$job = false;
+		// This method previously only queried for pending, so we respect that here.
+		if ( self::STATUS_PENDING !== $job->status ) {
+			return false;
 		}
 
 		return $job;
 	}
 
 	/**
-	 * Retrieve a single event by a combination of its timestamp, instance identifier, and either action or the action's hashed representation
+	 * Retrieve a single event by a combination of a timestamp, instance identifier, and either action or the action's hashed representation
+	 * Deprecation coming soon.
 	 *
 	 * @param array $attrs Array of event attributes to query by.
 	 * @return object|false
@@ -473,11 +300,7 @@ class Events_Store extends Singleton {
 			return false;
 		}
 
-		// Validate requested status.
-		$allowed_status   = self::ALLOWED_STATUSES;
-		$allowed_status[] = 'any';
-
-		if ( ! isset( $attrs['status'] ) || ! in_array( $attrs['status'], $allowed_status, true ) ) {
+		if ( ! isset( $attrs['status'] ) || ! self::validate_status( $attrs['status'] ) ) {
 			$attrs['status'] = self::STATUS_PENDING;
 		}
 
@@ -488,51 +311,20 @@ class Events_Store extends Singleton {
 			return false;
 		}
 
-		// Build query.
+		// Build the query args, supporting the API this method previously had.
+		$adjusted_args = [
+			'instance' => $attrs['instance'],
+			'status'   => $attrs['status'],
+		];
+
 		if ( isset( $attrs['action'] ) ) {
-			$action_column = 'action';
-			$action_value  = $attrs['action'];
+			$adjusted_args['action'] = $attrs['action'];
 		} else {
-			$action_column = 'action_hashed';
-			$action_value  = $attrs['action_hashed'];
+			$adjusted_args['action_hashed'] = $attrs['action_hashed'];
 		}
 
-		// Do not sort, otherwise index isn't used.
-		if ( 'any' === $attrs['status'] ) {
-			$query = $wpdb->prepare( "SELECT * FROM {$this->get_table_name()} WHERE timestamp = %d AND {$action_column} = %s AND instance = %s LIMIT 1", $attrs['timestamp'], $action_value, $attrs['instance'] );  // Cannot prepare table or column names. @codingStandardsIgnoreLine
-		} else {
-			$query = $wpdb->prepare( "SELECT * FROM {$this->get_table_name()} WHERE timestamp = %d AND {$action_column} = %s AND instance = %s AND status = %s LIMIT 1", $attrs['timestamp'], $action_value, $attrs['instance'], $attrs['status'] );  // Cannot prepare table or column names. @codingStandardsIgnoreLine
-		}
-
-		// Query and format results.
-		$job = $wpdb->get_row( $query ); // Already prepared. @codingStandardsIgnoreLine
-
-		if ( is_object( $job ) && ! is_wp_error( $job ) ) {
-			$job = $this->format_job( $job );
-		} else {
-			$job = false;
-		}
-
-		return $job;
-	}
-
-	/**
-	 * Get ID for given event details
-	 *
-	 * Used in situations where performance matters, which is why it exists despite duplicating `get_job_by_attributes()`
-	 * Queries outside of this class should use `get_job_by_attributes()`
-	 *
-	 * @param int    $timestamp    Unix timestamp event executes at.
-	 * @param string $action       Name of action used when the event is registered (unhashed).
-	 * @param string $instance     md5 hash of the event's arguments array, which Core uses to index the `cron` option.
-	 * @return int
-	 */
-	private function get_job_id( $timestamp, $action, $instance ) {
-		global $wpdb;
-
-		$job = $wpdb->get_col( $wpdb->prepare( "SELECT ID FROM {$this->get_table_name()} WHERE timestamp = %d AND action = %s AND instance = %s AND status = %s LIMIT 1;", $timestamp, $action, $instance, self::STATUS_PENDING ) ); // Cannot prepare table name. @codingStandardsIgnoreLine
-
-		return empty( $job ) ? 0 : (int) array_shift( $job );
+		$jobs = self::_query_events_raw( $adjusted_args );
+		return is_object( $jobs[0] ) ? $this->format_job( $jobs[0] ) : false;
 	}
 
 	/**
@@ -560,6 +352,7 @@ class Events_Store extends Singleton {
 
 	/**
 	 * Create or update entry for a given job
+	 * Deprecation coming soon.
 	 *
 	 * @param int    $timestamp    Unix timestamp event executes at.
 	 * @param string $action       Hook event fires.
@@ -568,54 +361,33 @@ class Events_Store extends Singleton {
 	 * @param bool   $flush_cache  Whether or not to flush internal caches after creating/updating the event.
 	 */
 	public function create_or_update_job( $timestamp, $action, $args, $update_id = null, $flush_cache = true ) {
-		// Don't create new jobs when manipulating jobs via the plugin's CLI commands.
-		if ( $this->job_creation_suspended ) {
-			return;
-		}
-
-		global $wpdb;
-
-		$job_post = array(
-			'timestamp'     => $timestamp,
-			'action'        => $action,
-			'action_hashed' => md5( $action ),
-			'instance'      => md5( maybe_serialize( $args['args'] ) ),
-			'args'          => maybe_serialize( $args['args'] ),
-			'last_modified' => current_time( 'mysql', true ),
-		);
-
-		if ( isset( $args['schedule'] ) && ! empty( $args['schedule'] ) ) {
-			$job_post['schedule'] = $args['schedule'];
-		}
-
-		if ( isset( $args['interval'] ) && ! empty( $args['interval'] ) && is_numeric( $args['interval'] ) ) {
-			$job_post['interval'] = (int) $args['interval'];
-		}
-
-		// Create the post, or update an existing entry to run again in the future.
 		if ( is_int( $update_id ) && $update_id > 0 ) {
-			$wpdb->update(
-				$this->get_table_name(),
-				$job_post,
-				array(
-					'ID' => $update_id,
-				)
-			);
+			// Update an existing entry.
+			$event = Event::get( $update_id );
+
+			if ( is_null( $event ) ) {
+				return;
+			}
 		} else {
-			$job_post['created'] = current_time( 'mysql', true );
-
-			$wpdb->insert( $this->get_table_name(), $job_post );
+			// Create a new event.
+			$event = new Event();
 		}
 
-		// Delete internal cache.
-		// Should only be skipped during bulk operations.
-		if ( $flush_cache ) {
-			$this->flush_internal_caches();
+		$event->set_timestamp( $timestamp );
+		$event->set_action( $action );
+		$event->set_args( $args['args'] );
+
+		if ( ! empty( $args['schedule'] ) && ! empty( $args['interval'] ) ) {
+			$event->set_schedule( $args['schedule'], (int) $args['interval'] );
 		}
+
+		// Saves the existing one, or creates a new one.
+		$event->save();
 	}
 
 	/**
 	 * Mark an event's entry as completed
+	 * Deprecation coming soon.
 	 *
 	 * Completed entries will be cleaned up by an internal job
 	 *
@@ -626,212 +398,63 @@ class Events_Store extends Singleton {
 	 * @return bool
 	 */
 	public function mark_job_completed( $timestamp, $action, $instance, $flush_cache = true ) {
-		$job_id = $this->get_job_id( $timestamp, $action, $instance );
+		$event = Event::find( [
+			'timestamp' => $timestamp,
+			'action'    => $action,
+			'instance'  => $instance,
+		] );
 
-		if ( ! $job_id ) {
+		if ( is_null( $event ) ) {
 			return false;
 		}
 
-		return $this->mark_job_record_completed( $job_id, $flush_cache );
+		$result = $event->complete();
+		return true === $result;
 	}
 
 	/**
 	 * Set a job post to the "completed" status
+	 * Deprecation coming soon.
 	 *
 	 * @param int  $job_id       ID of job's record.
 	 * @param bool $flush_cache  Whether or not to flush internal caches after creating/updating the event.
 	 * @return bool
 	 */
 	public function mark_job_record_completed( $job_id, $flush_cache = true ) {
-		global $wpdb;
+		$event = Event::get( $job_id );
 
-		/**
-		 * Constraint is broken to accommodate the following situation:
-		 * 1. Event with specific timestamp is scheduled.
-		 * 2. Event is unscheduled.
-		 * 3. Event is rescheduled.
-		 * 4. Event runs, or is unscheduled, but unique constraint prevents query from succeeding.
-		 * 5. Event retains `pending` status and runs again. Repeat steps 4 and 5 until `a8c_cron_control_purge_completed_events` runs and removes the entry from step 2.
-		 */
-		$updates = array(
-			'status'   => self::STATUS_COMPLETED,
-			'instance' => mt_rand( 1000000, 999999999 ), // Breaks unique constraint, and can be recreated from entry's remaining data.
-		);
-
-		$success = $wpdb->update(
-			$this->get_table_name(),
-			$updates,
-			array(
-				'ID' => $job_id,
-			)
-		);
-
-		// Delete internal cache.
-		// Should only be skipped during bulk operations.
-		if ( $flush_cache ) {
-			$this->flush_internal_caches();
+		$result = false;
+		if ( ! is_null( $event ) ) {
+			$result = $event->complete();
 		}
 
-		return (bool) $success;
+		return true === $result;
 	}
 
 	/**
-	 * Compare two arrays and return collapsed representation of the items present in one but not the other
-	 *
-	 * @param array $changed   Array to identify additional items from.
-	 * @param array $reference Array to compare against.
-	 * @return array
-	 */
-	private function find_cron_array_differences( $changed, $reference ) {
-		$differences = array();
-
-		$changed = collapse_events_array( $changed );
-
-		foreach ( $changed as $event ) {
-			$event = (object) $event;
-
-			if ( ! isset( $reference[ $event->timestamp ][ $event->action ][ $event->instance ] ) ) {
-				$differences[] = array(
-					'timestamp' => $event->timestamp,
-					'action'    => $event->action,
-					'instance'  => $event->instance,
-					'args'      => $event->args,
-				);
-			}
-		}
-
-		return $differences;
-	}
-
-	/**
-	 * Retrieve cron option from cache
-	 *
-	 * @return array|false
-	 */
-	private function get_cached_option() {
-		$cache_details = wp_cache_get( self::CACHE_KEY, null, true );
-
-		if ( ! is_array( $cache_details ) ) {
-			return false;
-		}
-
-		// Single bucket.
-		if ( isset( $cache_details['version'] ) ) {
-			return $cache_details;
-		}
-
-		// Invalid data!
-		if ( ! isset( $cache_details['incrementer'] ) ) {
-			return false;
-		}
-
-		$option_flat = array();
-
-		// Restore option from cached pieces.
-		for ( $i = 1; $i <= $cache_details['buckets']; $i++ ) {
-			$cache_key    = $this->get_cache_key_for_slice( $cache_details['incrementer'], $i );
-			$cached_slice = wp_cache_get( $cache_key, null, true );
-
-			// Bail if a chunk is missing.
-			if ( ! is_array( $cached_slice ) ) {
-				return false;
-			}
-
-			$option_flat += $cached_slice;
-		}
-
-		// Something's missing, likely due to cache eviction.
-		if ( empty( $option_flat ) || count( $option_flat ) !== $cache_details['event_count'] ) {
-			return false;
-		}
-
-		return inflate_collapsed_events_array( $option_flat );
-	}
-
-	/**
-	 * Cache cron option, accommodating large versions by splitting into chunks
-	 *
-	 * @param array $option Cron option to cache.
-	 * @return bool
-	 */
-	private function cache_option( $option ) {
-		// Determine storage requirements.
-		$option_flat        = collapse_events_array( $option );
-		$option_flat_string = maybe_serialize( $option_flat );
-		$option_size        = strlen( $option_flat_string );
-		$buckets            = (int) ceil( $option_size / CACHE_BUCKET_SIZE );
-
-		// Store in single cache key.
-		if ( 1 === $buckets ) {
-			return wp_cache_set( self::CACHE_KEY, $option, null, 1 * \HOUR_IN_SECONDS );
-		}
-
-		// Too large to cache?
-		if ( $buckets > MAX_CACHE_BUCKETS ) {
-			do_action( 'a8c_cron_control_uncacheable_cron_option', $option_size, $buckets, count( $option_flat ) );
-
-			$this->flush_internal_caches();
-			return false;
-		}
-
-		$incrementer  = md5( $option_flat_string . time() );
-		$event_count  = count( $option_flat );
-		$segment_size = (int) ceil( $event_count / $buckets );
-
-		for ( $i = 1; $i <= $buckets; $i++ ) {
-			$offset    = ( $i - 1 ) * $segment_size;
-			$slice     = array_slice( $option_flat, $offset, $segment_size, true );
-			$cache_key = $this->get_cache_key_for_slice( $incrementer, $i );
-
-			wp_cache_set( $cache_key, $slice, null, 1 * \HOUR_IN_SECONDS );
-		}
-
-		$option = array(
-			'incrementer' => $incrementer,
-			'buckets'     => $buckets,
-			'event_count' => count( $option_flat ),
-		);
-
-		return wp_cache_set( self::CACHE_KEY, $option, null, 1 * \HOUR_IN_SECONDS );
-	}
-
-	/**
-	 * Build cache key for a given portion of a large option
-	 *
-	 * @param string $incrementor Current cache incrementor.
-	 * @param int    $slice Slice ID.
-	 * @return string
-	 */
-	private function get_cache_key_for_slice( $incrementor, $slice ) {
-		return md5( self::CACHE_KEY . $incrementor . $slice );
-	}
-
-	/**
-	 * Delete the cached representation of the cron option
+	 * Deprecated soon, will be unused by the plugin.
+	 * Giving time to catch warnings before removing the public method.
 	 */
 	public function flush_internal_caches() {
-		$this->is_option_cache_valid = false;
-		return wp_cache_delete( self::CACHE_KEY );
+		self::flush_event_cache();
 	}
 
 	/**
-	 * Prevent event store from creating new entries
-	 *
-	 * Should be used sparingly, and followed by a call to resume_event_creation(), during bulk operations
+	 * Soon to be deprecated.
 	 */
 	public function suspend_event_creation() {
-		$this->job_creation_suspended = true;
+		// No longer needed.
 	}
 
 	/**
-	 * Stop discarding events, once again storing them in the table
+	 * Soon to be deprecated.
 	 */
 	public function resume_event_creation() {
-		$this->job_creation_suspended = false;
+		// No longer needed.
 	}
 
 	/**
-	 * Remove entries for non-recurring events that have been run
+	 * Remove entries for non-recurring events that have been run.
 	 *
 	 * @param bool $count_first Should events be counted before they're deleted.
 	 */
@@ -839,19 +462,13 @@ class Events_Store extends Singleton {
 		global $wpdb;
 
 		// Skip count if already performed.
+		$count = 1;
 		if ( $count_first ) {
 			if ( property_exists( $wpdb, 'srtm' ) ) {
-				$srtm       = $wpdb->srtm;
 				$wpdb->srtm = true;
 			}
 
 			$count = $this->count_events_by_status( self::STATUS_COMPLETED );
-
-			if ( isset( $srtm ) ) {
-				$wpdb->srtm = $srtm;
-			}
-		} else {
-			$count = 1;
 		}
 
 		if ( $count > 0 ) {
@@ -861,6 +478,7 @@ class Events_Store extends Singleton {
 					'status' => self::STATUS_COMPLETED,
 				)
 			);
+			self::flush_event_cache();
 		}
 	}
 
@@ -877,7 +495,8 @@ class Events_Store extends Singleton {
 			return false;
 		}
 
-		return (int) $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(ID) FROM {$this->get_table_name()} WHERE status = %s", $status ) ); // Cannot prepare table name. @codingStandardsIgnoreLine
+		// Cannot prepare table name. @codingStandardsIgnoreLine
+		return (int) $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(ID) FROM {$this->get_table_name()} WHERE status = %s", $status ) );
 	}
 
 	/*
@@ -999,7 +618,7 @@ class Events_Store extends Singleton {
 				'validation' => fn( $status ) => self::validate_status( $status ),
 			],
 			'limit' => [
-				'default'    => 1,
+				'default'    => 100,
 				'validation' => 'is_int',
 			],
 			'page' => [

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -176,3 +176,35 @@ function set_doing_cron() {
 	// These can be used to override the `DOING_CRON` constant, which may cause problems for plugin's requests.
 	add_filter( 'wp_doing_cron', '__return_true', 99999 );
 }
+
+function _deprecated_function( string $function, string $replacement = '', $error_level = 1 ) {
+	$errors_levels = [
+		'debug'  => 1,
+		'notice' => 2,
+		'warn'   => 3,
+	];
+
+	$message = sprintf( 'Cron-Control: %1$s is deprecated and will soon be removed.', $function );
+	if ( ! empty( $replacement ) ) {
+		$message .= sprintf( ' Use %1$s instead.', $replacement );
+	}
+
+	// Use E_WARNING error level.
+	$warning_constant = defined( 'CRON_CONTROL_WARN_FOR_DEPRECATIONS' ) && CRON_CONTROL_WARN_FOR_DEPRECATIONS;
+	if ( $warning_constant || $error_level >= $errors_levels['warn'] ) {
+		trigger_error( $message, E_USER_WARNING );
+		return;
+	}
+
+	// Use E_USER_NOTICE regardless of Debug mode.
+	if ( $error_level >= $errors_levels['notice'] ) {
+		trigger_error( $message, E_USER_NOTICE );
+		return;
+	}
+
+	// Use E_USER_NOTICE only in Debug mode.
+	if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+		trigger_error( $message, E_USER_NOTICE );
+		return;
+	}
+}

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -177,27 +177,28 @@ function set_doing_cron() {
 	add_filter( 'wp_doing_cron', '__return_true', 99999 );
 }
 
-function _deprecated_function( string $function, string $replacement = '', $error_level = 1 ) {
-	$errors_levels = [
+// Helper method for deprecating publicly accessibly functions/methods.
+function _deprecated_function( string $function, string $replacement = '', $error_level = 2 ) {
+	$error_levels = [
 		'debug'  => 1,
 		'notice' => 2,
 		'warn'   => 3,
 	];
 
-	$message = sprintf( 'Cron-Control: %1$s is deprecated and will soon be removed.', $function );
+	$message = sprintf( 'Cron-Control: %s is deprecated and will soon be removed.', $function );
 	if ( ! empty( $replacement ) ) {
-		$message .= sprintf( ' Use %1$s instead.', $replacement );
+		$message .= sprintf( ' Use %s instead.', $replacement );
 	}
 
 	// Use E_WARNING error level.
 	$warning_constant = defined( 'CRON_CONTROL_WARN_FOR_DEPRECATIONS' ) && CRON_CONTROL_WARN_FOR_DEPRECATIONS;
-	if ( $warning_constant || $error_level >= $errors_levels['warn'] ) {
+	if ( $warning_constant || $error_level >= $error_levels['warn'] ) {
 		trigger_error( $message, E_USER_WARNING );
 		return;
 	}
 
 	// Use E_USER_NOTICE regardless of Debug mode.
-	if ( $error_level >= $errors_levels['notice'] ) {
+	if ( $error_level >= $error_levels['notice'] ) {
 		trigger_error( $message, E_USER_NOTICE );
 		return;
 	}

--- a/tests/tests/class-events-store-tests.php
+++ b/tests/tests/class-events-store-tests.php
@@ -149,33 +149,6 @@ class Events_Store_Tests extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Test event-cache splitting
-	 */
-	function test_excessive_event_creation() {
-		$timestamp_base = time() + ( 1 * \HOUR_IN_SECONDS );
-
-		$dummy_text = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam enim ante, maximus nec nisi ut, finibus ultrices orci. Maecenas suscipit, est eu suscipit sagittis, enim massa dignissim augue, sagittis gravida dolor nulla ut mi. Phasellus venenatis bibendum cursus. Aliquam a erat purus. Nulla elit nunc, egestas eget eros iaculis, interdum tincidunt elit. Vivamus vel blandit nisl. Proin in ornare dolor, convallis porta sem. Mauris rutrum nibh et ornare egestas. Mauris ultricies diam at nunc tristique rutrum. Aliquam varius non leo vel luctus. Vestibulum sagittis scelerisque ante, non faucibus nibh accumsan sed.';
-		$args       = array_fill( 0, 15, $dummy_text );
-
-		for ( $i = 1; $i <= 100; $i++ ) {
-			$timestamp = $timestamp_base + $i;
-			$action    = 'excessive_test_event_' . $i;
-			wp_schedule_single_event( $timestamp, $action, $args );
-		}
-
-		get_option( 'cron' );
-
-		$cached = wp_cache_get( \Automattic\WP\Cron_Control\Events_Store::CACHE_KEY );
-
-		$this->assertArrayHasKey( 'incrementer', $cached );
-		$this->assertArrayHasKey( 'buckets', $cached );
-		$this->assertArrayHasKey( 'event_count', $cached );
-
-		$this->assertEquals( 4, $cached['buckets'] );
-		$this->assertEquals( 100, $cached['event_count'] );
-	}
-
-	/**
 	 * Test retrieving an event without requesting a status
 	 */
 	function test_get_job_by_attributes() {
@@ -344,6 +317,7 @@ class Events_Store_Tests extends \WP_UnitTestCase {
 			'action'   => 'test_query_raw_events',
 			'args'     => [ 'some' => 'data' ],
 			'schedule' => 'hourly',
+			'limit'    => 1,
 		] );
 
 		$this->assertEquals( 1, count( $result ), 'returns one event w/ oldest timestamp' );


### PR DESCRIPTION
"Cron control next, v2" has the base framework setup now. So time utilize the new methods for database interactions, and start deprecating unused methods (once they are truly unused by the plugin).

Now that we have a new DB interaction layer, we can quickly make the rest of the plugin "follow suit" by updating the store methods that the rest of the plugin has currently in use. This way our caching layer stays in tact and is invalidated when needed. And everything will start running again exactly as it did before.

As the usage of the old store method's are removed throughout the plugin, they will move from "deprecation coming soon" to actually deprecated w/ the `_deprecated_function()` being added so we can watch for php warnings in case of usage in the wild.

The methods that are not fully deprecated in this PR will be handled individually as other notable classes are cleaned up (really just looking at the runner/CLI for now I think). The rest will likely come post-real-merge.