### PR TITLE
Fix php deprecation notice with trim()

### DIFF
--- a/includes/utils.php
+++ b/includes/utils.php
@@ -127,27 +127,36 @@ function parse_request() {
 
 	list( $req_uri ) = explode( '?', $_SERVER['REQUEST_URI'] );
 	$self = $_SERVER['PHP_SELF'];
-	$home_path = trim( parse_url( home_url(), PHP_URL_PATH ), '/' );
-	$home_path_regex = sprintf( '|^%s|i', preg_quote( $home_path, '|' ) );
 
-	// Trim path info from the end and the leading home path from the
-	// front. For path info requests, this leaves us with the requesting
-	// filename, if any. For 404 requests, this leaves us with the
-	// requested permalink.
-	$req_uri = str_replace( $pathinfo, '', $req_uri );
-	$req_uri = trim( $req_uri, '/' );
-	$req_uri = preg_replace( $home_path_regex, '', $req_uri );
-	$req_uri = trim( $req_uri, '/' );
+	$home_path = parse_url( home_url(), PHP_URL_PATH );
+	$home_path_regex = '';
+	if ( is_string( $home_path ) && '' !== $home_path ) {
+		$home_path       = trim( $home_path, '/' );
+		$home_path_regex = sprintf( '|^%s|i', preg_quote( $home_path, '|' ) );
+	}
+
+	/*
+	 * Trim path info from the end and the leading home path from the front.
+	 * For path info requests, this leaves us with the requesting filename, if any.
+	 * For 404 requests, this leaves us with the requested permalink.
+	 */
+	$req_uri  = str_replace( $pathinfo, '', $req_uri );
+	$req_uri  = trim( $req_uri, '/' );
 	$pathinfo = trim( $pathinfo, '/' );
-	$pathinfo = preg_replace( $home_path_regex, '', $pathinfo );
-	$pathinfo = trim( $pathinfo, '/' );
-	$self = trim( $self, '/' );
-	$self = preg_replace( $home_path_regex, '', $self );
-	$self = trim( $self, '/' );
+	$self     = trim( $self, '/' );
+
+	if ( ! empty( $home_path_regex ) ) {
+		$req_uri  = preg_replace( $home_path_regex, '', $req_uri );
+		$req_uri  = trim( $req_uri, '/' );
+		$pathinfo = preg_replace( $home_path_regex, '', $pathinfo );
+		$pathinfo = trim( $pathinfo, '/' );
+		$self     = preg_replace( $home_path_regex, '', $self );
+		$self     = trim( $self, '/' );
+	}
 
 	// The requested permalink is in $pathinfo for path info requests and
 	//  $req_uri for other requests.
-	if ( ! empty( $pathinfo ) && !preg_match( '|^.*' . $rewrite_index . '$|', $pathinfo ) ) {
+	if ( ! empty( $pathinfo ) && ! preg_match( '|^.*' . $rewrite_index . '$|', $pathinfo ) ) {
 		$requested_path = $pathinfo;
 	} else {
 		// If the request uri is the index, blank it out so that we don't try to match it against a rule.


### PR DESCRIPTION
Fixes https://github.com/Automattic/Cron-Control/issues/323

Uses the same fix applied in core here: https://github.com/WordPress/WordPress/commit/5ca2a817abb025a01bf9a8056ed00c766f7e6eed

### Testing

With a test environment on php 8.1:

```
POST http://php81.vipdev.lndo.site/wp-json/cron-control/v1/events

{
  "secret": "this-is-a-secret"
}
```

You'll get a php error before the patch, and none after (but the endpoint still works of course).

Notably, the site's home_url() needs to have no subpath.