### PR TITLE
Prune duplicate recurring events

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,13 @@ By default the plugin disables default WP cron processing. It is recommended to 
 
 ## Frequently Asked Questions ##
 
+### Deviations from WordPress Core ###
+
+* Cron jobs are stored in a custom table and not in the `cron` option in wp_options. As long relevent code uses WP core functions for retrieving events and not direct SQL, all will stay compatible.
+* Duplicate recurring events with the same action/args/schedule are prevented. If multiple of the same action is needed on the same schedule, can add an arbitrary number to the args array.
+* When the cron control runner is running events, it does so via WP CLI. So the environment can be slightly different than that of a normal web request.
+* The cron control runner can process multiple events in parallel, whereas core cron only did 1 at a time. By default, events with the same action will not run in parallel unless specifically granted permission to do so.
+
 ### Adding Internal Events ###
 
 **This should be done sparingly as "Internal Events" bypass certain locks and limits built into the plugin.** Overuse will lead to unexpected resource usage, and likely resource exhaustion.

--- a/__tests__/unit-tests/test-events-store.php
+++ b/__tests__/unit-tests/test-events-store.php
@@ -203,4 +203,33 @@ class Events_Store_Tests extends \WP_UnitTestCase {
 		$this->assertEquals( 1, count( $result ), 'returned event from second page' );
 		$this->assertEquals( $event_two->get_timestamp(), $result[0]->timestamp, 'found the right event' );
 	}
+
+	public function test_query_raw_events_orderby() {
+		$store = Events_Store::instance();
+
+		$event_one   = Utils::create_test_event( [ 'timestamp' => 5, 'action' => 'test_query_raw_events_orderby' ] );
+		$event_two   = Utils::create_test_event( [ 'timestamp' => 2, 'action' => 'test_query_raw_events_orderby' ] );
+		$event_three = Utils::create_test_event( [ 'timestamp' => 3, 'action' => 'test_query_raw_events_orderby' ] );
+		$event_four  = Utils::create_test_event( [ 'timestamp' => 1, 'action' => 'test_query_raw_events_orderby' ] );
+
+		// Default orderby should be timestamp ASC
+		$result = $store->_query_events_raw();
+		$this->assertEquals( 4, count( $result ), 'returned the correct amount of events' );
+		$this->assertEquals( $event_four->get_timestamp(), $result[0]->timestamp, 'the oldest "due now" event is returned first' );
+
+		// Fetch by timestamp in descending order.
+		$result = $store->_query_events_raw( [ 'orderby' => 'timestamp', 'order' => 'desc' ] );
+		$this->assertEquals( 4, count( $result ), 'returned the correct amount of events' );
+		$this->assertEquals( $event_one->get_timestamp(), $result[0]->timestamp, 'the farthest "due now" event is returned first' );
+
+		// Fetch by ID in ascending order.
+		$result = $store->_query_events_raw( [ 'orderby' => 'ID', 'order' => 'asc' ] );
+		$this->assertEquals( 4, count( $result ), 'returned the correct amount of events' );
+		$this->assertEquals( $event_one->get_id(), $result[0]->ID, 'the lowest ID is returned first' );
+
+		// Fetch by ID in descending order.
+		$result = $store->_query_events_raw( [ 'orderby' => 'ID', 'order' => 'desc' ] );
+		$this->assertEquals( 4, count( $result ), 'returned the correct amount of events' );
+		$this->assertEquals( $event_four->get_id(), $result[0]->ID, 'the highest ID is returned first' );
+	}
 }

--- a/languages/cron-control.pot
+++ b/languages/cron-control.pot
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cron Control 3.0\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/cron-control\n"
-"POT-Creation-Date: 2022-01-19 22:39:12+00:00\n"
+"POT-Creation-Date: 2022-01-20 03:55:29+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -58,11 +58,11 @@ msgstr ""
 msgid "Job with action `%1$s` and arguments `%2$s` executed."
 msgstr ""
 
-#: includes/class-internal-events.php:110
+#: includes/class-internal-events.php:90
 msgid "Cron Control internal job - every 2 minutes (used to be 1 minute)"
 msgstr ""
 
-#: includes/class-internal-events.php:114
+#: includes/class-internal-events.php:94
 msgid "Cron Control internal job - every 10 minutes"
 msgstr ""
 

--- a/readme.txt
+++ b/readme.txt
@@ -25,6 +25,13 @@ By default the plugin disables default WP cron processing. It is recommended to 
 
 == Frequently Asked Questions ==
 
+= Deviations from WordPress Core =
+
+* Cron jobs are stored in a custom table and not in the `cron` option in wp_options. As long relevent code uses WP core functions for retrieving events and not direct SQL, all will stay compatible.
+* Duplicate recurring events with the same action/args/schedule are prevented. If multiple of the same action is needed on the same schedule, can add an arbitrary number to the args array.
+* When the cron control runner is running events, it does so via WP CLI. So the environment can be slightly different than that of a normal web request.
+* The cron control runner can process multiple events in parallel, whereas core cron only did 1 at a time. By default, events with the same action will not run in parallel unless specifically granted permission to do so.
+
 = Adding Internal Events =
 
 **This should be done sparingly as "Internal Events" bypass certain locks and limits built into the plugin.** Overuse will lead to unexpected resource usage, and likely resource exhaustion.


### PR DESCRIPTION
As apart of https://github.com/Automattic/Cron-Control/issues/234, this will help cleanup duplicate events that exist (daily). It's pretty safe, as we only look at recurring events that have the exact same action/args/schedule. There is really no need to have events like that. If you need the same hook on the same schedule, then the args need to be different to make them unique. If the args don't matter though, then probably the event should be looked into being added onto a schedule that occurs more often.

This alone won't solve all our problems mentioned in that issue, but no matter what we're going to need to cleanup the messes that currently exist. So this seems like a good starting point. Notably, this should drastically help reduce the "duplicate entry" db errors that can cause events to become stuck at the top of the queue and repeatedly run each cycle.

I opted for not including duplicate single events, since they technically clean themselves up. But could possibly revisit that in the future. For those will probably want to respect the "10minute window" that core checks: https://developer.wordpress.org/reference/functions/wp_schedule_single_event/. As in, only remove duplicate single events that exist within 10minutes of each other.

## Testing
The unit test is pretty good for this  as well :)

Did fresh WP install w/ cron control disabled and ran the following:

```
wp shell

wp_schedule_single_event( time() + 100, 'custom_single_event' );
wp_schedule_single_event( time() + 200, 'custom_single_event' );

wp_schedule_event( time() + 100, 'hourly', 'custom_recurring_event' );
wp_schedule_event( time() + 200, 'hourly', 'custom_recurring_event' );
```

Then activated cron control, and refreshed twice so the table & internal events could be setup. Then ran cron (so the cleanup legacy data task runs). Afterwards, both `custom_single_event` were in the custom table and only one `custom_recurring_event` was left.