### PR TITLE
Update table install process

### DIFF
--- a/includes/class-events-store.php
+++ b/includes/class-events-store.php
@@ -169,9 +169,33 @@ class Events_Store extends Singleton {
 
 	/*
 	|--------------------------------------------------------------------------
-	| Deprecated (or soon to be) methods for interactions w/ the data store.
+	| Deprecated (or soon to be) methods.
 	|--------------------------------------------------------------------------
 	*/
+
+	public function create_table_during_install() {
+		_deprecated_function( 'Events_Store\create_table_during_install' );
+	}
+
+	public function create_tables_during_multisite_install( $blog_id ) {
+		_deprecated_function( 'Events_Store\create_tables_during_multisite_install' );
+	}
+
+	public function maybe_create_table_on_shutdown() {
+		_deprecated_function( 'Events_Store\maybe_create_table_on_shutdown' );
+	}
+
+	public function prepare_table() {
+		_deprecated_function( 'Events_Store\prepare_table' );
+	}
+
+	public function cli_create_tables() {
+		_deprecated_function( 'Events_Store\cli_create_tables' );
+	}
+
+	public function remove_multisite_table( $tables_to_drop ) {
+		_deprecated_function( 'Events_Store\remove_multisite_table' );
+	}
 
 	/**
 	 * Deprecated, unused by the plugin.

--- a/includes/class-events-store.php
+++ b/includes/class-events-store.php
@@ -51,7 +51,7 @@ class Events_Store extends Singleton {
 			return true;
 		}
 
-		$table_name = $wpdb->prefix . self::TABLE_SUFFIX;;
+		$table_name = $wpdb->prefix . self::TABLE_SUFFIX;
 		$is_installed = 1 === count( $wpdb->get_col( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table_name ) ) );
 
 		if ( $is_installed ) {

--- a/includes/class-events-store.php
+++ b/includes/class-events-store.php
@@ -7,9 +7,6 @@
 
 namespace Automattic\WP\Cron_Control;
 
-/**
- * Event's Store class
- */
 class Events_Store extends Singleton {
 	const TABLE_SUFFIX = 'a8c_cron_control_jobs';
 
@@ -23,24 +20,17 @@ class Events_Store extends Singleton {
 	const ALLOWED_STATUSES = [ self::STATUS_PENDING, self::STATUS_RUNNING, self::STATUS_COMPLETED ];
 
 	protected function class_init() {
-		// Create tables during installation.
-		add_action( 'wp_install', array( $this, 'create_table_during_install' ) );
-		// TODO: This is deprecated hook, switch to wp_insert_site.
-		add_action( 'wpmu_new_blog', array( $this, 'create_tables_during_multisite_install' ) );
-
-		// Remove table when a multisite subsite is deleted.
-		add_filter( 'wpmu_drop_tables', array( $this, 'remove_multisite_table' ) );
-
-		// Try to get the table installed.
 		if ( ! self::is_installed() ) {
-			if ( ! defined( 'WP_INSTALLING' ) || ! WP_INSTALLING ) {
-				// Prime plugin's option before the options table exists.
-				add_option( self::DB_VERSION_OPTION, 0, null, false );
-			}
+			// Create tables during site installations.
+			add_action( 'wp_install', array( $this, 'install' ) );
 
-			// In limited circumstances, try creating the table.
-			add_action( 'shutdown', array( $this, 'maybe_create_table_on_shutdown' ) );
+			// Keep trying in case we weren't around during the site installation.
+			add_action( 'shutdown', array( $this, 'maybe_install_during_shutdown' ) );
 		}
+
+		// Handle adding/removing tables when subsites are created/deleted.
+		add_action( 'wp_insert_site', array( $this, 'install' ) );
+		add_filter( 'wpmu_drop_tables', array( $this, 'drop_tables_on_subsite_removal' ) );
 	}
 
 	/*
@@ -50,15 +40,25 @@ class Events_Store extends Singleton {
 	*/
 
 	/**
-	 * Check if events store is ready
-	 *
-	 * Plugin breaks spectacularly if events store isn't available
-	 *
-	 * @return bool
+	 * Check if the table is installed.
 	 */
-	public static function is_installed() {
-		$db_version = (int) get_option( self::DB_VERSION_OPTION );
-		return version_compare( $db_version, 0, '>' );
+	public static function is_installed(): bool {
+		global $wpdb;
+
+		// Can't rely on the DB_VERSION_OPTION here due to subsite copy/paste scenarios.
+		// Must truly check that the table is installed.
+		if ( wp_cache_get( 'is_installed', 'cron-control' ) ) {
+			return true;
+		}
+
+		$table_name = $wpdb->prefix . self::TABLE_SUFFIX;;
+		$is_installed = 1 === count( $wpdb->get_col( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table_name ) ) );
+
+		if ( $is_installed ) {
+			wp_cache_set( 'is_installed', true, 'cron-control' );
+		}
+
+		return $is_installed;
 	}
 
 	/**
@@ -70,78 +70,55 @@ class Events_Store extends Singleton {
 	}
 
 	/**
-	 * Create table during initial install
+	 * Run the installation process, usually for freshly created sites/subsites.
+	 *
+	 * @param WP_Site|null $new_site New site object during subsite creation, null for single/root site creation.
 	 */
-	public function create_table_during_install() {
-		if ( 'wp_install' !== current_action() ) {
+	public function install( $new_site = null ) {
+		if ( ! isset( $new_site->blog_id ) ) {
+			$this->_prepare_table();
 			return;
 		}
 
+		// Swap over to the new subsite being created.
+		switch_to_blog( (int) $new_site->blog_id );
 		$this->_prepare_table();
-	}
-
-	/**
-	 * Create table when new subsite is added to a multisite
-	 *
-	 * @param int $bid Blog ID.
-	 */
-	public function create_tables_during_multisite_install( $bid ) {
-		switch_to_blog( $bid );
-
-		if ( ! self::is_installed() ) {
-			$this->_prepare_table();
-		}
-
 		restore_current_blog();
 	}
 
 	/**
-	 * For certain requests, create the table on shutdown
-	 * Does not include front-end requests
+	 * For certain requests, create the table on shutdown if needed.
 	 */
-	public function maybe_create_table_on_shutdown() {
-		// TODO: Also let it try to create in CLI automatically, not just is_admin().
-		if ( ! is_admin() && ! is_rest_endpoint_request( REST_API::ENDPOINT_LIST ) ) {
+	public function maybe_install_during_shutdown() {
+		$is_cron_or_cli = wp_doing_cron() || ( defined( 'WP_CLI' ) && WP_CLI );
+		$is_admin = is_admin() && ! wp_doing_ajax();
+
+		if ( ! $is_cron_or_cli && ! $is_admin ) {
+			// Not a request we should try to install on.
 			return;
 		}
 
-		$this->prepare_table();
-	}
-
-	/**
-	 * Create table in non-setup contexts, with some protections
-	 */
-	public function prepare_table() {
-		// Table installed.
 		if ( self::is_installed() ) {
+			// Must have been installed earlier on in this request already.
 			return;
 		}
 
-		// Nothing to do.
-		$current_version = (int) get_option( self::DB_VERSION_OPTION );
-		if ( version_compare( $current_version, self::DB_VERSION, '>=' ) ) {
-			return;
+		if ( wp_cache_add( 'installation_lock', true, 'cron-control', \MINUTE_IN_SECONDS ) ) {
+			// We've claimed the lock, run the installation.
+			$this->_prepare_table();
 		}
-
-		// Limit chance of race conditions when creating table.
-		$create_lock_set = wp_cache_add( 'a8c_cron_control_creating_table', 1, null, 1 * \MINUTE_IN_SECONDS );
-		if ( false === $create_lock_set ) {
-			return;
-		}
-
-		$this->_prepare_table();
 	}
 
 	/**
 	 * Create the plugin's DB table when necessary
 	 */
 	protected function _prepare_table() {
+		global $wpdb;
+
 		// Use Core's method of creating/updating tables.
 		if ( ! function_exists( 'dbDelta' ) ) {
 			require_once ABSPATH . '/wp-admin/includes/upgrade.php';
 		}
-
-		global $wpdb;
 
 		$table_name = $this->get_table_name();
 
@@ -173,6 +150,7 @@ class Events_Store extends Singleton {
 		$table_count = count( $wpdb->get_col( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table_name ) ) );
 
 		if ( 1 === $table_count ) {
+			wp_cache_set( 'is_installed', true, 'cron-control' );
 			update_option( self::DB_VERSION_OPTION, self::DB_VERSION );
 		}
 
@@ -181,27 +159,12 @@ class Events_Store extends Singleton {
 	}
 
 	/**
-	 * Prepare table on demand via CLI
-	 */
-	public function cli_create_tables() {
-		if ( ! defined( 'WP_CLI' ) || ! \WP_CLI ) {
-			return;
-		}
-
-		$this->_prepare_table();
-	}
-
-	/**
-	 * When deleting a subsite from a multisite instance, include the plugin's table
+	 * When deleting a subsite from a multisite instance, include the plugin's table.
 	 *
-	 * Core only drops its tables
-	 *
-	 * @param  array $tables_to_drop Array of prefixed table names to drop.
-	 * @return array
+	 * @param array $tables_to_drop Array of prefixed table names to drop.
 	 */
-	public function remove_multisite_table( $tables_to_drop ) {
-		$tables_to_drop[] = $this->get_table_name();
-		return $tables_to_drop;
+	public function drop_tables_on_subsite_removal( $tables_to_drop ): array {
+		return array_merge( $tables_to_drop, [ $this->get_table_name() ] );
 	}
 
 	/*

--- a/includes/class-events.php
+++ b/includes/class-events.php
@@ -512,5 +512,3 @@ class Events extends Singleton {
 		return $flattened;
 	}
 }
-
-Events::instance();

--- a/includes/class-internal-events.php
+++ b/includes/class-internal-events.php
@@ -277,5 +277,3 @@ class Internal_Events extends Singleton {
 		Events_Store::instance()->purge_completed_events();
 	}
 }
-
-Internal_Events::instance();

--- a/includes/class-rest-api.php
+++ b/includes/class-rest-api.php
@@ -157,5 +157,3 @@ class REST_API extends Singleton {
 		return true;
 	}
 }
-
-REST_API::instance();

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -185,7 +185,7 @@ function _deprecated_function( string $function, string $replacement = '', $erro
 		'warn'   => 3,
 	];
 
-	$message = sprintf( 'Cron-Control: %s is deprecated and will soon be removed.', $function );
+	$message = sprintf( 'Cron-Control: Deprecation. %s is deprecated and will soon be removed.', $function );
 	if ( ! empty( $replacement ) ) {
 		$message .= sprintf( ' Use %s instead.', $replacement );
 	}

--- a/includes/wp-adapter.php
+++ b/includes/wp-adapter.php
@@ -5,8 +5,7 @@ namespace Automattic\WP\Cron_Control;
 use Automattic\WP\Cron_Control\Events_Store;
 use WP_Error;
 
-// Integrate w/ WP's cron api once the custom table is installed.
-if ( Events_Store::is_installed() ) {
+function register_adapter_hooks() {
 	// Core filters added in WP 5.1, allowing us to fully use the custom event's store.
 	add_filter( 'pre_schedule_event', __NAMESPACE__ . '\\pre_schedule_event', 10, 2 );
 	add_filter( 'pre_reschedule_event', __NAMESPACE__ . '\\pre_reschedule_event', 10, 2 );
@@ -303,7 +302,7 @@ function pre_update_cron_option( $new_value, $old_value ) {
 			'args'      => $event_to_add['args'],
 		];
 
-		if ( ! empty( $item['value']['schedule'] ) ) {
+		if ( ! empty( $event_to_add['schedule'] ) ) {
 			$wp_event['schedule'] = $event_to_add['schedule'];
 			$wp_event['interval'] = $event_to_add['interval'];
 		}

--- a/includes/wp-adapter.php
+++ b/includes/wp-adapter.php
@@ -302,7 +302,7 @@ function pre_update_cron_option( $new_value, $old_value ) {
 			'args'      => $event_to_add['args'],
 		];
 
-		if ( ! empty( $event_to_add['schedule'] ) ) {
+		if ( ! empty( $item['value']['schedule'] ) ) {
 			$wp_event['schedule'] = $event_to_add['schedule'];
 			$wp_event['interval'] = $event_to_add['interval'];
 		}

--- a/includes/wp-cli.php
+++ b/includes/wp-cli.php
@@ -7,9 +7,7 @@
 
 namespace Automattic\WP\Cron_Control\CLI;
 
-if ( ! defined( '\WP_CLI' ) || ! \WP_CLI ) {
-	return;
-}
+use Automattic\WP\Cron_Control\Events_Store;
 
 /**
  * Prepare environment
@@ -26,9 +24,8 @@ function prepare_environment() {
 	}
 
 	// Create table and die, to ensure command runs with proper state.
-	if ( ! \Automattic\WP\Cron_Control\Events_Store::is_installed() ) {
-		\Automattic\WP\Cron_Control\Events_Store::instance()->cli_create_tables();
-
+	if ( ! Events_Store::is_installed() ) {
+		Events_Store::instance()->install();
 		\WP_CLI::error( __( 'Cron Control installation completed. Please try again.', 'automattic-cron-control' ) );
 	}
 
@@ -38,7 +35,6 @@ function prepare_environment() {
 		\Automattic\WP\Cron_Control\set_doing_cron();
 	}
 }
-prepare_environment();
 
 /**
  * Consistent time format across commands

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -5,6 +5,8 @@
  * @package a8c_Cron_Control
  */
 
+use Automattic\WP\Cron_Control;
+
 $_tests_dir = getenv( 'WP_TESTS_DIR' );
 if ( ! $_tests_dir ) {
 	$_tests_dir = '/tmp/wordpress-tests-lib';
@@ -37,18 +39,8 @@ function _manually_load_plugin() {
 	require dirname( dirname( __FILE__ ) ) . '/cron-control.php';
 
 	// Plugin loads after `wp_install()` is called, so we compensate.
-	\Automattic\WP\Cron_Control\Events_Store::instance()->prepare_table();
-
-	// Need to re-add the filters since they would have been skipped over in wp-adapter.php the first time around.
-	add_filter( 'pre_schedule_event', __NAMESPACE__ . '\Automattic\WP\Cron_Control\pre_schedule_event', 10, 2 );
-	add_filter( 'pre_reschedule_event', __NAMESPACE__ . '\Automattic\WP\Cron_Control\pre_reschedule_event', 10, 2 );
-	add_filter( 'pre_unschedule_event', __NAMESPACE__ . '\Automattic\WP\Cron_Control\pre_unschedule_event', 10, 4 );
-	add_filter( 'pre_clear_scheduled_hook', __NAMESPACE__ . '\Automattic\WP\Cron_Control\pre_clear_scheduled_hook', 10, 3 );
-	add_filter( 'pre_unschedule_hook', __NAMESPACE__ . '\Automattic\WP\Cron_Control\pre_unschedule_hook', 10, 2 );
-	add_filter( 'pre_get_scheduled_event', __NAMESPACE__ . '\Automattic\WP\Cron_Control\pre_get_scheduled_event', 10, 4 );
-	add_filter( 'pre_get_ready_cron_jobs', __NAMESPACE__ . '\Automattic\WP\Cron_Control\pre_get_ready_cron_jobs', 10, 1 );
-	add_filter( 'pre_option_cron', __NAMESPACE__ . '\Automattic\WP\Cron_Control\pre_get_cron_option', 10 );
-	add_filter( 'pre_update_option_cron', __NAMESPACE__ . '\Automattic\WP\Cron_Control\pre_update_cron_option', 10, 2 );
+	Cron_Control\Events_Store::instance()->install();
+	Cron_Control\register_adapter_hooks();
 }
 tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 


### PR DESCRIPTION
- Helps resolve an issue noted in https://github.com/Automattic/Cron-Control/issues/232 where a site has the option set but doesn't actually have the table installed. So instead the `is_installed()` check now directly checks if the table exists and use the site cache instead of relying just on the option.
- `wpmu_new_blog` is deprecated, so swapping it out for `wp_insert_site`.
- Removes some of the direct side-effects from file-loading, and instead more decisively bootstraps the plugin.

Also simplified the usage a bit, now just have the public methods listed below. I checked the methods I removed and didn't see any usage, but because they were public I've added them back with deprecation notices just for extra safety during updates.

```
is_installed()
install()
maybe_install_during_shutdown()
drop_tables_on_subsite_removal()
```

The only piece this PR doesn't solve for is the "Prepare for schema changes" action item. Will handle that separately when the time comes, probably with `needs_db_update()` and `maybe_run_database_update()` methods.

## Testing

Single Site:
1) Setup a fresh single site and check that the table is created.
2) Delete the table manually and flush cache. Reload and see if table is created.

Multisite:
1) Setup a fresh multisite and check that the table is created on the root site.
2) Create a new subsite and check the the table is created.
3) Delete the table on the root site and subsite, flush cache on both. Reload and ensure table was added back.