### PR TITLE
Validate schedule_event filter

### DIFF
--- a/includes/wp-adapter.php
+++ b/includes/wp-adapter.php
@@ -64,6 +64,9 @@ function pre_schedule_event( $pre, $event ) {
 
 	/** This filter is documented in wordpress/wp-includes/cron.php */
 	$event = apply_filters( 'schedule_event', $event );
+	if ( ! isset( $event->hook, $event->timestamp, $event->args ) ) {
+		return new WP_Error( 'cron-control:wp:schedule-event-prevented' );
+	}
 
 	// Passed duplicate checks, all clear to create an event.
 	$new_event = new Event();


### PR DESCRIPTION
WP core kinda set a precedent for this filter being used as a mechanism for preventing events to be scheduled, as various plugins will return `false`. So safeguarding against that and any other filter weirdness.

Currently seeing fatals like this as a result:

```
PHP Fatal error:  Uncaught TypeError: Argument 1 passed to Automattic\WP\Cron_Control\Event::set_action() must be of the type string, null given, called in /var/www/wp-content/mu-plugins/cron-control/includes/wp-adapter.php on line 70 and defined in /var/www/wp-content/mu-plugins/cron-control/includes/class-event.php:77
```