### PR TITLE
Ignore deactivated subsites

### DIFF
--- a/__tests__/bootstrap.php
+++ b/__tests__/bootstrap.php
@@ -45,3 +45,19 @@ require_once __DIR__ . '/utils.php';
 
 // Start up the WP testing environment.
 require $_tests_dir . '/includes/bootstrap.php';
+
+// Setup WP CLI depedencies.
+if ( ! defined( 'WP_CLI_ROOT' ) ) {
+	define( 'WP_CLI_ROOT', __DIR__ . '/../vendor/wp-cli/wp-cli' );
+}
+
+include WP_CLI_ROOT . '/php/utils.php';
+include WP_CLI_ROOT . '/php/dispatcher.php';
+include WP_CLI_ROOT . '/php/class-wp-cli.php';
+include WP_CLI_ROOT . '/php/class-wp-cli-command.php';
+
+\WP_CLI\Utils\load_dependencies();
+
+// WP_CLI wasn't defined during plugin bootup, so bootstrap our cli classes manually
+require dirname( dirname( __FILE__ ) ) . '/includes/wp-cli.php';
+Cron_Control\CLI\prepare_environment();

--- a/__tests__/unit-tests/test-cli-orchestrate-sites.php
+++ b/__tests__/unit-tests/test-cli-orchestrate-sites.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Automattic\WP\Cron_Control\Tests;
+
+use Automattic\WP\Cron_Control\CLI;
+use WP_Site;
+
+class Orchestrate_Sites_Tests extends \WP_UnitTestCase {
+	function setUp() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Skipping tests that only run on multisites.' );
+		}
+
+		parent::setUp();
+	}
+
+	function tearDown() {
+		parent::tearDown();
+	}
+
+	function test_list_sites_removes_inactive_subsites() {
+		add_filter( 'sites_pre_query', [ $this, 'mock_get_sites' ], 10, 2 );
+
+		// The archived/spam/deleted subsites should not be returned.
+		$expected = wp_json_encode( [ [ 'url' => 'site1.com' ], [ 'url' => 'site2.com/two' ], [ 'url' => 'site3.com/three' ], [ 'url' => 'site7.com/seven' ] ] );
+		$this->expectOutputString( $expected );
+		( new CLI\Orchestrate_Sites() )->list();
+
+		remove_filter( 'sites_pre_query', [ $this, 'mock_get_sites' ], 10, 2 );
+	}
+
+	function test_list_sites_2_hosts() {
+		add_filter( 'sites_pre_query', [ $this, 'mock_get_sites' ], 10, 2 );
+
+		// With two hosts, all active sites should still be returned.
+		$this->mock_hosts_list( 2 );
+		$expected = wp_json_encode( [ [ 'url' => 'site1.com' ], [ 'url' => 'site2.com/two' ], [ 'url' => 'site3.com/three' ], [ 'url' => 'site7.com/seven' ] ] );
+		$this->expectOutputString( $expected );
+		( new CLI\Orchestrate_Sites() )->list();
+
+		remove_filter( 'sites_pre_query', [ $this, 'mock_get_sites' ], 10, 2 );
+	}
+
+	function test_list_sites_7_hosts() {
+		add_filter( 'sites_pre_query', [ $this, 'mock_get_sites' ], 10, 2 );
+
+		// With seven hosts, our current request should only be given two of the active sites.
+		$this->mock_hosts_list( 7 );
+		$expected = wp_json_encode( [ [ 'url' => 'site1.com' ], [ 'url' => 'site7.com/seven' ] ] );
+		$this->expectOutputString( $expected );
+		( new CLI\Orchestrate_Sites() )->list();
+
+		remove_filter( 'sites_pre_query', [ $this, 'mock_get_sites' ], 10, 2 );
+	}
+
+	function mock_hosts_list( $number_of_hosts ) {
+		// Always have the "current" host.
+		$heartbeats = [ gethostname() => time() ];
+
+		if ( $number_of_hosts > 1 ) {
+			for ( $i = 1; $i < $number_of_hosts; $i++ ) {
+				$heartbeats[ "test_$i" ] = time();
+			}
+		}
+
+		wp_cache_set( CLI\Orchestrate_Sites::RUNNER_HOST_HEARTBEAT_KEY, $heartbeats );
+	}
+
+	function mock_get_sites( $site_data, $query_class ) {
+		if ( $query_class->query_vars['count'] ) {
+			return 7;
+		}
+
+		return [
+			new WP_Site( (object) [ 'domain' => 'site1.com', 'path' => '/' ] ),
+			new WP_Site( (object) [ 'domain' => 'site2.com', 'path' => '/two' ] ),
+			new WP_Site( (object) [ 'domain' => 'site3.com', 'path' => '/three' ] ),
+			new WP_Site( (object) [ 'domain' => 'site4.com', 'path' => '/four', 'archived' => '1' ] ),
+			new WP_Site( (object) [ 'domain' => 'site5.com', 'path' => '/five', 'spam' => '1' ] ),
+			new WP_Site( (object) [ 'domain' => 'site6.com', 'path' => '/six', 'deleted' => '1' ] ),
+			new WP_Site( (object) [ 'domain' => 'site7.com', 'path' => '/seven' ] ),
+		];
+	}
+}

--- a/phpunit-multisite.xml
+++ b/phpunit-multisite.xml
@@ -1,0 +1,17 @@
+<phpunit
+	bootstrap="__tests__/bootstrap.php"
+	backupGlobals="false"
+	colors="true"
+	convertErrorsToExceptions="true"
+	convertNoticesToExceptions="true"
+	convertWarningsToExceptions="true"
+	>
+	<php>
+		<const name="WP_TESTS_MULTISITE" value="1" />
+	</php>
+	<testsuites>
+		<testsuite name="Unit Tests">
+			<directory prefix="test-" suffix=".php">./__tests__/unit-tests/</directory>
+		</testsuite>
+	</testsuites>
+</phpunit>


### PR DESCRIPTION
When we run `wp cron-control orchestrate sites list` in the runner, it returns deactivated subsites such as those marked as archived/deleted/spam. The runner then tries to fetch and process events on these subsites but we don't even currently load up the cron control plugin for those sites so the subsequent CLIs fail (https://github.com/Automattic/vip-go-mu-plugins/blob/master/001-cron.php#L35-L39).

I plan to make it so cron control is loaded for all subsites no matter what, just like the rest of mu plugins, so this PR adjusts the site listing so we exclude the deactivated subsites.

For context, sites marked as archived/deleted/spam are unaccessible. So core WP cron would not be running on them either.

### Testing

- Run `wp cron-control orchestrate sites list` on a multisite.
- Run `phpunit -c phpunit-multisite.xml` (is covered by CI already)