### PR TITLE
Add the package type to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
   "name": "automattic/cron-control",
   "description": "Execute WordPress cron events in parallel, with custom event storage for high-volume cron.",
+  "type": "wordpress-muplugin",
   "license": "GPL-2.0",
   "require": {
     "php": ">=7.4.0"


### PR DESCRIPTION
This Pull Request adds a package type to `composer.json`.
When managing WordPress installation via [Composer](https://github.com/roots/bedrock/blob/master/composer.json#L61), it allows installing the plugin using the `composer require automattic/cron-control` command. Without the package type, this plugin ends up in the `vendor` folder instead of `wp-content/mu-plugins`.

<details><summary>Repo info</summary>
Of course, to install this plugin, you need to add the repository to the composer.json file

```
...
"repositories": [
  {
    "type": "vcs",
    "url": "https://github.com/Automattic/Cron-Control"
   },
  ...
]
...
```
</details>