### PR TITLE
ci: update workflows

### DIFF
--- a/.github/workflows/ci-grunt.yaml
+++ b/.github/workflows/ci-grunt.yaml
@@ -13,7 +13,6 @@ env:
 
 jobs:
   build:
-    if: "!contains(github.event.head_commit.message, '[ci skip]')"
     name: Run Grunt tasks
     runs-on: ubuntu-latest
     steps:
@@ -24,7 +23,7 @@ jobs:
         uses: actions/setup-node@v3.6.0
         with:
           node-version: ${{ env.NODE_VERSION }}
-          caching: true
+          cache: npm
 
       - name: Install dependencies
         run: npm ci --ignore-scripts

--- a/.github/workflows/ci-php.yaml
+++ b/.github/workflows/ci-php.yaml
@@ -12,7 +12,6 @@ jobs:
   test:
     name: Run tests
     runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.message, '[ci skip]')"
     strategy:
       fail-fast: false
       matrix:
@@ -39,8 +38,7 @@ jobs:
     steps:
       - name: Install svn
         run: sudo apt-get update && sudo apt-get install -y subversion
-        shell: bash
-        
+
       - name: Check out source code
         uses: actions/checkout@v3.3.0
 
@@ -49,24 +47,8 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
 
-      - name: Get composer cache directory
-        id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-
-      - name: Cache Composer packages
-        uses: actions/cache@v3.2.3
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-php-${{ matrix.php }}-${{ hashFiles('**/composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-php-${{ matrix.php }}
-            ${{ runner.os }}-php-
-
-      - name: Validate composer.json and composer.lock
-        run: composer validate
-
-      - name: Install dependencies
-        run: composer install --prefer-dist --no-progress --no-interaction --ignore-platform-reqs
+      - name: Install PHP Dependencies
+        uses: ramsey/composer-install@3.0.0
 
       - name: Verify MariaDB connection
         run: |

--- a/.github/workflows/phpcs.yaml
+++ b/.github/workflows/phpcs.yaml
@@ -12,7 +12,6 @@ jobs:
   codestyle:
     name: Run code style check
     runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.message, '[ci skip]')"
     steps:
       - name: Check out source code
         uses: actions/checkout@v3.3.0
@@ -20,24 +19,10 @@ jobs:
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.4
+          php-version: 8.1
 
-      - name: Get composer cache directory
-        id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-
-      - name: Cache Composer packages
-        uses: actions/cache@v3.2.3
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-php-7.4-${{ hashFiles('**/composer.lock') }}
-          restore-keys: ${{ runner.os }}-php-7.4
-
-      - name: Validate composer.json and composer.lock
-        run: composer validate
-
-      - name: Install dependencies
-        run: composer install --prefer-dist --no-progress --no-interaction --ignore-platform-reqs
+      - name: Install PHP Dependencies
+        uses: ramsey/composer-install@3.0.0
 
       - name: Add error matcher
         run: echo "::add-matcher::$(pwd)/.github/checkstyle-problem-matcher.json"


### PR DESCRIPTION
* Properly set up caching for Grunt;
* Use `ramsey/composer-install` to manage `composer.lock` and dependency cache for PHP;
* Use PHP 8.1 to run `phpcs`.
