### PR TITLE
chore: pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/ci-php.yaml
+++ b/.github/workflows/ci-php.yaml
@@ -46,12 +46,12 @@ jobs:
         uses: actions/checkout@v6.0.2
 
       - name: Set up PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
         with:
           php-version: ${{ matrix.php }}
 
       - name: Install PHP Dependencies
-        uses: ramsey/composer-install@3.1.1
+        uses: ramsey/composer-install@3cf229dc2919194e9e36783941438d17239e8520 # 3.1.1
 
       - name: Verify MariaDB connection
         run: |

--- a/.github/workflows/phpcs.yaml
+++ b/.github/workflows/phpcs.yaml
@@ -22,12 +22,12 @@ jobs:
         uses: actions/checkout@v6.0.2
 
       - name: Set up PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
         with:
           php-version: 8.3
 
       - name: Install PHP Dependencies
-        uses: ramsey/composer-install@3.1.1
+        uses: ramsey/composer-install@3cf229dc2919194e9e36783941438d17239e8520 # 3.1.1
 
       - name: Add error matcher
         run: echo "::add-matcher::$(pwd)/.github/checkstyle-problem-matcher.json"


### PR DESCRIPTION
Pins third-party GitHub Actions in this repo to immutable commit SHAs.

This is a draft PR for review before merging. It was prepared with agent assistance and manually verified.

Tracking: DEVPROD-1072

Repo-level summary:
- Pinned distinct third-party action refs in this PR: 2
- Repo-level unpinned usage count from the trunk recheck: 4
- Dependabot GitHub Actions coverage: already_present (.github/dependabot.yml)


Verification commands:

```bash
# ramsey/composer-install # 3.1.1 -> 3cf229dc2919194e9e36783941438d17239e8520
gh api repos/ramsey/composer-install/commits/3.1.1 --jq '.sha'
# expected: 3cf229dc2919194e9e36783941438d17239e8520

# shivammathur/setup-php # 2.37.1 -> 7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc
gh api repos/shivammathur/setup-php/commits/2.37.1 --jq '.sha'
# expected: 7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc
```
