### PR TITLE
Implement extra caching layer for events

### DIFF
--- a/includes/class-event.php
+++ b/includes/class-event.php
@@ -177,7 +177,7 @@ class Event {
 		// Prevent conflicts with the unique constraints in the table.
 		// Is a bit unfortunate since it won't be as easy to query for the event anymore.
 		// Perhaps in the future could remove the unique constraint in favor of stricter duplicate checking.
-		$this->instance = (string) mt_rand( 1000000, 9999999999999 );
+		$this->instance = 'randomized:' . (string) mt_rand( 1000000, 9999999999999 );
 
 		$this->set_status( Events_Store::STATUS_COMPLETED );
 		return $this->save();

--- a/includes/class-events-store.php
+++ b/includes/class-events-store.php
@@ -177,7 +177,7 @@ class Events_Store extends Singleton {
 		}
 
 		// Clear caches now that the table exists.
-		self::flush_event_cache();
+		self::flush_all_caches();
 	}
 
 	/**
@@ -449,7 +449,7 @@ class Events_Store extends Singleton {
 	 */
 	public function flush_internal_caches() {
 		_deprecated_function( 'Events_Store\flush_internal_caches' );
-		self::flush_event_cache();
+		self::flush_all_caches();
 	}
 
 	/**
@@ -493,7 +493,7 @@ class Events_Store extends Singleton {
 					'status' => self::STATUS_COMPLETED,
 				)
 			);
-			self::flush_event_cache();
+			self::flush_all_caches();
 		}
 	}
 
@@ -537,7 +537,13 @@ class Events_Store extends Singleton {
 
 		$result = $wpdb->insert( $this->get_table_name(), $row_data, self::row_formatting( $row_data ) );
 
-		self::flush_event_cache();
+		self::flush_query_cache();
+		if ( isset( $row_data['action'], $row_data['instance'] ) ) {
+			self::flush_event_cache( $row_data['action'], $row_data['instance'] );
+		} else {
+			self::flush_event_cache();
+		}
+
 		return false === $result ? 0 : $wpdb->insert_id;
 	}
 
@@ -559,7 +565,15 @@ class Events_Store extends Singleton {
 		$where  = [ 'ID' => $event_id ];
 		$result = $wpdb->update( $this->get_table_name(), $row_data, $where, self::row_formatting( $row_data ), self::row_formatting( $where ) );
 
-		self::flush_event_cache();
+		self::flush_query_cache();
+		if ( isset( $row_data['action'], $row_data['args'] ) ) {
+			// Regenerate the initial instance because "completed" events have it randomized to avoid db contraint conflicts.
+			$instance = Event::create_instance_hash( maybe_unserialize( $row_data['args'] ) );
+			self::flush_event_cache( $row_data['action'], $instance );
+		} else {
+			self::flush_event_cache();
+		}
+
 		return false !== $result;
 	}
 
@@ -735,16 +749,30 @@ class Events_Store extends Singleton {
 			}
 		}
 
-		$last_changed = wp_cache_get_last_changed( 'cron-control-events' );
-		$query_hash   = sha1( serialize( [ $sql, $placeholders ] ) ) . "::{$last_changed}";
+		$cache_group = 'cron-control-queries';
+		$query_hash  = sha1( serialize( [ $sql, $placeholders ] ) );
+		$cache_key   = "events::{$query_hash}::" . wp_cache_get_last_changed( $cache_group );
 
-		$results = wp_cache_get( "events::{$query_hash}", 'cron-control-events' );
+		// Conditionally use a more specific cache for common FE queries, helping avoid most bulk invalidations.
+		$allowed_arg_count = array_key_exists( 'timestamp', $args ) ? 4 : 3;
+		if ( 1 === $args['limit'] && count( $args ) === $allowed_arg_count ) {
+			$has_timestamp = array_key_exists( 'timestamp', $args ) && ! is_null( $args['timestamp'] );
+
+			// Request was for the next event based on action/args, i.e. wp_next_scheduled()
+			if ( isset( $args['action'], $args['args'] ) && ! $has_timestamp ) {
+				$cache_group = 'cron-control-event';
+				$hashed_args = sha1( serialize( [ 'action' => $args['action'], 'instance' => Event::create_instance_hash( $args['args'] ) ] ) );
+				$cache_key   = "event::{$hashed_args}::" . wp_cache_get_last_changed( $cache_group );
+			}
+		}
+
+		$results = wp_cache_get( $cache_key, $cache_group );
 		if ( false === $results ) {
 			// Already prepared @codingStandardsIgnoreLine
 			$results = $wpdb->get_results( $wpdb->prepare( $sql, $placeholders ) );
 			$results = is_array( $results ) ? $results : [];
 
-			wp_cache_set( "events::{$query_hash}", $results, 'cron-control-events' );
+			wp_cache_set( $cache_key, $results, $cache_group );
 		}
 
 		return $results;
@@ -797,8 +825,26 @@ class Events_Store extends Singleton {
 		return $formatting;
 	}
 
-	private static function flush_event_cache() {
-		wp_cache_set( 'last_changed', microtime(), 'cron-control-events' );
+	private static function flush_all_caches() {
+		self::flush_query_cache();
+		self::flush_event_cache();
+	}
+
+	private static function flush_query_cache() {
+		wp_cache_set( 'last_changed', microtime(), 'cron-control-queries' );
+	}
+
+	private static function flush_event_cache( string $event_action = null, string $event_instance = null ) {
+		$cache_group = 'cron-control-event';
+
+		if ( is_null( $event_action ) || is_null( $event_instance ) ) {
+			// Flush the whole group when a specific event was not specified.
+			wp_cache_set( 'last_changed', microtime(), $cache_group );
+		} else {
+			$hashed_args = sha1( serialize( [ 'action' => $event_action, 'instance' => $event_instance ] ) );
+			$cache_key   = "event::{$hashed_args}::" . wp_cache_get_last_changed( $cache_group );
+			wp_cache_delete( $cache_key, $cache_group );
+		}
 	}
 }
 

--- a/includes/class-events-store.php
+++ b/includes/class-events-store.php
@@ -567,7 +567,7 @@ class Events_Store extends Singleton {
 
 		self::flush_query_cache();
 		if ( isset( $row_data['action'], $row_data['args'] ) ) {
-			// Regenerate the initial instance because "completed" events have it randomized to avoid db contraint conflicts.
+			// Regenerate the initial instance because "completed" events have it randomized to avoid db constraint conflicts.
 			$instance = Event::create_instance_hash( maybe_unserialize( $row_data['args'] ) );
 			self::flush_event_cache( $row_data['action'], $instance );
 		} else {


### PR DESCRIPTION
Kind of put this off initially due to extra complexity and not wanting to pre-optimize w/o data, but thinking it's likely going to be desired. So starting the work on it ahead of time.

In short, this is perhaps the most common pattern on the frontend:

```
if ( ! wp_next_scheduled ( 'action_name', $args ) ) {
  wp_schedule_event( time(), 'hourly', 'action_name', $args );
}
```

Right now we flush the whole query cache anytime an event is updated (such as when events are run). This means the next FE request will need to do a fresh query for that `wp_next_scheduled()` call, which can amount to quite a number throughout the codebase.

This PR addresses this by adding an additional caching layer that we can more selectively invalidate. As events are run, the FE shouldn't see much impact under normal conditions.