### PR TITLE
Improve performance of is_installed check

### DIFF
--- a/includes/class-events-store.php
+++ b/includes/class-events-store.php
@@ -55,8 +55,7 @@ class Events_Store extends Singleton {
 		$table_name = $wpdb->prefix . self::TABLE_SUFFIX;
 		$is_installed = 1 === count( $wpdb->get_col( $wpdb->prepare( 'SELECT TABLE_NAME FROM information_schema.tables WHERE TABLE_NAME = %s', $table_name ) ) );
 
-		// Cache false for future is_installed checks. Will be overriden by
-		// _prepare_table when/if it's ultimately installed.
+		// Cache the results, will be overridden by _prepare_table() during installation.
 		wp_cache_add( 'is_installed', $is_installed, 'cron-control' );
 
 		return $is_installed;

--- a/includes/class-events-store.php
+++ b/includes/class-events-store.php
@@ -47,16 +47,17 @@ class Events_Store extends Singleton {
 
 		// Can't rely on the DB_VERSION_OPTION here due to subsite copy/paste scenarios.
 		// Must truly check that the table is installed.
-		if ( wp_cache_get( 'is_installed', 'cron-control' ) ) {
-			return true;
+		$is_installed = wp_cache_get( 'is_installed', 'cron-control', false, $cache_exists );
+		if ( $cache_exists ) {
+			return $is_installed;
 		}
 
 		$table_name = $wpdb->prefix . self::TABLE_SUFFIX;
-		$is_installed = 1 === count( $wpdb->get_col( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table_name ) ) );
+		$is_installed = 1 === count( $wpdb->get_col( $wpdb->prepare( 'SELECT TABLE_NAME FROM information_schema.tables WHERE TABLE_NAME = %s', $table_name ) ) );
 
-		if ( $is_installed ) {
-			wp_cache_set( 'is_installed', true, 'cron-control' );
-		}
+		// Cache false for future is_installed checks. Will be overriden by
+		// _prepare_table when/if it's ultimately installed.
+		wp_cache_add( 'is_installed', $is_installed, 'cron-control' );
 
 		return $is_installed;
 	}
@@ -147,10 +148,10 @@ class Events_Store extends Singleton {
 		dbDelta( $schema, true );
 
 		// Confirm that the table was created, and set the option to prevent further updates.
-		$table_count = count( $wpdb->get_col( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table_name ) ) );
+		$is_installed = 1 === count( $wpdb->get_col( $wpdb->prepare( 'SELECT TABLE_NAME FROM information_schema.tables WHERE TABLE_NAME = %s', $table_name ) ) );
+		wp_cache_set( 'is_installed', $is_installed, 'cron-control' );
 
-		if ( 1 === $table_count ) {
-			wp_cache_set( 'is_installed', true, 'cron-control' );
+		if ( $is_installed ) {
 			update_option( self::DB_VERSION_OPTION, self::DB_VERSION );
 		}
 


### PR DESCRIPTION
We noticed this query performing poorly in some cases, especially when the DB is under load. See this post for more context: p4IuY0-4S6-p2#comment-16728. This PR includes two improvements:

1. Use an information_schema query for table existence check, rather than `SHOW TABLES LIKE ...`. Running this query by itself on the mysql replica takes under 10ms, whereas the show tables query is more like 700+ms. (Not the best benchmark, but does verify that it should be better.
2. Just in case, also cache `false` is_installed values. While it shouldn't happen that frequently since Cron Control is active by default, this query otherwise executes a few times every page load, so it should be a nice little improvement.

is_installed should execute (at least) on admin pageviews, so you can verify the main changes there. 