### PR TITLE
Fix fatal error when trying to access private member

### DIFF
--- a/includes/class-event.php
+++ b/includes/class-event.php
@@ -9,7 +9,7 @@ class Event {
 	private string $status;
 
 	// TODO: Maybe we don't need action_hashed going forward?
-	private string $action;
+	public string $action;
 	private string $action_hashed;
 
 	private array $args = [];


### PR DESCRIPTION
the Event $action string is being used includes/class-events.php:368 and in order to be able to access it it's visibility needs to be public