### PR TITLE
Fix php warning in list-due-batch CLI

### DIFF
--- a/includes/wp-cli/class-orchestrate-runner.php
+++ b/includes/wp-cli/class-orchestrate-runner.php
@@ -43,12 +43,13 @@ class Orchestrate_Runner extends \WP_CLI_Command {
 		}
 
 		$events = \Automattic\WP\Cron_Control\Events::instance()->get_events( $queue_size, $queue_window );
+		$events = is_array( $events['events'] ) ? $events['events'] : [];
 
 		$format = \WP_CLI\Utils\get_flag_value( $assoc_args, 'format', 'table' );
 
 		\WP_CLI\Utils\format_items(
 			$format,
-			$events['events'],
+			$events,
 			array(
 				'timestamp',
 				'action',


### PR DESCRIPTION
The below error happens during `wp cron-control orchestrate runner-only list-due-batch` when there are no due events to run:

```
Warning: Invalid argument supplied for foreach() in /wp/vendor/wp-cli/wp-cli/php/WP_CLI/Formatter.php on line 162 [$ /usr/local/bin/wp --allow-root cron-control orchestrate runner-only list-due-batch --queue-window=0 --format=json] [vendor/wp-cli/wp-cli/php/WP_CLI/Formatter.php:98 WP_CLI\Formatter->format(), vendor/wp-cli/wp-cli/php/utils.php:337 WP_CLI\Formatter->display_items(), wp-content/mu-plugins/cron-control/includes/wp-cli/class-orchestrate-runner.php:54 WP_CLI\Utils\format_items(), Automattic\WP\Cron_Control\CLI\Orchestrate_Runner->list_due_now()
```

`format_items()` expects an array, but sometimes we pass `null`: https://github.com/Automattic/Cron-Control/blob/bf67b6426243819fa4d601c4bae0f1ddc4e14000/includes/class-events.php#L107

Not really a new error, just more likely now that we don't fetch events due in the future. Planning to unnest/cleanup this portion in the future - but for now this will help silence the errors.