### PR TITLE
Migrate legacy cron events from the cron option

### DIFF
--- a/__tests__/unit-tests/test-internal-events.php
+++ b/__tests__/unit-tests/test-internal-events.php
@@ -28,5 +28,37 @@ class Internal_Events_Tests extends \WP_UnitTestCase {
 		}
 	}
 
-	// TODO: Test the actual logic that internal events run.
+	function test_migrate_legacy_cron_events() {
+		global $wpdb;
+
+		// Ensure we start with an empty cron option.
+		delete_option( 'cron' );
+
+		// Create one saved event and two unsaved events.
+		$existing_event = Utils::create_test_event( [ 'timestamp' => time(), 'action' => 'existing_event' ] );
+		$legacy_event = Utils::create_unsaved_event( [ 'timestamp' => time() + 500, 'action' => 'legacy_event' ] );
+		$legacy_recurring_event = Utils::create_unsaved_event( [ 'timestamp' => time() + 600, 'action' => 'legacy_recurring_event', 'schedule' => 'hourly', 'interval' => \HOUR_IN_SECONDS ] );
+
+		$cron_array = Cron_Control\Events::format_events_for_wp( [ $existing_event, $legacy_event, $legacy_recurring_event ] );
+		$cron_array['version'] = 2;
+
+		// Put the legacy event directly into the cron option, avoiding our special filtering. @codingStandardsIgnoreLine
+		$result = $wpdb->query( $wpdb->prepare( "INSERT INTO `$wpdb->options` (`option_name`, `option_value`, `autoload`) VALUES (%s, %s, %s)", 'cron', serialize( $cron_array ), 'yes' ) );
+		wp_cache_delete( 'alloptions', 'options' );
+		wp_cache_delete( 'notoptions', 'options' );
+		wp_cache_delete( 'cron', 'options' );
+
+		// Run the migration.
+		Cron_Control\Internal_Events::instance()->clean_legacy_data();
+
+		// Should now have all three events registered.
+		$registered_events = Cron_Control\Events::query( [ 'limit' => 100 ] );
+		$this->assertEquals( 3, count( $registered_events ), 'correct number of registered events' );
+		$this->assertEquals( $registered_events[0]->get_action(), $existing_event->get_action(), 'existing event stayed registered' );
+		$this->assertEquals( $registered_events[1]->get_action(), $legacy_event->get_action(), 'legacy event was registered' );
+		$this->assertEquals( $registered_events[2]->get_schedule(), $legacy_recurring_event->get_schedule(), 'legacy recurring event was registered' );
+
+		$cron_row = $wpdb->get_row( "SELECT * FROM $wpdb->options WHERE option_name = 'cron'" );
+		$this->assertNull( $cron_row, 'cron option was deleted' );
+	}
 }

