### PR TITLE
Deprecate legacy store getters

### DIFF
--- a/includes/class-event.php
+++ b/includes/class-event.php
@@ -134,12 +134,8 @@ class Event {
 		}
 
 		if ( $this->exists() ) {
-<<<<<<< HEAD
 			$success = Events_Store::instance()->_update_event( $this->id, $row_data );
-=======
-			$success = Events_Store::_update_event( $this->id, $row_data );
 			// TODO: update last modified
->>>>>>> 91f7cb0 (Cleanup Events())
 			return true === $success ? true : new WP_Error( 'cron-control:event:failed-update' );
 		}
 

--- a/includes/class-event.php
+++ b/includes/class-event.php
@@ -22,6 +22,9 @@ class Event {
 	// When the event will run next.
 	private int $timestamp;
 
+	private $created;
+	private $last_modified;
+
 	/*
 	|--------------------------------------------------------------------------
 	| Getters
@@ -131,7 +134,12 @@ class Event {
 		}
 
 		if ( $this->exists() ) {
+<<<<<<< HEAD
 			$success = Events_Store::instance()->_update_event( $this->id, $row_data );
+=======
+			$success = Events_Store::_update_event( $this->id, $row_data );
+			// TODO: update last modified
+>>>>>>> 91f7cb0 (Cleanup Events())
 			return true === $success ? true : new WP_Error( 'cron-control:event:failed-update' );
 		}
 
@@ -140,6 +148,7 @@ class Event {
 			return new WP_Error( 'cron-control:event:failed-create' );
 		}
 
+		// TODO: update created/last modified
 		$this->id = $event_id;
 		return true;
 	}
@@ -223,6 +232,8 @@ class Event {
 		$event->set_action( (string) $data->action );
 		$event->set_timestamp( (int) $data->timestamp );
 		$event->set_args( (array) maybe_unserialize( $data->args ) );
+		$event->created = $data->created;
+		$event->last_modified = $data->last_modified;
 
 		if ( ! empty( $data->schedule ) && ! empty( $data->interval ) ) {
 			// Note: the db is sending back "null" and "0" for the above two on single events,
@@ -260,6 +271,26 @@ class Event {
 		}
 
 		return (object) $wp_event;
+	}
+
+	// The old way this plugin used to pass around event objects.
+	// Needed for BC for some hooks, hopefully deprecated/removed fully later on.
+	public function get_legacy_event_format(): object {
+		$legacy_format = [
+			'ID'            => $this->get_id(),
+			'timestamp'     => $this->get_timestamp(),
+			'action'        => $this->get_action(),
+			'action_hashed' => $this->action_hashed,
+			'instance'      => $this->get_instance(),
+			'args'          => $this->get_args(),
+			'schedule'      => isset( $this->schedule ) ? $this->get_schedule() : false,
+			'interval'      => isset( $this->interval ) ? $this->get_interval() : 0,
+			'status'        => $this->get_status(),
+			'created'       => $this->created,
+			'last_modified' => $this->last_modified,
+		];
+
+		return (object) $legacy_format;
 	}
 
 	public static function create_instance_hash( array $args ): string {

--- a/includes/class-events-store.php
+++ b/includes/class-events-store.php
@@ -216,7 +216,7 @@ class Events_Store extends Singleton {
 	 * @deprecated
 	 */
 	public function get_option() {
-		_deprecated_function( 'get_option', 'pre_get_cron_option' );
+		_deprecated_function( 'Events_Store\get_option', 'pre_get_cron_option' );
 		return pre_get_cron_option( false );
 	}
 
@@ -226,7 +226,7 @@ class Events_Store extends Singleton {
 	 * @deprecated
 	 */
 	public function update_option( $new_value, $old_value ) {
-		_deprecated_function( 'update_option', 'pre_update_cron_option' );
+		_deprecated_function( 'Events_Store\update_option', 'pre_update_cron_option' );
 		return pre_update_cron_option( $new_value, $old_value );
 	}
 
@@ -236,7 +236,7 @@ class Events_Store extends Singleton {
 	 * @deprecated
 	 */
 	public function block_creation_if_job_exists( $job ) {
-		_deprecated_function( 'block_creation_if_job_exists' );
+		_deprecated_function( 'Events_Store\block_creation_if_job_exists' );
 		return $job;
 	}
 
@@ -244,10 +244,13 @@ class Events_Store extends Singleton {
 	 * Retrieve jobs given a set of parameters
 	 * Deprecation coming soon.
 	 *
+	 * @deprecated
 	 * @param array $args Job arguments to search by.
 	 * @return array
 	 */
 	public function get_jobs( $args ) {
+		_deprecated_function( 'Events_Store\get_jobs' );
+
 		// Adjust this method's previous defaults for what our new method expects.
 		$adjusted_args = [
 			'limit'  => isset( $args['quantity'] ) && is_numeric( $args['quantity'] ) ? $args['quantity'] : 100,

--- a/includes/class-events-store.php
+++ b/includes/class-events-store.php
@@ -292,13 +292,15 @@ class Events_Store extends Singleton {
 
 	/**
 	 * Retrieve a single event by a combination of a timestamp, instance identifier, and either action or the action's hashed representation
-	 * Deprecation coming soon.
 	 *
+	 * @deprecated
 	 * @param array $attrs Array of event attributes to query by.
 	 * @return object|false
 	 */
 	public function get_job_by_attributes( $attrs ) {
 		global $wpdb;
+
+		_deprecated_function( 'Events_Store\get_job_by_attributes' );
 
 		// Validate basic inputs.
 		if ( ! is_array( $attrs ) || empty( $attrs ) ) {

--- a/includes/class-events-store.php
+++ b/includes/class-events-store.php
@@ -242,7 +242,6 @@ class Events_Store extends Singleton {
 
 	/**
 	 * Retrieve jobs given a set of parameters
-	 * Deprecation coming soon.
 	 *
 	 * @deprecated
 	 * @param array $args Job arguments to search by.
@@ -264,12 +263,14 @@ class Events_Store extends Singleton {
 
 	/**
 	 * Retrieve a single event by its ID
-	 * Deprecation coming soon.
 	 *
+	 * @deprecated
 	 * @param int $jid Job ID.
 	 * @return object|false
 	 */
 	public function get_job_by_id( $jid ) {
+		_deprecated_function( 'Events_Store\get_job_by_id' );
+
 		// Validate ID.
 		$jid = absint( $jid );
 		if ( ! $jid ) {

--- a/includes/class-events-store.php
+++ b/includes/class-events-store.php
@@ -527,9 +527,6 @@ class Events_Store extends Singleton {
 			return 0;
 		}
 
-		$row_data['created']       = current_time( 'mysql', true );
-		$row_data['last_modified'] = current_time( 'mysql', true );
-
 		$result = $wpdb->insert( $this->get_table_name(), $row_data, self::row_formatting( $row_data ) );
 
 		self::flush_event_cache();
@@ -550,8 +547,6 @@ class Events_Store extends Singleton {
 		if ( empty( $event_id ) || empty( $row_data ) ) {
 			return 0;
 		}
-
-		$row_data['last_modified'] = current_time( 'mysql', true );
 
 		$where  = [ 'ID' => $event_id ];
 		$result = $wpdb->update( $this->get_table_name(), $row_data, $where, self::row_formatting( $row_data ), self::row_formatting( $where ) );

--- a/includes/class-events.php
+++ b/includes/class-events.php
@@ -220,6 +220,7 @@ class Events extends Singleton {
 
 		// Ensure we don't run jobs ahead of time.
 		if ( ! $force && $timestamp > time() ) {
+			/* translators: 1: Job identifier */
 			$error_message = sprintf( __( 'Job with identifier `%1$s` is not scheduled to run yet.', 'automattic-cron-control' ), "$timestamp-$action-$instance" );
 			return new WP_Error( 'premature', $error_message, [ 'status' => 404 ] );
 		}
@@ -233,6 +234,7 @@ class Events extends Singleton {
 
 		// Nothing to do...
 		if ( is_null( $event ) ) {
+			/* translators: 1: Job identifier */
 			$error_message = sprintf( __( 'Job with identifier `%1$s` could not be found.', 'automattic-cron-control' ), "$timestamp-$action-$instance" );
 			return new WP_Error( 'no-event', $error_message, [ 'status' => 404 ] );
 		}

--- a/includes/class-events.php
+++ b/includes/class-events.php
@@ -7,6 +7,8 @@
 
 namespace Automattic\WP\Cron_Control;
 
+use WP_Error;
+
 /**
  * Events class
  */
@@ -30,9 +32,9 @@ class Events extends Singleton {
 	private $concurrent_action_whitelist = array();
 
 	/**
-	 * Name of action currently being executed
+	 * The event currently being executed.
 	 *
-	 * @var mixed
+	 * @var null|Event
 	 */
 	private $running_event = null;
 
@@ -89,56 +91,41 @@ class Events extends Singleton {
 	}
 
 	/**
-	 * List events pending for the current period
+	 * List events pending for the current period.
 	 *
-	 * @param array $job_queue_size   Maximum number of events to return (excludes internal events).
-	 * @param array $job_queue_window How many seconds into the future events should be fetched.
-	 * @return array
+	 * @param null|int $job_queue_size   Maximum number of events to return (excludes internal events).
+	 * @param null|int $job_queue_window How many seconds into the future events should be fetched.
+	 * @return array Events to be run in the next batch.
 	 */
-	public function get_events( $job_queue_size = null, $job_queue_window = null ) {
+	public function get_events( $job_queue_size = null, $job_queue_window = null ): array {
 		$job_queue_size   = is_null( $job_queue_size ) ? JOB_QUEUE_SIZE : $job_queue_size;
 		$job_queue_window = is_null( $job_queue_window ) ? JOB_QUEUE_WINDOW_IN_SECONDS : $job_queue_window;
 
-		$events = get_option( 'cron' );
+		// Grab relevant events that are due, or soon will be.
+		$current_time = time();
+		$events = self::query( [
+			'timestamp' => [ 'from' => 0, 'to' => $current_time + $job_queue_window ],
+			'status'    => Events_Store::STATUS_PENDING,
+			'limit'     => -1, // Need to get all, to ensure we grab internals even when queue is backed up.
+		] );
 
 		// That was easy.
-		if ( ! is_array( $events ) || empty( $events ) ) {
-			return array(
-				'events' => null,
-			);
+		if ( empty( $events ) ) {
+			return [ 'events' => null ];
 		}
 
-		// Simplify array format for further processing.
-		$events = collapse_events_array( $events );
-
-		// Select only those events to run in the next sixty seconds.
-		// Will include missed events as well.
-		$current_events  = array();
-		$internal_events = array();
-		$current_window  = strtotime( sprintf( '+%d seconds', $job_queue_window ) );
-
+		$current_events  = [];
+		$internal_events = [];
 		foreach ( $events as $event ) {
-			// Skip events whose time hasn't come.
-			if ( $event['timestamp'] > $current_window ) {
-				continue;
-			}
-
-			// Skip events that don't have any callbacks hooked to their actions, unless their execution is requested.
-			if ( ! $this->action_has_callback_or_should_run_anyway( $event ) ) {
-				continue;
-			}
-
-			// Necessary data to identify an individual event.
-			// `$event['action']` is hashed to avoid information disclosure.
-			// Core hashes `$event['instance']` for us.
-			$event_data_public = array(
-				'timestamp' => $event['timestamp'],
-				'action'    => md5( $event['action'] ),
-				'instance'  => $event['instance'],
-			);
+			// action is hashed to avoid information disclosure.
+			$event_data_public = [
+				'timestamp' => $event->get_timestamp(),
+				'action'    => md5( $event->get_action() ),
+				'instance'  => $event->get_instance(),
+			];
 
 			// Queue internal events separately to avoid them being blocked.
-			if ( is_internal_event( $event['action'] ) ) {
+			if ( $event->is_internal() ) {
 				$internal_events[] = $event_data_public;
 			} else {
 				$current_events[] = $event_data_public;
@@ -152,39 +139,7 @@ class Events extends Singleton {
 
 		// Combine with Internal Events.
 		// TODO: un-nest array, which is nested for legacy reasons.
-		return array(
-			'events' => array_merge( $current_events, $internal_events ),
-		);
-	}
-
-	/**
-	 * Check that an event has a callback to run, and allow the check to be overridden
-	 * Empty events are, by default, skipped and removed/rescheduled
-	 *
-	 * @param array $event Event data.
-	 * @return bool
-	 */
-	private function action_has_callback_or_should_run_anyway( $event ) {
-		// Event has a callback, so let's get on with it.
-		if ( false !== has_action( $event['action'] ) ) {
-			return true;
-		}
-
-		// Run the event anyway, perhaps because callbacks are added using the `all` action.
-		if ( apply_filters( 'a8c_cron_control_run_event_with_no_callbacks', false, $event ) ) {
-			return true;
-		}
-
-		// Remove or reschedule the empty event.
-		if ( false === $event['args']['schedule'] ) {
-			wp_unschedule_event( $event['timestamp'], $event['action'], $event['args']['args'] );
-		} else {
-			$timestamp = $event['timestamp'] + ( isset( $event['args']['interval'] ) ? $event['args']['interval'] : 0 );
-			wp_reschedule_event( $timestamp, $event['args']['schedule'], $event['action'], $event['args']['args'] );
-			unset( $timestamp );
-		}
-
-		return false;
+		return [ 'events' => array_merge( $current_events, $internal_events ) ];
 	}
 
 	/**
@@ -194,7 +149,7 @@ class Events extends Singleton {
 	 * @param array $max_queue_size Maximum number of events to return.
 	 * @return array
 	 */
-	private function reduce_queue( $events, $max_queue_size ) {
+	private function reduce_queue( $events, $max_queue_size ): array {
 		// Loop through events, adding one of each action during each iteration.
 		$reduced_queue = array();
 		$action_counts = array();
@@ -255,52 +210,31 @@ class Events extends Singleton {
 	 * @param string $action md5 hash of the action used when the event is registered.
 	 * @param string $instance  md5 hash of the event's arguments array, which Core uses to index the `cron` option.
 	 * @param bool   $force Run event regardless of timestamp or lock status? eg, when executing jobs via wp-cli.
-	 * @return array|\WP_Error
+	 * @return array|WP_Error
 	 */
 	public function run_event( $timestamp, $action, $instance, $force = false ) {
 		// Validate input data.
 		if ( empty( $timestamp ) || empty( $action ) || empty( $instance ) ) {
-			return new \WP_Error(
-				'missing-data',
-				__( 'Invalid or incomplete request data.', 'automattic-cron-control' ),
-				array(
-					'status' => 400,
-				)
-			);
+			return new WP_Error( 'missing-data', __( 'Invalid or incomplete request data.', 'automattic-cron-control' ), [ 'status' => 400 ] );
 		}
 
 		// Ensure we don't run jobs ahead of time.
 		if ( ! $force && $timestamp > time() ) {
-			return new \WP_Error(
-				'premature',
-				/* translators: 1: Job identifier */
-				sprintf( __( 'Job with identifier `%1$s` is not scheduled to run yet.', 'automattic-cron-control' ), "$timestamp-$action-$instance" ),
-				array(
-					'status' => 403,
-				)
-			);
+			$error_message = sprintf( __( 'Job with identifier `%1$s` is not scheduled to run yet.', 'automattic-cron-control' ), "$timestamp-$action-$instance" );
+			return new WP_Error( 'premature', $error_message, [ 'status' => 404 ] );
 		}
 
-		// Find the event to retrieve the full arguments.
-		$event = get_event_by_attributes(
-			array(
-				'timestamp'     => $timestamp,
-				'action_hashed' => $action,
-				'instance'      => $instance,
-				'status'        => Events_Store::STATUS_PENDING,
-			)
-		);
+		$event = Event::find( [
+			'timestamp'     => $timestamp,
+			'action_hashed' => $action,
+			'instance'      => $instance,
+			'status'        => Events_Store::STATUS_PENDING,
+		] );
 
 		// Nothing to do...
-		if ( ! is_object( $event ) ) {
-			return new \WP_Error(
-				'no-event',
-				/* translators: 1: Job identifier */
-				sprintf( __( 'Job with identifier `%1$s` could not be found.', 'automattic-cron-control' ), "$timestamp-$action-$instance" ),
-				array(
-					'status' => 404,
-				)
-			);
+		if ( is_null( $event ) ) {
+			$error_message = sprintf( __( 'Job with identifier `%1$s` could not be found.', 'automattic-cron-control' ), "$timestamp-$action-$instance" );
+			return new WP_Error( 'no-event', $error_message, [ 'status' => 404 ] );
 		}
 
 		unset( $timestamp, $action, $instance );
@@ -311,40 +245,37 @@ class Events extends Singleton {
 			$this->prime_event_action_lock( $event );
 
 			if ( ! $this->can_run_event( $event ) ) {
-				return new \WP_Error(
-					'no-free-threads',
-					/* translators: 1: Event action, 2: Event arguments */
-					sprintf( __( 'No resources available to run the job with action `%1$s` and arguments `%2$s`.', 'automattic-cron-control' ), $event->action, maybe_serialize( $event->args ) ),
-					array(
-						'status' => 429,
-					)
-				);
+				/* translators: 1: Event action, 2: Event arguments */
+				$error_message = sprintf( __( 'No resources available to run the job with action `%1$s` and arguments `%2$s`.', 'automattic-cron-control' ), $event->get_action(), maybe_serialize( $event->get_args() ) );
+				return new WP_Error( 'no-free-threads', $error_message, [ 'status' => 429 ] );
 			}
 
-			// Free locks should event throw uncatchable error.
+			// Free locks later in case event throws an uncatchable error.
 			$this->running_event = $event;
 			add_action( 'shutdown', array( $this, 'do_lock_cleanup_on_shutdown' ) );
 		}
 
-		// Mark the event completed, and reschedule if desired.
-		// Core does this before running the job, so we respect that.
-		$this->update_event_record( $event );
+		// Core reschedules/conpletes an event before running it, so we respect that.
+		if ( $event->is_recurring() ) {
+			$event->reschedule();
+		} else {
+			$event->complete();
+		}
 
-		// Run the event.
 		try {
-			do_action_ref_array( $event->action, $event->args );
+			$event->run();
 		} catch ( \Throwable $t ) {
 			/**
 			 * Note that timeouts and memory exhaustion do not invoke this block.
 			 * Instead, those locks are freed in `do_lock_cleanup_on_shutdown()`.
 			 */
 
-			do_action( 'a8c_cron_control_event_threw_catchable_error', $event, $t );
+			do_action( 'a8c_cron_control_event_threw_catchable_error', $event->get_legacy_event_format(), $t );
 
 			$return = array(
 				'success' => false,
 				/* translators: 1: Event action, 2: Event arguments, 3: Throwable error, 4: Line number that raised Throwable error */
-				'message' => sprintf( __( 'Callback for job with action `%1$s` and arguments `%2$s` raised a Throwable - %3$s in %4$s on line %5$d.', 'automattic-cron-control' ), $event->action, maybe_serialize( $event->args ), $t->getMessage(), $t->getFile(), $t->getLine() ),
+				'message' => sprintf( __( 'Callback for job with action `%1$s` and arguments `%2$s` raised a Throwable - %3$s in %4$s on line %5$d.', 'automattic-cron-control' ), $event->get_action(), maybe_serialize( $event->get_args() ), $t->getMessage(), $t->getFile(), $t->getLine() ),
 			);
 		}
 
@@ -362,36 +293,24 @@ class Events extends Singleton {
 			$return = array(
 				'success' => true,
 				/* translators: 1: Event action, 2: Event arguments */
-				'message' => sprintf( __( 'Job with action `%1$s` and arguments `%2$s` executed.', 'automattic-cron-control' ), $event->action, maybe_serialize( $event->args ) ),
+				'message' => sprintf( __( 'Job with action `%1$s` and arguments `%2$s` executed.', 'automattic-cron-control' ), $event->get_action(), maybe_serialize( $event->get_args() ) ),
 			);
 		}
 
 		return $return;
 	}
 
-	/**
-	 * Prime the event-specific lock
-	 *
-	 * Used to ensure only one instance of a particular event, such as `wp_version_check` runs at one time
-	 *
-	 * @param object $event Event data.
-	 */
-	private function prime_event_action_lock( $event ) {
+	private function prime_event_action_lock( Event $event ): void {
 		Lock::prime_lock( $this->get_lock_key_for_event_action( $event ), JOB_LOCK_EXPIRY_IN_MINUTES * \MINUTE_IN_SECONDS );
 	}
 
-	/**
-	 * Are resources available to run this event?
-	 *
-	 * @param object $event Event data.
-	 * @return bool
-	 */
-	private function can_run_event( $event ) {
+	// Checks concurrency locks, deciding if the event can be run at this moment.
+	private function can_run_event( Event $event ): bool {
 		// Limit to one concurrent execution of a specific action by default.
 		$limit = 1;
 
-		if ( isset( $this->concurrent_action_whitelist[ $event->action ] ) ) {
-			$limit = absint( $this->concurrent_action_whitelist[ $event->action ] );
+		if ( isset( $this->concurrent_action_whitelist[ $event->get_action() ] ) ) {
+			$limit = absint( $this->concurrent_action_whitelist[ $event->get_action() ] );
 			$limit = min( $limit, JOB_CONCURRENCY_LIMIT );
 		}
 
@@ -400,7 +319,7 @@ class Events extends Singleton {
 		}
 
 		// Internal Events aren't subject to the global lock.
-		if ( is_internal_event( $event->action ) ) {
+		if ( $event->is_internal() ) {
 			return true;
 		}
 
@@ -415,14 +334,9 @@ class Events extends Singleton {
 		return true;
 	}
 
-	/**
-	 * Free locks after event completes
-	 *
-	 * @param object $event Event data.
-	 */
-	private function do_lock_cleanup( $event ) {
-		// Lock isn't set when event is Internal, so we don't want to alter it.
-		if ( ! is_internal_event( $event->action ) ) {
+	private function do_lock_cleanup( Event $event ): void {
+		// Site-level lock isn't set when event is Internal, so we don't want to alter it.
+		if ( ! $event->is_internal() ) {
 			Lock::free_lock( self::LOCK );
 		}
 
@@ -430,17 +344,11 @@ class Events extends Singleton {
 		$this->reset_event_lock( $event );
 	}
 
-	/**
-	 * Frees the lock for an individual event
-	 *
-	 * @param object $event Event data.
-	 * @return bool
-	 */
-	private function reset_event_lock( $event ) {
+	private function reset_event_lock( Event $event ): bool {
 		$lock_key = $this->get_lock_key_for_event_action( $event );
 		$expires  = JOB_LOCK_EXPIRY_IN_MINUTES * \MINUTE_IN_SECONDS;
 
-		if ( isset( $this->concurrent_action_whitelist[ $event->action ] ) ) {
+		if ( isset( $this->concurrent_action_whitelist[ $event->get_action() ] ) ) {
 			return Lock::free_lock( $lock_key, $expires );
 		} else {
 			return Lock::reset_lock( $lock_key, $expires );
@@ -450,81 +358,30 @@ class Events extends Singleton {
 	/**
 	 * Turn the event action into a string that can be used with a lock
 	 *
-	 * @param object $event Event data.
+	 * @param Event|stdClass $event
 	 * @return string
 	 */
-	public function get_lock_key_for_event_action( $event ) {
+	public function get_lock_key_for_event_action( $event ): string {
 		// Hashed solely to constrain overall length.
-		return md5( 'ev-' . $event->action );
-	}
-
-	/**
-	 * Mark an event completed, and reschedule when requested
-	 *
-	 * @param object $event Event data.
-	 */
-	private function update_event_record( $event ) {
-		if ( false !== $event->schedule ) {
-			// Re-implements much of the logic from `wp_reschedule_event()`.
-			$schedules = wp_get_schedules();
-			$interval  = 0;
-
-			// First, we try to get it from the schedule.
-			if ( isset( $schedules[ $event->schedule ] ) ) {
-				$interval = (int) $schedules[ $event->schedule ]['interval'];
-			}
-
-			// Now we try to get it from the saved interval, in case the schedule disappears.
-			if ( 0 === $interval ) {
-				$interval = $event->interval;
-			}
-
-			// If we have an interval, update the existing event entry.
-			if ( 0 !== $interval ) {
-				// Determine new timestamp, according to how `wp_reschedule_event()` does.
-				$now           = time();
-				$new_timestamp = $event->timestamp;
-
-				if ( $new_timestamp >= $now ) {
-					$new_timestamp = $now + $interval;
-				} else {
-					$new_timestamp = $now + ( $interval - ( ( $now - $new_timestamp ) % $interval ) );
-				}
-
-				// Build the expected arguments format.
-				$event_args = array(
-					'schedule' => $event->schedule,
-					'args'     => $event->args,
-					'interval' => $interval,
-				);
-
-				// Update event store.
-				schedule_event( $new_timestamp, $event->action, $event_args, $event->ID );
-
-				// If the event could be rescheduled, don't then delete it.
-				return;
-			}
-		}
-
-		// Either event doesn't recur, or the interval couldn't be determined.
-		delete_event( $event->timestamp, $event->action, $event->instance );
+		$action = method_exists( $event, 'get_action' ) ? $event->get_action() : $event->action;
+		return md5( 'ev-' . $action );
 	}
 
 	/**
 	 * If event execution throws uncatchable error, free locks
-	 *
 	 * Covers situations such as timeouts and memory exhaustion, which aren't \Throwable errors
-	 *
 	 * Under normal conditions, this callback isn't hooked to `shutdown`
 	 */
 	public function do_lock_cleanup_on_shutdown() {
-		if ( is_null( $this->running_event ) ) {
+		$event = $this->running_event;
+
+		if ( is_null( $event ) ) {
 			return;
 		}
 
-		do_action( 'a8c_cron_control_freeing_event_locks_after_uncaught_error', $this->running_event );
+		do_action( 'a8c_cron_control_freeing_event_locks_after_uncaught_error', $event->get_legacy_event_format() );
 
-		$this->do_lock_cleanup( $this->running_event );
+		$this->do_lock_cleanup( $event );
 	}
 
 	/**

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -131,10 +131,12 @@ function get_event_by_attributes( $attributes ) {
 /**
  * Retrieve a single event by its ID
  *
+ * @deprecated
  * @param  int $jid Job ID.
  * @return object|false
  */
 function get_event_by_id( $jid ) {
+	_deprecated_function( 'Automattic\WP\Cron_Control\get_event_by_id' );
 	return Events_Store::instance()->get_job_by_id( $jid );
 }
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -121,10 +121,12 @@ function get_events( $args ) {
 /**
  * Retrieve a single event by ID, or by a combination of its timestamp, instance identifier, and either action or the action's hashed representation
  *
+ * @deprecated
  * @param  array $attributes Array of event attributes to query by.
  * @return object|false
  */
 function get_event_by_attributes( $attributes ) {
+	_deprecated_function( 'Automattic\WP\Cron_Control\get_event_by_attributes' );
 	return Events_Store::instance()->get_job_by_attributes( $attributes );
 }
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -109,10 +109,12 @@ function delete_event_by_id( $id, $flush_cache = false ) {
 /**
  * Retrieve jobs given a set of parameters
  *
+ * @deprecated
  * @param array $args Event arguments to filter by.
  * @return array
  */
 function get_events( $args ) {
+	_deprecated_function( 'Automattic\WP\Cron_Control\get_events' );
 	return Events_Store::instance()->get_jobs( $args );
 }
 

--- a/includes/wp-cli/class-events.php
+++ b/includes/wp-cli/class-events.php
@@ -145,7 +145,7 @@ class Events extends \WP_CLI_Command {
 		}
 
 		/* translators: 1: Event ID, 2: Event action, 3. Event instance */
-		\WP_CLI::log( sprintf( __( 'Found event %1$d with action `%2$s` and instance identifier `%3$s`', 'automattic-cron-control' ), $args[0], $event->action, $event->instance ) );
+		\WP_CLI::log( sprintf( __( 'Found event %1$d with action `%2$s` and instance identifier `%3$s`', 'automattic-cron-control' ), $args[0], $event->get_action(), $event->get_instance() ) );
 
 		$now = time();
 		$event_timestamp = $event->get_timestamp();

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -25,6 +25,7 @@
 		<exclude name="Squiz.Commenting.FunctionComment.Missing"/>
 		<exclude name="Squiz.Commenting.FunctionComment.WrongStyle"/>
 		<exclude name="Squiz.Commenting.FunctionComment.MissingParamTag"/>
+		<exclude name="Squiz.Commenting.FunctionComment.MissingParamComment"/>
 		<exclude name="Squiz.Commenting.FunctionComment.ParamCommentFullStop"/>
 		<exclude name="Squiz.Commenting.VariableComment.WrongStyle"/>
 		<exclude name="Squiz.Commenting.InlineComment.InvalidEndChar"/>

--- a/tests/tests/class-events-store-tests.php
+++ b/tests/tests/class-events-store-tests.php
@@ -148,57 +148,6 @@ class Events_Store_Tests extends \WP_UnitTestCase {
 		$this->assertEmpty( Utils::get_events_from_store() );
 	}
 
-	/**
-	 * Test retrieving an event without requesting a status
-	 */
-	function test_get_job_by_attributes() {
-		$event = Utils::create_test_event();
-
-		$event_from_store = \Automattic\WP\Cron_Control\get_event_by_attributes(
-			[
-				'timestamp' => $event['timestamp'],
-				'action'    => $event['action'],
-				'instance'  => md5( maybe_serialize( $event['args'] ) ),
-			]
-		);
-
-		$this->assertInternalType( 'object', $event_from_store );
-	}
-
-	/**
-	 * Test retrieving an event with any status
-	 */
-	function test_get_job_by_attributes_with_any_status() {
-		$event = Utils::create_test_event();
-
-		$event_from_store = \Automattic\WP\Cron_Control\get_event_by_attributes(
-			[
-				'timestamp' => $event['timestamp'],
-				'action'    => $event['action'],
-				'instance'  => md5( maybe_serialize( $event['args'] ) ),
-				'status'    => 'any',
-			]
-		);
-
-		$this->assertInternalType( 'object', $event_from_store );
-	}
-
-	/**
-	 * Test retrieving an event with insufficient information
-	 */
-	function test_get_job_by_attributes_with_insufficient_args() {
-		$event = Utils::create_test_event();
-
-		$event_from_store = \Automattic\WP\Cron_Control\get_event_by_attributes(
-			[
-				'timestamp' => $event['timestamp'],
-				'action'    => $event['action'],
-			]
-		);
-
-		$this->assertFalse( $event_from_store );
-	}
-
 	/*
 	|--------------------------------------------------------------------------
 	| New event's store methods. The above may be deprecated in the future.


### PR DESCRIPTION
Finishes fully deprecating the following legacy "getters" from the events store, so they are no longer used within the plugin:

```
Events_Store->get_jobs()
Events_Store->get_job_by_id()
Events_Store->get_job_by_attributes()

// And their "helpers"
get_events()
get_event_by_attributes()
get_event_by_id()
```

I tried my best to not touch too much.