### PR TITLE
fix: exclude deleted/archived/spam sites from Site Query

### DIFF
--- a/__tests__/unit-tests/test-cli-orchestrate-sites.php
+++ b/__tests__/unit-tests/test-cli-orchestrate-sites.php
@@ -14,17 +14,6 @@ class Orchestrate_Sites_Tests extends \WP_UnitTestCase {
 		parent::setUp();
 	}
 
-	public function test_list_sites_removes_inactive_subsites() {
-		add_filter( 'sites_pre_query', [ $this, 'mock_get_sites' ], 10, 2 );
-
-		// The archived/spam/deleted subsites should not be returned.
-		$expected = wp_json_encode( [ [ 'url' => 'site1.com' ], [ 'url' => 'site2.com/two' ], [ 'url' => 'site3.com/three' ], [ 'url' => 'site7.com/seven' ] ] );
-		$this->expectOutputString( $expected );
-		( new CLI\Orchestrate_Sites() )->list();
-
-		remove_filter( 'sites_pre_query', [ $this, 'mock_get_sites' ], 10, 2 );
-	}
-
 	public function test_list_sites_2_hosts() {
 		add_filter( 'sites_pre_query', [ $this, 'mock_get_sites' ], 10, 2 );
 
@@ -64,16 +53,13 @@ class Orchestrate_Sites_Tests extends \WP_UnitTestCase {
 
 	public function mock_get_sites( $site_data, $query_class ) {
 		if ( $query_class->query_vars['count'] ) {
-			return 7;
+			return 4;
 		}
 
 		return [
 			new WP_Site( (object) [ 'domain' => 'site1.com', 'path' => '/' ] ),
 			new WP_Site( (object) [ 'domain' => 'site2.com', 'path' => '/two' ] ),
 			new WP_Site( (object) [ 'domain' => 'site3.com', 'path' => '/three' ] ),
-			new WP_Site( (object) [ 'domain' => 'site4.com', 'path' => '/four', 'archived' => '1' ] ),
-			new WP_Site( (object) [ 'domain' => 'site5.com', 'path' => '/five', 'spam' => '1' ] ),
-			new WP_Site( (object) [ 'domain' => 'site6.com', 'path' => '/six', 'deleted' => '1' ] ),
 			new WP_Site( (object) [ 'domain' => 'site7.com', 'path' => '/seven' ] ),
 		];
 	}

--- a/includes/wp-cli/class-orchestrate-sites.php
+++ b/includes/wp-cli/class-orchestrate-sites.php
@@ -61,22 +61,24 @@ class Orchestrate_Sites extends \WP_CLI_Command {
 	 * @param int $group      Group number.
 	 */
 	private function display_sites( $num_groups = 1, $group = 0 ) {
-		$site_count = get_sites( [ 'count' => 1 ] );
+		$site_query = array(
+			'archived' => 0,
+			'spam'     => 0,
+			'deleted'  => 0,
+		);
+
+		$site_count = get_sites( array_merge( array( 'count' => 1 ), $site_query ) );
+
 		if ( $site_count > self::MAX_SITES ) {
-			trigger_error( 'Cron-Control: This multisite has more than ' . self::MAX_SITES . ' subsites, currently unsupported.', E_USER_WARNING );
+			trigger_error( sprintf( 'Cron-Control: This multisite has more than %u active subsites, currently unsupported.', self::MAX_SITES ), E_USER_WARNING );
 		}
 
 		// Keep the query simple, then process the results.
-		$all_sites = get_sites( [ 'number' => self::MAX_SITES ] );
+		$all_sites = get_sites( array_merge( array( 'number' => self::MAX_SITES ), $site_query ) );
 		$sites_to_display = [];
 		foreach ( $all_sites as $index => $site ) {
 			if ( $index % $num_groups !== $group ) {
 				// The site does not belong to this group.
-				continue;
-			}
-
-			if ( in_array( '1', array( $site->archived, $site->spam, $site->deleted ), true ) ) {
-				// Deactivated subsites don't need cron run on them.
 				continue;
 			}
 


### PR DESCRIPTION
This pull request focuses on refining the handling of multisite queries by filtering out inactive subsites (archived, spam, or deleted) at the query level rather than during post-processing. Additionally, it removes a unit test that validated this filtering logic, as it is now handled earlier in the process.

### Changes to multisite query handling:

* [`includes/wp-cli/class-orchestrate-sites.php`](diffhunk://#diff-2a3017f71b3718cea5a8b54f15c3470186d0af7ff65bf0c68a5fc04c0744581cL63-L81): Updated the `display_sites` method to include query parameters (`archived`, `spam`, and `deleted`) directly in the `get_sites` calls, ensuring inactive subsites are excluded at the query stage. Removed redundant checks for inactive subsites during result processing.

### Updates to unit tests:

* [`__tests__/unit-tests/test-cli-orchestrate-sites.php`](diffhunk://#diff-4176c3428cdd8b76897009482801dc030570c4cb8981314fe8118aef82363e1dL17-L27): Removed the `test_list_sites_removes_inactive_subsites` unit test, as filtering of inactive subsites is now handled directly in the query.
* [`__tests__/unit-tests/test-cli-orchestrate-sites.php`](diffhunk://#diff-4176c3428cdd8b76897009482801dc030570c4cb8981314fe8118aef82363e1dL67-L76): Modified the `mock_get_sites` method to return only active subsites by excluding archived, spam, and deleted sites, and adjusted the count to reflect this change.