--- a/__tests__/unit-tests/test-wp-adapter.php
+++ b/__tests__/unit-tests/test-wp-adapter.php
@@ -245,11 +245,11 @@ class WP_Adapter_Tests extends \WP_UnitTestCase {
 
 		// Schedule one event, and leave two unsaved.
 		$default_args   = [ 'timestamp' => time() + 100, 'args' => [ 'some', 'args' ] ];
-		$existing_event = $this->create_unsaved_event( array_merge( $default_args, [ 'action' => 'test_pre_update_cron_option_existing' ] ) );
+		$existing_event = Utils::create_unsaved_event( array_merge( $default_args, [ 'action' => 'test_pre_update_cron_option_existing' ] ) );
 		$existing_event->save();
 
-		$event_to_add           = $this->create_unsaved_event( array_merge( $default_args, [ 'action' => 'test_pre_update_cron_option_new' ] ) );
-		$recurring_event_to_add = $this->create_unsaved_event( array_merge( $default_args, [
+		$event_to_add           = Utils::create_unsaved_event( array_merge( $default_args, [ 'action' => 'test_pre_update_cron_option_new' ] ) );
+		$recurring_event_to_add = Utils::create_unsaved_event( array_merge( $default_args, [
 			'action' => 'test_pre_update_cron_option_new_recurring',
 			'schedule' => 'hourly',
 			'interval' => HOUR_IN_SECONDS,
@@ -307,18 +307,5 @@ class WP_Adapter_Tests extends \WP_UnitTestCase {
 			'future'    => $future_event,
 			'recurring' => $recurring,
 		];
-	}
-
-	private function create_unsaved_event( array $args ) {
-		$event = new Event();
-		$event->set_action( $args['action'] );
-		$event->set_timestamp( $args['timestamp'] );
-		$event->set_args( $args['args'] );
-
-		if ( isset( $args['schedule'] ) ) {
-			$event->set_schedule( $args['schedule'], $args['interval'] );
-		}
-
-		return $event;
 	}
 }

--- a/__tests__/utils.php
+++ b/__tests__/utils.php
@@ -19,18 +19,22 @@ class Utils {
 	}
 
 	public static function create_test_event( array $args = [] ): Event {
+		$event = self::create_unsaved_event( $args );
+		$event->save();
+		return $event;
+	}
+
+	public static function create_unsaved_event( array $args = [] ) {
 		if ( empty( $args ) ) {
 			$args = array(
 				'timestamp' => time(),
-				'action'    => 'test_event_action',
+				'action'    => 'test_unsaved_event_action',
 				'args'      => [],
 			);
 		}
 
 		$event = new Event();
 		self::apply_event_props( $event, $args );
-		$event->save();
-
 		return $event;
 	}
 

--- a/includes/class-internal-events.php
+++ b/includes/class-internal-events.php
@@ -1,84 +1,64 @@
 <?php
 /**
- * Internal events to manage plugin and common WP cron complaints
+ * Internal events to manage the plugin and resolve common WP cron complaints.
  *
  * @package a8c_Cron_Control
  */
 
 namespace Automattic\WP\Cron_Control;
 
-/**
- * Internal Events class
- */
 class Internal_Events extends Singleton {
-	/**
-	 * PLUGIN SETUP
-	 */
 
-	/**
-	 * List of registered internal events
-	 *
-	 * @var array
-	 */
-	private $internal_events = array();
+	private array $internal_events = [];
+	private array $internal_events_schedules = [];
 
-	/**
-	 * Schedules for internal events
-	 *
-	 * Provides for intervals shorter than Core does by default
-	 *
-	 * @var array
-	 */
-	private $internal_events_schedules = array();
-
-	/**
-	 * Register hooks
-	 */
 	protected function class_init() {
-		// Prepare events and their schedules, allowing for additions.
 		$this->prepare_internal_events();
 		$this->prepare_internal_events_schedules();
 
-		// Register hooks.
-		if ( defined( 'WP_CLI' ) && \WP_CLI ) {
-			add_action( 'wp_loaded', array( $this, 'schedule_internal_events' ) );
-		} else {
-			add_action( 'admin_init', array( $this, 'schedule_internal_events' ) );
+		// Schedule the internal events once our custom store is in place.
+		if ( Events_Store::is_installed() ) {
+			$is_cron_or_cli = wp_doing_cron() || ( defined( 'WP_CLI' ) && WP_CLI );
+			$is_admin = is_admin() && ! wp_doing_ajax();
+
+			if ( $is_cron_or_cli || $is_admin ) {
+				add_action( 'wp_loaded', [ $this, 'schedule_internal_events' ] );
+			}
 		}
 
-		add_filter( 'cron_schedules', array( $this, 'register_internal_events_schedules' ) );
-
+		// Register schedules and callbacks.
+		add_filter( 'cron_schedules', [ $this, 'register_internal_events_schedules' ] );
 		foreach ( $this->internal_events as $internal_event ) {
 			add_action( $internal_event['action'], $internal_event['callback'] );
 		}
 	}
 
 	/**
-	 * Populate internal events, allowing for additions
+	 * Populate internal events, allowing for additions.
 	 */
 	private function prepare_internal_events() {
-		$internal_events = array(
-			array(
+		$internal_events = [
+			[
 				'schedule' => 'a8c_cron_control_minute',
 				'action'   => 'a8c_cron_control_force_publish_missed_schedules',
-				'callback' => array( $this, 'force_publish_missed_schedules' ),
-			),
-			array(
+				'callback' => [ $this, 'force_publish_missed_schedules' ],
+			],
+			[
 				'schedule' => 'a8c_cron_control_ten_minutes',
 				'action'   => 'a8c_cron_control_confirm_scheduled_posts',
-				'callback' => array( $this, 'confirm_scheduled_posts' ),
-			),
-			array(
-				'schedule' => 'daily',
-				'action'   => 'a8c_cron_control_clean_legacy_data',
-				'callback' => array( $this, 'clean_legacy_data' ),
-			),
-			array(
+				'callback' => [ $this, 'confirm_scheduled_posts' ],
+			],
+			[
 				'schedule' => 'hourly',
 				'action'   => 'a8c_cron_control_purge_completed_events',
-				'callback' => array( $this, 'purge_completed_events' ),
-			),
-		);
+				'callback' => [ $this, 'purge_completed_events' ],
+			],
+			[
+				'schedule' => 'daily',
+				'action'   => 'a8c_cron_control_clean_legacy_data',
+				'callback' => [ $this, 'clean_legacy_data' ],
+			],
+		];
 
 		// Allow additional internal events to be specified, ensuring the above cannot be overwritten.
 		if ( defined( 'CRON_CONTROL_ADDITIONAL_INTERNAL_EVENTS' ) && is_array( \CRON_CONTROL_ADDITIONAL_INTERNAL_EVENTS ) ) {
@@ -101,19 +81,19 @@ class Internal_Events extends Singleton {
 	}
 
 	/**
-	 * Allow custom internal events to provide their own schedules
+	 * Allow custom internal events to provide their own schedules.
 	 */
 	private function prepare_internal_events_schedules() {
-		$internal_events_schedules = array(
-			'a8c_cron_control_minute'      => array(
+		$internal_events_schedules = [
+			'a8c_cron_control_minute' => [
 				'interval' => 2 * MINUTE_IN_SECONDS,
 				'display'  => __( 'Cron Control internal job - every 2 minutes (used to be 1 minute)', 'automattic-cron-control' ),
-			),
-			'a8c_cron_control_ten_minutes' => array(
+			],
+			'a8c_cron_control_ten_minutes' => [
 				'interval' => 10 * MINUTE_IN_SECONDS,
 				'display'  => __( 'Cron Control internal job - every 10 minutes', 'automattic-cron-control' ),
-			),
-		);
+			],
+		];
 
 		// Allow additional schedules for custom events, ensuring the above cannot be overwritten.
 		if ( defined( 'CRON_CONTROL_ADDITIONAL_INTERNAL_EVENTS_SCHEDULES' ) && is_array( \CRON_CONTROL_ADDITIONAL_INTERNAL_EVENTS_SCHEDULES ) ) {
@@ -133,19 +113,10 @@ class Internal_Events extends Singleton {
 		$this->internal_events_schedules = $internal_events_schedules;
 	}
 
-	/**
-	 * Include custom schedules used for internal events
-	 *
-	 * @param array $schedules List of registered event intervals.
-	 * @return array
-	 */
-	public function register_internal_events_schedules( $schedules ) {
+	public function register_internal_events_schedules( array $schedules ): array {
 		return array_merge( $schedules, $this->internal_events_schedules );
 	}
 
-	/**
-	 * Schedule internal events
-	 */
 	public function schedule_internal_events() {
 		foreach ( $this->internal_events as $event_args ) {
 			if ( ! wp_next_scheduled( $event_args['action'] ) ) {
@@ -155,25 +126,22 @@ class Internal_Events extends Singleton {
 	}
 
 	/**
-	 * PLUGIN UTILITIES
-	 */
-
-	/**
-	 * Events that are always run, regardless of how many jobs are queued
+	 * Check if an action belongs to an internal event.
 	 *
 	 * @param string $action Event action.
-	 * @return bool
 	 */
-	public function is_internal_event( $action ) {
+	public function is_internal_event( $action ): bool {
 		return in_array( $action, wp_list_pluck( $this->internal_events, 'action' ), true );
 	}
 
-	/**
-	 * EVENT CALLBACKS
-	 */
+	/*
+	|--------------------------------------------------------------------------
+	| Internal Event Callbacks
+	|--------------------------------------------------------------------------
+	*/
 
 	/**
-	 * Publish scheduled posts that miss their schedule
+	 * Publish scheduled posts that miss their schedule.
 	 */
 	public function force_publish_missed_schedules() {
 		global $wpdb;
@@ -190,7 +158,7 @@ class Internal_Events extends Singleton {
 	}
 
 	/**
-	 * Ensure scheduled posts have a corresponding cron job to publish them
+	 * Ensure scheduled posts have a corresponding cron job to publish them.
 	 */
 	public function confirm_scheduled_posts() {
 		global $wpdb;
@@ -230,20 +198,23 @@ class Internal_Events extends Singleton {
 	}
 
 	/**
-	 * Remove unnecessary data and scheduled events
+	 * Delete event objects for events that have run.
+	 */
+	public function purge_completed_events() {
+		Events_Store::instance()->purge_completed_events();
+	}
+
+	/**
+	 * Remove unnecessary data and scheduled events.
 	 *
-	 * Some of this data relates to how Core manages Cron when this plugin isn't active
+	 * Some of this data relates to how Core manages Cron when this plugin isn't active.
 	 */
 	public function clean_legacy_data() {
 		// Cron option can be very large, so it shouldn't linger.
 		delete_option( 'cron' );
 
 		// While this plugin doesn't use this locking mechanism, other code may check the value.
-		if ( wp_using_ext_object_cache() ) {
-			wp_cache_delete( 'doing_cron', 'transient' );
-		} else {
-			delete_transient( 'doing_cron' );
-		}
+		delete_transient( 'doing_cron' );
 
 		// Confirm internal events are scheduled for when they're expected.
 		$schedules = wp_get_schedules();
@@ -268,12 +239,5 @@ class Internal_Events extends Singleton {
 				$event->save();
 			}
 		}
-	}
-
-	/**
-	 * Delete event objects for events that have run
-	 */
-	public function purge_completed_events() {
-		Events_Store::instance()->purge_completed_events();
 	}
 }


### PR DESCRIPTION
Cleaned up the internal events class some in the process, but there are just two main bits of functionality changes here:

1) Internal events will only be registered after the custom table has been installed. Does not really make sense to have them before that.
2) The `clean_legacy_data()` daily cron job will now migrate events from the `cron` option to our custom table, if they don't exist still.

This is mainly an improvement for sites that are moved onto cron control after already existing for a while. It fixes https://github.com/Automattic/Cron-Control/issues/203, where notably WooCommerce cron jobs will go missing after a site is moved onto cron control. But also helps cover a range of other cases where recurring events are conditionally registered (like during plugin install), or where specific single events exist for future tasks but would currently be lost forever if a site migrated to cron control before the event ran.

Also provides a tiny bit of extra "compatibility", should some plugin decide to manually add their events directly to the `cron` option via SQL.

## Testing

The unit test is pretty good for this :)

I've also done a fresh WP install and confirmed the internal events are no longer added to the `cron` option but instead go into the table once it's been created.

And then did another fresh install (without cron control), registered a custom event manually, then activated cron cron. After running cron jobs `wp cron event run --due-now`, the custom event was moved to the custom table