### PR TITLE
Check args size, and increase query limit

### DIFF
--- a/includes/class-event.php
+++ b/includes/class-event.php
@@ -368,8 +368,7 @@ class Event {
 		$db_row_size_of_normal_event = 300;
 
 		// Note: Memcache can only cache up to 1mb values, after compression.
-		$default_storage_needed_for_events = $db_row_size_of_normal_event * $max_events_per_page;
-		$reasonable_size = ( MB_IN_BYTES - $default_storage_needed_for_events ) / $max_events_per_page;
+		$reasonable_size = ( MB_IN_BYTES / $max_events_per_page ) - $db_row_size_of_normal_event;
 
 		// First a quick uncompressed test.
 		$uncompressed_size = mb_strlen( serialize( $this->get_args() ), '8bit' );

--- a/includes/class-event.php
+++ b/includes/class-event.php
@@ -325,6 +325,11 @@ class Event {
 			}
 		}
 
+		// Don't prevent event creation, but do warn about overly large arguments.
+		if ( ! $this->args_array_is_reasonably_sized() ) {
+			trigger_error( sprintf( 'Cron-Control: Event (action: %s) was added w/ abnormally large arguments. This can badly effect performance.', $this->get_action() ), E_USER_WARNING );
+		}
+
 		return true;
 	}
 
@@ -353,5 +358,34 @@ class Event {
 
 		// If we couldn't get from schedule (was removed), use whatever was saved already.
 		return $this->interval;
+	}
+
+	private function args_array_is_reasonably_sized(): bool {
+		// We aim to cache queries w/ up to 500 events.
+		$max_events_per_page = 500;
+
+		// A compressed db row of an event is around 300 bytes.
+		$db_row_size_of_normal_event = 300;
+
+		// Note: Memcache can only cache up to 1mb values, after compression.
+		$default_storage_needed_for_events = $db_row_size_of_normal_event * $max_events_per_page;
+		$reasonable_size = ( MB_IN_BYTES - $default_storage_needed_for_events ) / $max_events_per_page;
+
+		// First a quick uncompressed test.
+		$uncompressed_size = mb_strlen( serialize( $this->get_args() ), '8bit' );
+		if ( $uncompressed_size < $reasonable_size * 4 ) {
+			// After compression, this is for sure generously under the limit.
+			return true;
+		}
+
+		// Now the more expensive test, accounting for compression.
+		$compressed_args = gzdeflate( serialize( $this->get_args() ) );
+		if ( false === $compressed_args ) {
+			// Wasn't able to compress, let's assume it is above the ideal limit.
+			return false;
+		}
+
+		$compressed_size = mb_strlen( $compressed_args, '8bit' );
+		return $compressed_size < $reasonable_size;
 	}
 }

