### PR TITLE
Add `type` of `wordpress-muplugin` to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
   "name": "automattic/cron-control",
   "description": "Execute WordPress cron events in parallel, with custom event storage for high-volume cron.",
+  "type": "wordpress-muplugin",
   "license": "GPL-2.0",
   "require": {
     "php": ">=7.4.0"


### PR DESCRIPTION
As this plugin is meant to be installed as a WordPress must-use plugin
I have added `type` of `wordpress-muplugin` to composer.json

This works with [composer/installers](https://github.com/composer/installers) to automate installation (when used with Composer and that plugin is enabled) to the right folder (`wp-content/mu-plugins/`)

This change should be safe:
- Only adds one line to composer.json
- Doesn't change any code
- Only works with composer/installers
- Is backwards compatible so won't break existing setups
- Doesn't interfere with the installing the plugin manually