### PR TITLE
Swap to non-static methods in Event's store

### DIFF
--- a/includes/class-event.php
+++ b/includes/class-event.php
@@ -131,11 +131,11 @@ class Event {
 		}
 
 		if ( $this->exists() ) {
-			$success = Events_Store::_update_event( $this->id, $row_data );
+			$success = Events_Store::instance()->_update_event( $this->id, $row_data );
 			return true === $success ? true : new WP_Error( 'cron-control:event:failed-update' );
 		}
 
-		$event_id = Events_Store::_create_event( $row_data );
+		$event_id = Events_Store::instance()->_create_event( $row_data );
 		if ( $event_id < 1 ) {
 			return new WP_Error( 'cron-control:event:failed-create' );
 		}
@@ -202,12 +202,12 @@ class Event {
 	*/
 
 	public static function get( int $event_id ): ?Event {
-		$db_row = Events_Store::_get_event_raw( $event_id );
+		$db_row = Events_Store::instance()->_get_event_raw( $event_id );
 		return is_null( $db_row ) ? null : self::get_from_db_row( $db_row );
 	}
 
 	public static function find( array $query_args ): ?Event {
-		$results = Events_Store::_query_events_raw( array_merge( $query_args, [ 'limit' => 1 ] ) );
+		$results = Events_Store::instance()->_query_events_raw( array_merge( $query_args, [ 'limit' => 1 ] ) );
 		return empty( $results ) ? null : self::get_from_db_row( $results[0] );
 	}
 

--- a/includes/class-events.php
+++ b/includes/class-events.php
@@ -567,7 +567,7 @@ class Events extends Singleton {
 	 * @return array An array of Event objects.
 	 */
 	public static function query( array $query_args = [] ): array {
-		$event_db_rows = Events_Store::_query_events_raw( $query_args );
+		$event_db_rows = Events_Store::instance()->_query_events_raw( $query_args );
 		$events = array_map( fn( $db_row ) => Event::get_from_db_row( $db_row ), $event_db_rows );
 		return array_filter( $events, fn( $event ) => ! is_null( $event ) );
 	}

--- a/tests/tests/class-event-tests.php
+++ b/tests/tests/class-event-tests.php
@@ -317,7 +317,7 @@ class Event_Tests extends \WP_UnitTestCase {
 		$expected_result['id'] = $test_event->get_id();
 
 		// Grab straight from the DB so we can make sure the enclosed properties worked correctly.
-		$raw_event = Events_Store::_get_event_raw( $test_event->get_id() );
+		$raw_event = Events_Store::instance()->_get_event_raw( $test_event->get_id() );
 		Utils::assert_event_raw_data_equals( $raw_event, $expected_result, $this );
 
 		// Initiate the event again, testing the getters and ensuring data is hydrated correctly.
@@ -342,7 +342,7 @@ class Event_Tests extends \WP_UnitTestCase {
 			'timestamp' => 1637447875,
 		];
 
-		$raw_event = Events_Store::_get_event_raw( $test_event->get_id() );
+		$raw_event = Events_Store::instance()->_get_event_raw( $test_event->get_id() );
 
 		// Will populate the event w/ full data from database.
 		$event = Event::get_from_db_row( $raw_event );


### PR DESCRIPTION
per feedback in https://github.com/Automattic/Cron-Control/pull/226#issuecomment-992229011

Nothing much changes, just preps making it easier in the future to inject the Store into Event/Events if we wanted to mock easier / provide a filter for swapping out w/ custom stores.

(php 7.3 tests will fail until the other PR is merged)