--- a/includes/wp-adapter.php
+++ b/includes/wp-adapter.php
@@ -147,7 +147,7 @@ function pre_clear_scheduled_hook( $pre, $hook, $args ) {
 	$query_args = [
 		'action' => $hook,
 		'args'   => $args,
-		'limit'  => 100,
+		'limit'  => 500,
 		'page'   => 1,
 	];
 
@@ -245,8 +245,8 @@ function pre_get_cron_option( $pre ) {
 	}
 
 	// For maximum BC, we need to truly give all events here.
-	// Still stepping in increments of 100 to allow query caching to do it's job.
-	$query_args = [ 'limit' => 100, 'page' => 1 ];
+	// Stepping in increments of 500 to allow query caching to do it's job.
+	$query_args = [ 'limit' => 500, 'page' => 1 ];
 	$all_events = [];
 	do {
 		$events     = Events::query( $query_args );


### PR DESCRIPTION
Addresses https://github.com/Automattic/Cron-Control/issues/159. Instead of blocking events w/ large arguments though (which could cause other problems), just warn for now so it is at least visible.

W/ this new checking in place, it's safer to go ahead and increase how many events we query at a time under the presumption that events will stay under this "reasonable limit". This really only matters if there is still code doing `get_option( 'cron' )` somewhere, as that is when we need to retrieve all events.

Increasing from 100 to 500 is a pretty good improvement, as a site w/ say 3000 active events will need to do just 6 queries instead of 30. Of course they are cached for subsequent requests (assuming args stay under the, quite gracious, size limit), but the cache is invalidated whenever events are updated/run - so it will still take place fairly often should code like the `get_option( 'cron' )` still exist on the frontend.

Worst case, if a ton of events w/ massive args are added, the query will fail to save some result sets in memcache and instead will need to re-query each time. It's not the end of the world since the queries for "all events" are quite performant since we are talking about a pretty small table, and the warnings should be noticeable.
 
_____

I ran quite a few size tests, writing them down here for posterity. Could probably go higher than expecting to cache just 500 events per cache key, but seems like a reasonable and safe number for now.

Test event creation:

```
add_action( 'init', function() {
  for ( $i = 0; $i <= 1000; $i++ ) {
    // no args
    $args = [];
    wp_schedule_event( time(), 'hourly', 'some_action1', [$i, $args] );

    // w/ medium sized args
    $args = array_fill( 0, 100, 'a' );
    wp_schedule_event( time(), 'hourly', 'some_action2', [$i, $args] );

    // w/ big args
    $args = array_fill( 0, 100, str_repeat( 'a', 100 ) );
    wp_schedule_event( time(), 'hourly', 'some_action3', [$i, $args] );

    // w/ bigger array, smaller content
    $args = array_fill( 0, 1000, 'a' );
    wp_schedule_event( time(), 'hourly', 'some_action4', [$i, $args] );

    // quite massive
    $args = array_fill( 0, 1000, str_repeat( 'a', 1000 ) );
    wp_schedule_event( time(), 'hourly', 'some_action5', [$i, $args] );
  }
} );
```

Sizing checks:

```
// No args:

$test = Automattic\WP\Cron_Control\Events_Store::instance()->_query_events_raw( [ 'limit' => 100, 'page' => 1, 'action' => 'some_action1' ] );
mb_strlen( serialize( $test ), '8bit' )
=> int(44068) // .044mb

____

// w/ medium sized args
$args = array_fill( 0, 100, 'a' );

$test = Automattic\WP\Cron_Control\Events_Store::instance()->_query_events_raw( [ 'limit' => 100, 'page' => 1, 'action' => 'some_action2' ] );
mb_strlen( serialize( $test ), '8bit' )
=> int(173609) // 0.17mb

____

// W/ big args
$args = array_fill( 0, 1000, str_repeat( 'a', 100 ) ) ;

$test = Automattic\WP\Cron_Control\Events_Store::instance()->_query_events_raw( [ 'limit' => 100, 'page' => 1, 'action' => 'some_action3' ] );
mb_strlen( serialize( $test ), '8bit' )
=> int(1183893) // 1.1mb

// compressed
mb_strlen( gzdeflate( serialize( $test ) ), '8bit' )
=> int(16050) .01mb
____

// W/ bigger array, smaller content
$args = array_fill( 0, 1000, 'a' ) ;

$test = Automattic\WP\Cron_Control\Events_Store::instance()->_query_events_raw( [ 'limit' => 100, 'page' => 1, 'action' => 'some_action4' ] );
mb_strlen( serialize( $test ), '8bit' )
=> int(1433672) // 1.4mb

// compressed
strlen( gzdeflate( serialize( $test ) ) );
mb_strlen( gzdeflate( serialize( $test ) ), '8bit' )
=> int(28508) // .02mb

____

Quite Massive

$args = array_fill( 0, 1000, str_repeat( 'a', 1000 ) ) ;

$test = Automattic\WP\Cron_Control\Events_Store::instance()->_query_events_raw( [ 'limit' => 100, 'page' => 1, 'action' => 'some_action5' ] );
mb_strlen( serialize( $test ), '8bit' )
=> int(11533771) // 11.5mb

// compressed
mb_strlen( gzdeflate( serialize( $test ) ), '8bit' )
=> int(309113) .3mb
```