### PR TITLE
Replace hardcoded value with class constant and bump the limit to 11k

### DIFF
--- a/includes/wp-cli/class-orchestrate-sites.php
+++ b/includes/wp-cli/class-orchestrate-sites.php
@@ -14,6 +14,7 @@ namespace Automattic\WP\Cron_Control\CLI;
  */
 class Orchestrate_Sites extends \WP_CLI_Command {
 	const RUNNER_HOST_HEARTBEAT_KEY = 'a8c_cron_control_host_heartbeats';
+	const MAX_SITES = 11000;
 
 	/**
 	 * Record a heartbeat
@@ -61,12 +62,12 @@ class Orchestrate_Sites extends \WP_CLI_Command {
 	 */
 	private function display_sites( $num_groups = 1, $group = 0 ) {
 		$site_count = get_sites( [ 'count' => 1 ] );
-		if ( $site_count > 10000 ) {
-			trigger_error( 'Cron-Control: This multisite has more than 10000 subsites, currently unsupported.', E_USER_WARNING );
+		if ( $site_count > self::MAX_SITES ) {
+			trigger_error( 'Cron-Control: This multisite has more than ' . self::MAX_SITES . ' subsites, currently unsupported.', E_USER_WARNING );
 		}
 
 		// Keep the query simple, then process the results.
-		$all_sites = get_sites( [ 'number' => 10000 ] );
+		$all_sites = get_sites( [ 'number' => self::MAX_SITES ] );
 		$sites_to_display = [];
 		foreach ( $all_sites as $index => $site ) {
 			if ( $index % $num_groups !== $group ) {


### PR DESCRIPTION
Slightly increase the maximum allowed sizes value and make it a constant.

This pull request introduces a configurable constant to manage the maximum number of subsites supported in a multisite environment, replacing hardcoded values. The changes improve maintainability and make it easier to adjust the limit in the future.

### Introduction of `MAX_SITES` constant:

* [`includes/wp-cli/class-orchestrate-sites.php`](diffhunk://#diff-2a3017f71b3718cea5a8b54f15c3470186d0af7ff65bf0c68a5fc04c0744581cR17): Added a new constant `MAX_SITES` with a value of `11000` to define the maximum number of supported subsites. This replaces the previously hardcoded value of `10000`.

### Refactoring to use `MAX_SITES`:

* [`includes/wp-cli/class-orchestrate-sites.php`](diffhunk://#diff-2a3017f71b3718cea5a8b54f15c3470186d0af7ff65bf0c68a5fc04c0744581cL64-R70): Updated the `display_sites` method to use the `MAX_SITES` constant in the subsite count check and the `get_sites` query, ensuring consistency and easier future updates.