### PR TITLE
Correctly register recurring events during manual 'cron' option updates

### DIFF
--- a/includes/wp-adapter.php
+++ b/includes/wp-adapter.php
@@ -303,7 +303,7 @@ function pre_update_cron_option( $new_value, $old_value ) {
 			'args'      => $event_to_add['args'],
 		];
 
-		if ( ! empty( $item['value']['schedule'] ) ) {
+		if ( ! empty( $event_to_add['schedule'] ) ) {
 			$wp_event['schedule'] = $event_to_add['schedule'];
 			$wp_event['interval'] = $event_to_add['interval'];
 		}

--- a/tests/tests/class-wp-adapter-tests.php
+++ b/tests/tests/class-wp-adapter-tests.php
@@ -244,20 +244,28 @@ class WP_Adapter_Tests extends \WP_UnitTestCase {
 		$update_result = Cron_Control\pre_update_cron_option( 'not array', [ 'old array' ] );
 		$this->assertEquals( [ 'old array' ], $update_result );
 
-		// Schedule an event, and leave one unsaved.
+		// Schedule one event, and leave two unsaved.
 		$default_args   = [ 'timestamp' => time() + 100, 'args' => [ 'some', 'args' ] ];
-		$event_to_add   = $this->create_unsaved_event( array_merge( $default_args, [ 'action' => 'test_pre_update_cron_option_new' ] ) );
 		$existing_event = $this->create_unsaved_event( array_merge( $default_args, [ 'action' => 'test_pre_update_cron_option_existing' ] ) );
 		$existing_event->save();
 
-		// Mock the scenario of sending a fresh event into the mix.
+		$event_to_add           = $this->create_unsaved_event( array_merge( $default_args, [ 'action' => 'test_pre_update_cron_option_new' ] ) );
+		$recurring_event_to_add = $this->create_unsaved_event( array_merge( $default_args, [
+			'action' => 'test_pre_update_cron_option_new_recurring',
+			'schedule' => 'hourly',
+			'interval' => HOUR_IN_SECONDS,
+		] ) );
+
+		// Mock the scenario of sending a fresh events into the mix.
 		$existing_option = Events::format_events_for_wp( [ $existing_event ] );
-		$new_option      = Events::format_events_for_wp( [ $existing_event, $event_to_add ] );
+		$new_option      = Events::format_events_for_wp( [ $existing_event, $event_to_add, $recurring_event_to_add ] );
 		$update_result   = Cron_Control\pre_update_cron_option( $new_option, $existing_option );
 
 		$this->assertEquals( $existing_option, $update_result, 'return value is always the prev value' );
 		$added_event = Event::find( [ 'action' => 'test_pre_update_cron_option_new' ] );
-		$this->assertEquals( $event_to_add->get_action(), $added_event->get_action(), 'event was registered' );
+		$this->assertEquals( $event_to_add->get_action(), $added_event->get_action(), 'single event was registered' );
+		$added_recurring_event = Event::find( [ 'action' => 'test_pre_update_cron_option_new_recurring' ] );
+		$this->assertEquals( $recurring_event_to_add->get_schedule(), $added_recurring_event->get_schedule(), 'recurring event was registered' );
 
 		// Mock the scenario of deleting an event from the mix.
 		$existing_option = Events::format_events_for_wp( [ $existing_event, $added_event ] );
@@ -307,6 +315,10 @@ class WP_Adapter_Tests extends \WP_UnitTestCase {
 		$event->set_action( $args['action'] );
 		$event->set_timestamp( $args['timestamp'] );
 		$event->set_args( $args['args'] );
+
+		if ( isset( $args['schedule'] ) ) {
+			$event->set_schedule( $args['schedule'], $args['interval'] );
+		}
 
 		return $event;
 	}


### PR DESCRIPTION
Fixes a bug that would show itself only if somebody called `update_option( 'cron'...` directly and had added new recurring cron jobs. Without the fix, we'll currently end up registering it as one-time jobs instead of a recurring job.

Pretty rare scenario, as this is like the backup-backwards-compatibility layer.